### PR TITLE
docs: bootstrap docs/wiki/ and mark project as experimental

### DIFF
--- a/.github/workflows/docs-integrity.yml
+++ b/.github/workflows/docs-integrity.yml
@@ -1,0 +1,22 @@
+name: Docs Integrity
+
+on:
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docs-integrity:
+    name: Check Docs Integrity
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Check docs integrity
+        run: python3 ./scripts/check-docs-integrity.py

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -16,8 +16,26 @@ permissions:
 jobs:
   summarize:
     runs-on: ubuntu-latest
+    # Skip when no provider API key is configured. This keeps the workflow
+    # green-by-skip until a `GEMINI_API_KEY` (or other provider key) is
+    # provisioned as a repository secret. Once a key exists, this guard lets
+    # the job run; otherwise the summarize action would fail with
+    # `API_KEY not set`.
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
     steps:
+      - name: Skip if API key missing
+        id: gate
+        env:
+          API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        run: |
+          if [[ -z "${API_KEY}" ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::GEMINI_API_KEY secret is not set; skipping PR summary."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Generate PR Summary
+        if: steps.gate.outputs.skip == 'false'
         uses: alexanderlhicks/lean-summary-workflow@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,6 +187,48 @@ For routine local validation: `./scripts/validate.sh`.
 Lean toolchain and Mathlib stay in sync (both currently `v4.29.0`).
 Files should stay under 1500 lines.
 
+## Further Reading
+
+Deeper agent-facing notes live in [`docs/wiki/`](docs/wiki/). Use this
+`AGENTS.md` for the one-screen overview and the wiki for details that are
+too specific or too changeable to keep at the repo root.
+
+- [`docs/wiki/README.md`](docs/wiki/README.md): hub and maintenance contract.
+- [`docs/wiki/quickstart.md`](docs/wiki/quickstart.md): commands and
+  validation playbook.
+- [`docs/wiki/repo-map.md`](docs/wiki/repo-map.md): subtree map and where to
+  start by task.
+- [`docs/wiki/generated-files.md`](docs/wiki/generated-files.md): derived
+  outputs and source-of-truth rules.
+- [`docs/wiki/pfunctor.md`](docs/wiki/pfunctor.md): the polynomial-functor
+  substrate.
+- [`docs/wiki/itree.md`](docs/wiki/itree.md): interaction trees layer.
+- [`docs/wiki/interaction.md`](docs/wiki/interaction.md): generic interaction
+  framework (`Spec`, two-party, multiparty, concurrent, UC).
+- [`docs/wiki/notation.md`](docs/wiki/notation.md): notation reference (UC
+  composition operators).
+- [`docs/wiki/gotchas.md`](docs/wiki/gotchas.md): recurring traps and
+  troubleshooting.
+
+### Wiki Maintenance Contract
+
+The wiki is **recently authored and not stable**. Most pages were written
+together with the initial port from
+[`Verified-zkEVM/VCV-io`](https://github.com/Verified-zkEVM/VCV-io) and will
+be edited and refined as the formalization matures. Do **not** treat the
+wiki, `AGENTS.md`, `CONTRIBUTING.md`, or `README.md` as gospel:
+
+- If a page contradicts the source, the source wins. Fix the page in the
+  same PR.
+- If a PR changes commands, repo structure, generated-file behavior, file
+  naming, namespaces, or load-bearing public APIs, update the matching wiki
+  page in the same PR. Add a new page when that is the cleaner split.
+- Promote recurring agent learnings into [`docs/wiki/`](docs/wiki/); do not
+  let stable guidance live only in ephemeral notes (`*-NEVER-COMMIT.md`,
+  scratch chats, scratch worktrees).
+- Prefer linking to canonical docs (Lean source, Mathlib, papers in
+  [`REFERENCES.md`](REFERENCES.md)) over copying their contents.
+
 ## References
 
 Module docstrings cite a small set of foundational papers. The

--- a/README.md
+++ b/README.md
@@ -1,14 +1,23 @@
 # PolyFun
 
 Polynomial functors, interaction trees, and dependent interaction frameworks
-in Lean 4 — generic substrate for protocol theory, PL semantics, and
+in Lean 4, generic substrate for protocol theory, PL semantics, and
 concurrent systems.
 
-## Status
+## Status: Experimental
 
-Bootstrap. The first wholesale port from
-[`Verified-zkEVM/VCV-io`](https://github.com/Verified-zkEVM/VCV-io) is in
-progress; see [`PORTING-PLAN.md`](PORTING-PLAN.md) for the exhaustive plan,
+> **PolyFun is in active bootstrap and is not yet stable.** Names, namespaces,
+> module layout, design notes, and the wiki under [`docs/wiki/`](docs/wiki/)
+> are all expected to change. Treat everything here as a work in progress.
+> Documentation, including this README, [`AGENTS.md`](AGENTS.md),
+> [`CONTRIBUTING.md`](CONTRIBUTING.md), and [`docs/wiki/`](docs/wiki/), is
+> recently authored material that will be edited and refined as the
+> formalization matures. Do not treat any of it as gospel; if you find
+> something out of date, fix it in the same PR rather than copying it forward.
+
+The first wholesale port from
+[`Verified-zkEVM/VCV-io`](https://github.com/Verified-zkEVM/VCV-io) has just
+landed; see [`PORTING-PLAN.md`](PORTING-PLAN.md) for the exhaustive plan,
 file inventory, and migration sequence.
 
 ## Scope
@@ -43,6 +52,20 @@ lake build
 Requires the toolchain pinned in [`lean-toolchain`](lean-toolchain) and
 [`mathlib v4.29.0`](https://github.com/leanprover-community/mathlib4) (only
 external dependency).
+
+## Documentation
+
+- [`AGENTS.md`](AGENTS.md), [`CLAUDE.md`](CLAUDE.md): one-screen guide for
+  human and AI contributors. Symlinked.
+- [`CONTRIBUTING.md`](CONTRIBUTING.md): style, naming, attribution, and large-
+  contribution policy.
+- [`REFERENCES.md`](REFERENCES.md): the bibliography backing module
+  docstrings.
+- [`docs/wiki/`](docs/wiki/): deeper agent-facing notes on the
+  `PFunctor` substrate, interaction trees, the interaction framework,
+  notation, and recurring gotchas. **Recently authored, expected to drift; see
+  the warning above.**
+- [`PORTING-PLAN.md`](PORTING-PLAN.md): the wholesale port plan from VCV-io.
 
 ## License
 

--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -1,0 +1,88 @@
+# PolyFun Agent Wiki
+
+This directory is the deeper companion to [`AGENTS.md`](../../AGENTS.md). Use
+`AGENTS.md` for the one-screen overview and this wiki for details that are
+too specific or too changeable to keep at the repo root.
+
+## Status: Recently Authored, Expect Drift
+
+These pages were written together with the initial port of `PolyFun` from
+[`Verified-zkEVM/VCV-io`](https://github.com/Verified-zkEVM/VCV-io) and have
+not yet had time to settle. They are the best current reference for
+agent-facing context, but they are **not gospel**:
+
+- If a page contradicts a Lean source file, the source wins.
+- Fix stale guidance in the same PR you noticed it in. Do not copy a stale
+  paragraph forward into a new doc.
+- The repo's load-bearing files (the actual Lean source under
+  [`PolyFun/`](../../PolyFun/), [`AGENTS.md`](../../AGENTS.md),
+  [`CONTRIBUTING.md`](../../CONTRIBUTING.md), [`REFERENCES.md`](../../REFERENCES.md))
+  are the source of truth. The wiki is supporting commentary.
+
+See the *Wiki Maintenance Contract* section in
+[`AGENTS.md`](../../AGENTS.md) for the canonical policy.
+
+## Start Here
+
+- [`quickstart.md`](quickstart.md): canonical agent command and validation
+  playbook.
+- [`repo-map.md`](repo-map.md): where to edit and how the main subtrees
+  relate.
+- [`generated-files.md`](generated-files.md): derived outputs and their
+  sources of truth.
+
+## Layer-Specific Notes
+
+- [`pfunctor.md`](pfunctor.md): the polynomial-functor substrate
+  (`PFunctor`, lenses, charts, equivalences, free monad `FreeM`,
+  displayed `FreeM`, `Cofree` / M-type).
+- [`itree.md`](itree.md): coinductive interaction trees.
+- [`interaction.md`](interaction.md): the generic interaction framework
+  (sequential `Spec`, two-party, multiparty local views, concurrent
+  processes, UC open systems).
+
+## Cross-Cutting Notes
+
+- [`notation.md`](notation.md): notation reference. Currently scoped to UC
+  composition (`∥`, `⊞`, `⊠`) and boundary tensor / swap.
+- [`gotchas.md`](gotchas.md): recurring Lean traps and PolyFun-specific
+  pitfalls.
+
+## Maintenance Contract
+
+- [`AGENTS.md`](../../AGENTS.md) is the canonical root guide.
+  [`CLAUDE.md`](../../CLAUDE.md) is only a symlink.
+- Keep one primary owner topic per page. The current pages are:
+  - `quickstart.md` for commands, validation, and when to run which checks.
+  - `repo-map.md` for repo structure and main work areas.
+  - `generated-files.md` for derived outputs and source-of-truth rules.
+  - `pfunctor.md` for the `PFunctor` / `FreeM` / `Cofree` substrate.
+  - `itree.md` for interaction trees, bisimulation, and handlers.
+  - `interaction.md` for the interaction framework above `FreeM`.
+  - `notation.md` for notation cross-references.
+  - `gotchas.md` for recurring traps.
+- Add new pages when a recurring topic no longer fits cleanly in an existing
+  guide.
+- If a PR changes commands, repo structure, generated-file behavior, file
+  naming, namespaces, or load-bearing public APIs, update the matching page
+  in the same PR.
+- Keep these files committed so worktrees and delegated agents see the same
+  guidance.
+- Promote recurring, repo-specific agent learnings here once they prove
+  stable. Do not let stable guidance live only in ephemeral
+  `*-NEVER-COMMIT.md` notes.
+- Prefer links to canonical docs (Lean source, Mathlib, public papers) over
+  copying their contents.
+
+## Canonical Project Docs
+
+- [`../../README.md`](../../README.md): project overview and experimental
+  status banner.
+- [`../../AGENTS.md`](../../AGENTS.md): canonical agent guide (also
+  [`CLAUDE.md`](../../CLAUDE.md) as a symlink).
+- [`../../CONTRIBUTING.md`](../../CONTRIBUTING.md): style, naming,
+  attribution, and large-contribution policy.
+- [`../../REFERENCES.md`](../../REFERENCES.md): bibliography backing module
+  docstrings.
+- [`../../PORTING-PLAN.md`](../../PORTING-PLAN.md): the wholesale port plan
+  from [`Verified-zkEVM/VCV-io`](https://github.com/Verified-zkEVM/VCV-io).

--- a/docs/wiki/generated-files.md
+++ b/docs/wiki/generated-files.md
@@ -1,0 +1,22 @@
+# Generated and Derived Files
+
+Edit the source of truth, not the output.
+
+| Path | What it is | Edit directly? | Source of truth / refresh path |
+| --- | --- | --- | --- |
+| `CLAUDE.md` | compatibility symlink | No | Edit `AGENTS.md` |
+| `PolyFun.lean` | generated umbrella imports | No | `./scripts/update-lib.sh` or `./scripts/check-imports.sh` |
+| `.lake/` | build artifacts and cache | No | `lake build`, `lake exe cache get` |
+| `lake-manifest.json` | resolved dependency lockfile | Manual edits unsafe | `lake update` (or the `update.yml` workflow) |
+
+## Important Notes
+
+- `./scripts/update-lib.sh` only uses tracked `PolyFun/**/*.lean` files and
+  fails fast if untracked Lean files would be skipped. Stage new files
+  first, then rerun.
+- `./scripts/check-imports.sh` is the lightweight read-only check used in
+  CI: it regenerates `PolyFun.lean` to a temp file and diffs against the
+  committed copy.
+- If a path looks derived, confirm its source of truth before editing it.
+- The wiki itself is *not* generated, but is recently authored and expected
+  to drift. See [`README.md`](README.md) for the maintenance contract.

--- a/docs/wiki/generated-files.md
+++ b/docs/wiki/generated-files.md
@@ -17,6 +17,11 @@ Edit the source of truth, not the output.
 - `./scripts/check-imports.sh` is the lightweight read-only check used in
   CI: it regenerates `PolyFun.lean` to a temp file and diffs against the
   committed copy.
+- `./scripts/check-docs-integrity.py` validates the CLAUDE.md symlink and
+  resolves all internal markdown links in tracked top-level docs and
+  `docs/`. Run it (or `./scripts/validate.sh`, which calls it) after any
+  doc rename, move, or deletion. CI runs this via
+  [`../../.github/workflows/docs-integrity.yml`](../../.github/workflows/docs-integrity.yml).
 - If a path looks derived, confirm its source of truth before editing it.
 - The wiki itself is *not* generated, but is recently authored and expected
   to drift. See [`README.md`](README.md) for the maintenance contract.

--- a/docs/wiki/gotchas.md
+++ b/docs/wiki/gotchas.md
@@ -1,0 +1,184 @@
+# Gotchas and Troubleshooting
+
+## Critical (Will Bite You Immediately)
+
+### 1. `autoImplicit = false` is set globally in `lakefile.toml`
+
+Every variable must be explicitly declared. Do not rely on Lean's
+auto-implicit mechanism, and do not add
+`set_option autoImplicit false` in individual files.
+
+**Symptom**: `unknown identifier` for variables you expected Lean to
+infer.
+
+### 2. `Spec.done` and `Spec.node` are `@[match_pattern, reducible]` wrappers
+
+`Spec` is defined as `PFunctor.FreeM Spec.basePFunctor PUnit`, with
+`done` / `node` exposed as `@[match_pattern, reducible]` wrappers over
+`PFunctor.FreeM.{pure, roll}`. Pattern matching on `done` / `node` works
+transparently; `rfl` against the polynomial substrate also works. **Do
+not break either invariant when refactoring** the substrate or these
+wrappers.
+
+### 3. No cryptographic content
+
+Do not introduce dependencies on probability monads (`PMF`,
+`evalDist`, `ProbComp`), evaluation distributions, oracle simulation
+typeclasses, security predicates, or concrete cryptographic algebra
+(specific groups, fields, hash functions). Parameterize over an abstract
+monad `m : Type v → Type w` with `[Pure m]` / `[Monad m]` / `[LawfulMonad m]`
+instead. Cryptographic content belongs in
+[`Verified-zkEVM/VCV-io`](https://github.com/Verified-zkEVM/VCV-io)
+downstream.
+
+When in doubt, ask: *can I state this against an arbitrary monad with no
+probability and no security predicate?* If yes, it belongs here. If no,
+push it downstream.
+
+### 4. Files should stay under 1500 lines
+
+Unless explicitly opted out per file. The long-file linter cap is
+enforced repo-wide.
+
+### 5. Do not disable linters to silence errors
+
+Do not use `set_option linter.* false`,
+`set_option weak.linter.* false`, or add repo-level `leanOptions` that
+turn lints off. Fix the root cause instead. Treat linter failures as
+real problems and fix the underlying declaration, proof, naming, or
+formatting issue.
+
+## Type System
+
+### 6. Core types are `@[reducible]` thin wrappers
+
+`Spec`, `Decoration`, `Strategy`, and friends are `def` / `abbrev` /
+`@[reducible]` over `PFunctor.FreeM` machinery. Lean may unfold them
+aggressively. Use the canonical eliminators
+(`PFunctor.FreeM.construct` / `FreeM.inductionOn` and the
+`Decoration` / `Path` analogues) rather than pattern matching on
+`PFunctor.FreeM.pure` / `roll` directly.
+
+### 7. Universe polymorphism
+
+`PFunctor` carries two universe parameters `(uA, uB)`; `FreeM`,
+`Decoration`, `Spec`, `Strategy`, and the open-process layer add more
+on top (one for the monad's argument universe, one for its result
+universe). Universe unification errors are common when composing
+across layers because lens-style `MonadLift` parents drag in extra
+metavariables.
+
+**Fix**: Use `{ι : Type*}` rather than `{ι : Type u}` to let universes
+resolve independently. Keep `α β : Type` (not `Type u`) when a single
+universe suffices.
+
+### 8. `do`-notation bind uses a different `Bind` instance (Lean 4.29+)
+
+Lean 4.29 changed `do`-block elaboration so the desugared bind may use
+a `Bind` instance that differs syntactically from `Monad.toBind`. This
+means `pure_bind`, `bind_assoc`, and `bind_pure` won't fire via `simp`
+or `rw` on goals produced by `do` notation in special cases of more
+non-standard instances.
+
+**Symptom**: `simp [pure_bind]` or `rw [bind_assoc]` does nothing on a
+`do`-block goal.
+
+**Fix**: Use the restated lemmas in
+[`PolyFun/Control/Lawful/Basic.lean`](../../PolyFun/Control/Lawful/Basic.lean)
+(namespace `LawfulMonad`):
+`do_pure_bind`, `do_bind_pure`, `do_bind_assoc`, `do_bind_pure_comp`,
+`do_map_bind`, `do_bind_map_left`. All are `@[simp]`.
+
+## Proof Patterns
+
+### 9. Avoid `cast` / `Eq.mp` / `Eq.mpr` in core definitions
+
+Per [`AGENTS.md`](../../AGENTS.md): keep core definitions, especially in
+`PolyFun/Interaction/`, free of proof-generated transports such as
+`cast`, `Eq.mp`, `Eq.mpr`, `eq_mpr`, or casts introduced by `rw`,
+`simp`, `convert`, or similar tactics. These usually indicate that the
+dependent indexing or recursion principle is not definitionally aligned.
+Prefer redesigning the type or API so branches compute by pattern
+matching.
+
+Intrinsic typed reindexing operations such as `Fin.castLE`, `Fin.succ`,
+or established Mathlib combinators are acceptable when they are the
+intended data transformation.
+
+### 10. Preserve partial proof attempts with `stop`
+
+When a proof attempt is not finished or is currently broken, insert a
+local `stop` marker instead of deleting large proof blocks. This
+preserves search context for later agents.
+
+### 11. Prefer existing combinators over bespoke wrappers
+
+Per [`AGENTS.md`](../../AGENTS.md): if a definition is just snoc, append,
+update, projection, or reindexing and a clear standard combinator
+already expresses it, use that combinator directly. Do not write a
+wrapper definition just to give the operation a project-specific name.
+
+## Module Structure
+
+### 12. Module organization: no thin re-export umbrellas inside subdirectories
+
+When splitting a file into a folder of submodules, do **not** add a
+sibling `X.lean` whose only content is a chain of
+`import X.A; import X.B`. Each caller imports the specific submodule it
+actually uses.
+
+**Allowed umbrellas** (strictly top-level roots only): `PolyFun.lean` is
+the only allowed umbrella. It is generated by
+[`scripts/update-lib.sh`](../../scripts/update-lib.sh); see
+[`generated-files.md`](generated-files.md).
+
+**Not allowed**: umbrellas inside a subdirectory (e.g. a top-level
+`PolyFun.PFunctor` umbrella beside the `PolyFun/PFunctor/` folder, or a
+`PolyFun.Interaction.Basic` umbrella beside the
+`PolyFun/Interaction/Basic/` folder). Even if a module "feels cohesive",
+callers must import the specific submodule they use.
+
+### 13. Full cutover, no backward-compatibility shims
+
+When refactoring APIs, notations, or proof infrastructure, update all
+call sites in one pass. Do not add deprecated aliases, migration
+wrappers, or compatibility layers.
+
+### 14. Agent guidance files must be committed
+
+Agents dispatched to `git worktree` clones need to read
+[`AGENTS.md`](../../AGENTS.md), this wiki, and any other guidance files.
+Ensure these are committed so all worktrees see them. Do not park
+durable guidance in untracked `*-NEVER-COMMIT.md` notes; those are
+strictly ephemeral.
+
+## Build and Tooling
+
+### 15. Always run `lake exe cache get` before `lake build`
+
+Building Mathlib from source takes hours. Always fetch the precompiled
+cache first.
+
+### 16. After adding new `.lean` files, run `./scripts/update-lib.sh`
+
+This regenerates `PolyFun.lean`, the umbrella import file covered by the
+build import check
+([`scripts/check-imports.sh`](../../scripts/check-imports.sh)). CI
+checks that it is up to date. Stage new files first;
+`./scripts/update-lib.sh` deliberately fails if untracked
+`PolyFun/**/*.lean` files are present.
+
+### 17. Lean toolchain and Mathlib version must stay in sync
+
+Both currently `v4.29.0`. When upgrading, update both
+[`lean-toolchain`](../../lean-toolchain) and the `require mathlib` line
+in [`lakefile.toml`](../../lakefile.toml) simultaneously.
+
+### 18. Use public references in shared docs
+
+When a proof framework follows an external paper, cite the public paper
+by title, venue, or URL rather than pointing agents at a repo-local file
+path. Foundational citations live in
+[`REFERENCES.md`](../../REFERENCES.md); module docstrings reference
+those keys (`Hancock-Setzer`, `Spivak-Niu`, etc.) rather than copying
+prose.

--- a/docs/wiki/interaction.md
+++ b/docs/wiki/interaction.md
@@ -1,0 +1,622 @@
+# Interaction Framework
+
+General-purpose protocol interaction theory: sequential specs, two-party
+roles, multiparty local views, and concurrent process semantics. PolyFun's
+[`PolyFun/Interaction/`](../../PolyFun/Interaction/) is intentionally
+*generic*. It carries no probability, no security predicates, and no
+concrete cryptographic algebra. Cryptographic content of any kind belongs
+in [`Verified-zkEVM/VCV-io`](https://github.com/Verified-zkEVM/VCV-io)
+downstream.
+
+This page is descriptive. The Lean source under
+[`PolyFun/Interaction/`](../../PolyFun/Interaction/) is the canonical
+reference. Cite Lean source by file path plus declaration when accuracy
+matters.
+
+## Design philosophy
+
+The framework is organized around a few stable principles:
+
+- **Continuation-first semantics.** `Spec` is a `PUnit`-leaved free tree on
+  `Spec.basePFunctor` (`PFunctor.FreeM Spec.basePFunctor PUnit`): each
+  round's continuation type depends on the move chosen. All composition,
+  decoration, and strategy types respect this structure. See
+  [`pfunctor.md`](pfunctor.md) for the substrate.
+- **Control vs observation are orthogonal.** Who *chooses* a move (per-node:
+  `NodeAuthority`; per-spec-tree: `Concurrent.Control`) and who *sees* a
+  move (per-node: `NodeView`; per-party-per-node: `Multiparty.ViewMode`;
+  per-spec-tree: `Concurrent.Profile`) are independent axes. A party can
+  control a node but see only a quotient of its own move, or observe a node
+  fully without controlling it.
+- **Boundary vs composition.** *Boundaries* adapt the interface of a fixed
+  protocol (same transcript shape, same round structure). *Composition*
+  (`append`, `replicate`, `stateChain`) extends the protocol with new
+  rounds. Never conflate the two.
+- **Concurrency is layered.** The kernel is `par` + `Front` (frontier) +
+  `residual` (one-step reduction). Interleaving is the basic semantics;
+  independence and true concurrency are refinements on top. Dynamic
+  `Process` wraps sequential `Spec` episodes into a coinductive stream.
+- **UC as a frontend, not the foundation.** The open-systems layer
+  (`Interface`, `PortBoundary`, `OpenTheory`) provides compositional
+  operations (`map`, `par`, `wire`, `plug`). Computational equivalence,
+  asymptotic security, and other security-flavored UC layers are *not*
+  part of PolyFun: those live in
+  [`Verified-zkEVM/VCV-io`](https://github.com/Verified-zkEVM/VCV-io).
+
+## Quick orientation
+
+| Layer | Directory | What it models |
+|-------|-----------|----------------|
+| Sequential core | `Basic/` | Specs, transcripts, decorations, strategies, composition |
+| Two-party | `TwoParty/` | Sender/receiver roles, counterparts, public-coin replay |
+| Multiparty | `Multiparty/` | Per-party local view modes (pick / observe / hidden / react) and observation kernels |
+| Concurrent | `Concurrent/` | Parallel composition, frontiers, processes, refinement |
+| UC frontend | `UC/` | Open-system interfaces, port boundaries, structural composition algebra (`map` / `par` / `wire` / `plug`), corruption surfaces |
+
+Dependencies flow downward: `Concurrent/` may import `Multiparty/` and
+`Basic/`; `TwoParty/` and `Multiparty/` import only `Basic/`; `UC/` is
+above all of them.
+
+## Core concepts: Spec, Node, Party, Profile
+
+Before reading any one file, it helps to fix four words. They are the
+load-bearing vocabulary of the entire `Interaction/` layer.
+
+### Node, a structural location in the protocol tree
+
+A `Spec` is an interaction tree
+([`PolyFun/Interaction/Basic/Spec.lean`](../../PolyFun/Interaction/Basic/Spec.lean)).
+A **node** is one branching point of that tree: a pair
+`(Moves : Type, rest : Moves → Spec)`. It is *not* an actor; it is a
+location where some next move gets chosen. At the level of `Spec` alone, a
+node knows its move space and its continuation family, and nothing else:
+not who chooses, not who watches, not what monad runs, not what data is
+attached. Those concerns are deferred to companion layers (`Decoration`,
+`NodeProfile`, `StepOver`, `SyntaxOver`, `InteractionOver`).
+
+The namespace `Spec.Node.*` (`Context`, `Schema`, `ContextHom` in
+[`PolyFun/Interaction/Basic/Node.lean`](../../PolyFun/Interaction/Basic/Node.lean))
+is *generic node-context infrastructure*: for any type family
+`Γ : Type → Type`, a `Γ`-decoration attaches one `Γ X` value at every node
+with move space `X`.
+
+### Party, an actor that plays across many nodes
+
+A `Party` is a free type parameter introduced by the *content* layers
+(`Multiparty/`, `Concurrent/`, `UC/`). A party is an actor that may control
+or observe moves at *various* nodes throughout the same protocol tree. A
+party is whole-tree (it has a strategy across the entire `Spec`); a node
+is local (it lives at one location in the tree). Typically there are *many
+more* nodes than parties: a long protocol may have unboundedly many nodes
+(or a continuation-based infinite stream of them via `ProcessOver`), but
+always the same finite party set.
+
+### ViewMode, what a single party sees at a single node
+
+`Multiparty.ViewMode X`
+([`PolyFun/Interaction/Multiparty/Core.lean`](../../PolyFun/Interaction/Multiparty/Core.lean))
+records how *one* party locally experiences a node whose move space is
+`X`. The four constructors `pick` / `observe` / `hidden` / `react ⟨Obs, toObs⟩`
+are the canonical observation modes. A `ViewMode` is the smallest atomic
+node × party × observation triple in the framework.
+
+The information content of a `ViewMode` is captured by
+`Multiparty.Observation X`
+([`PolyFun/Interaction/Multiparty/Observation.lean`](../../PolyFun/Interaction/Multiparty/Observation.lean)),
+a `Σ Obs : Type, X → Obs` realized as
+`PFunctor.Idx (Observation.basePFunctor X)`. `Observation X` carries
+Mathlib's order typeclasses (`⊤`, `⊥`, `≤`, `⊔`) so refinement and join
+in the information lattice use standard notation.
+
+### NodeProfile, per-node attribution of who-authors-what and who-sees-what
+
+`NodeProfile Party X`
+([`PolyFun/Interaction/Concurrent/Process.lean`](../../PolyFun/Interaction/Concurrent/Process.lean))
+is the bridge between a single node and the whole party set. It bundles
+two orthogonal factor structures:
+
+- `NodeAuthority Party X`: `controllers : X → List Party`. For each
+  possible move, which parties are credited as having authored it
+  (move-dependent and possibly multi-controller).
+- `NodeView Party X`: `views : Party → Multiparty.ViewMode X`. For each
+  party, what local view they have at this node.
+
+The structure `extends` both factors, so dot-notation field access
+(`node.controllers x`, `node.views me`) and the structure-literal
+constructor `{ controllers := ..., views := ... }` work transparently.
+Code that depends only on authorship can take a `NodeAuthority Party X`
+parameter; code that depends only on observation can take a
+`NodeView Party X` parameter.
+
+The naming `NodeView` (rather than `NodeObservation`) deliberately avoids
+collision with `Multiparty.Observation X`, the kernel-level *information
+content* of a single party's view.
+
+`OpenNodeProfile Party Δ X`
+([`PolyFun/Interaction/UC/OpenProcess.lean`](../../PolyFun/Interaction/UC/OpenProcess.lean))
+is the open-system extension that adds one `BoundaryAction Δ X` field for
+external traffic.
+
+### Mental picture
+
+The protocol tree is the stage; **nodes** are scenes on the stage;
+**parties** are actors who appear in many scenes; a **`NodeProfile`** is
+one scene's cast list and sightlines. `ViewMode` is a single actor's
+vantage on a single scene.
+
+| Concept | Scope | Role |
+|---|---|---|
+| `Spec` | whole protocol tree | branching shape of all possible plays |
+| Node | one location in the tree | one scene: move space + continuation |
+| Party | spans the whole tree | actor; may control or observe at various nodes |
+| `Multiparty.ViewMode X` | one node × one party | that party's vantage on that one scene |
+| `Multiparty.Observation X` | one node × one party | information content (kernel) of that vantage |
+| `NodeProfile Party X` | one node × all parties | full cast list + sightlines for that scene |
+
+## Core types
+
+### `Spec` and `Transcript` (`Basic/Spec.lean`)
+
+`Spec` is `PFunctor.FreeM Spec.basePFunctor PUnit` exposed via
+`@[match_pattern, reducible]` wrappers `Spec.done` and `Spec.node`:
+`done` (no more moves) or `node Moves rest` (one round of type `Moves`,
+with dependent continuation `rest : Moves → Spec`). `Transcript spec` is
+one full play through a `Spec`.
+
+### `Decoration` (`Basic/Decoration.lean`)
+
+`Decoration Γ spec` attaches node-local metadata from a `Node.Context Γ`
+to every node of a `Spec`. `Decoration.Over` adds a dependent second
+layer. Used for role labels, monad annotations, party assignments, etc.
+The substrate is `PFunctor.FreeM.Displayed` /
+`PFunctor.FreeM.Decoration`. See [`pfunctor.md`](pfunctor.md).
+
+### `Strategy` (`Basic/Strategy.lean`)
+
+`Strategy m spec Output` is a one-player strategy with monadic effects in
+`m`. `Strategy.run` executes it against a counterpart to produce a
+`Transcript`. `Strategy.mapOutput` is functorial over the output family.
+
+## Sequential composition
+
+Three ways to compose specs sequentially, each suited to a different
+pattern:
+
+| Combinator | When to use |
+|------------|-------------|
+| `Spec.append s₁ s₂` | Two-phase protocol where phase 2 depends on phase 1's transcript |
+| `Spec.replicate spec n` | Fixed `n`-fold repetition of an identical spec |
+| `Spec.stateChain Stage step n` | `n` stages with explicit state threading |
+| `Spec.Chain n` | Continuation-style telescope (no external state type needed) |
+
+`Transcript.liftAppend` lifts a type family on the first transcript to
+the combined transcript, avoiding `cast` / `Eq.rec` pollution.
+`Strategy.comp` composes strategies along `append`.
+
+## Two-party protocols (`TwoParty/`)
+
+Label each node with `Role` (`.sender` or `.receiver`) via
+`RoleDecoration`. Then:
+
+- **`Strategy.withRoles m spec roles Output`**: the focal party's strategy,
+  seeing sender nodes as "produce a move" and receiver nodes as "observe a
+  move".
+- **`Counterpart m spec roles Output`**: the environment (verifier if
+  focal is prover).
+- **`Strategy.runWithRoles`**: executes focal + counterpart to get a
+  transcript.
+
+For public-coin protocols, `PublicCoinCounterpart` and `replay` support
+public-coin transcript replay (Fiat-Shamir-style).
+
+### Composition
+
+`Strategy.compWithRoles` and `Counterpart.append` compose along
+`Spec.append`. The flat variants (`compWithRolesFlat`,
+`Counterpart.appendFlat`) take a single output family on the combined
+transcript. Factorization theorems (e.g.
+`runWithRoles_compWithRoles_append`) show that executing a composed
+protocol equals sequential execution of its parts. These require
+`LawfulCommMonad` (independent effects may be swapped).
+
+## Multiparty local views (`Multiparty/`)
+
+`ViewMode X` characterizes what a participant sees at a node with move
+type `X`:
+
+| Constructor | Meaning |
+|-------------|---------|
+| `.pick` | Participant locally selects the move (effectful Σ-of-X) |
+| `.observe` | Participant sees the full move (function-from-X) |
+| `.hidden` | Participant sees nothing |
+| `.react ⟨Obs, toObs⟩` | Participant sees `toObs x : Obs` (partial information) |
+
+Three packaged resolver patterns:
+
+- **`Broadcast.Strategy`**: one acting party per node, all others observe.
+- **`Directed.Strategy`**: sender / receiver pair per node.
+- **`Profile.Strategy`**: full per-party `ViewProfile` decoration.
+
+### Information kernel vs operational shape
+
+`ViewMode` carries information along **two orthogonal axes**:
+
+- **Information**: what observation does the participant make? Fully
+  captured by a single projection `toObs : X → Obs` packaged with its
+  codomain `Obs`. This polynomial-element form is
+  `Multiparty.Observation X`, defined as
+  `PFunctor.Idx (Observation.basePFunctor X)` where
+  `Observation.basePFunctor X := ⟨Type, (X → ·)⟩`. Concretely it
+  unfolds to `Σ Obs : Type, X → Obs`. Every `ViewMode X` collapses to
+  an `Observation X` via `ViewMode.toObservation`.
+- **Operational**: what continuation-passing shape does the participant
+  use for `Action`? `.pick` (effectful Σ-of-X), `.observe`
+  (function-from-X), `.hidden` (function-into-Cont, prepared in
+  advance), `.react` (function on the observation, prepared in advance).
+
+The four-constructor `ViewMode` is the *ergonomically convenient* form;
+it specializes `Action` to a definitionally simpler shape per pattern,
+which keeps protocol examples short. `Observation` is the *semantically
+universal* form; protocols whose participants make arbitrary observations
+not captured by `.pick` / `.observe` / `.hidden` should build observations
+directly. The two are related by `ViewMode.toObservation` (collapse) and
+`Observation.toViewMode` (lift into the universal `.react` constructor);
+on the operational side,
+`ViewMode.Action (.react ⟨..⟩) = Observation.Action ⟨..⟩` definitionally.
+
+The information lattice on `Observation X` is exposed via Mathlib's order
+typeclasses, so `⊤`, `⊥`, `≤`, `⊔` work directly:
+
+- `⊤ : Observation X` is `Observation.top X = ⟨X, id⟩`. Full information.
+  This is exactly the kernel of `ViewMode.observe`.
+- `⊥ : Observation X` is `Observation.bot X = ⟨PUnit, fun _ => .unit⟩`.
+  No information. This is exactly the kernel of `ViewMode.hidden`.
+- `k₁ ≤ k₂` denotes `Observation.Refines k₁ k₂`. `k₁` is no more
+  revealing than `k₂`.
+- `k₁ ⊔ k₂` denotes `Observation.combine k₁ k₂`. The join (Σ-product) of
+  two observations.
+
+`Refines` is only a *preorder* (mutual refinement permits codomain
+bijections), so `Observation X` carries `Preorder`, `OrderTop`,
+`OrderBot`, and `Max` instances but not `PartialOrder` / `SemilatticeSup`.
+Profile-level order theory comes through Mathlib's `Pi` instances on
+`ObservationProfile Party X = Party → Observation X` for free.
+
+The operational distinction `.pick` vs `.observe` is **not** the
+canonical authorship attribution. Authorship-of-move is recorded by
+`Concurrent.NodeAuthority.controllers : X → List Party` (move-dependent,
+possibly multi-controller). `ViewMode.pick` indicates only that the
+participant chooses *locally* in its endpoint; the protocol-level
+controllers of a given move are recorded separately.
+
+### Literature
+
+Three independent traditions converge on the kernel form
+`Σ Obs, X → Obs`:
+
+- *Epistemic logic* (Halpern-Vardi *Reasoning About Knowledge*): agent
+  observation as a projection from global state to local
+  indistinguishability classes.
+- *Noninterference / information-flow* (Goguen-Meseguer; Sabelfeld-Myers
+  *Language-Based Information-Flow Security*): per-security-level
+  projection of observable outputs.
+- *Session types and endpoint projection* (Honda-Yoshida-Carbone
+  *Multiparty Asynchronous Session Types*; Cruz-Filipe-Montesi *A Core
+  Model for Choreographic Programming*): projection of a global type /
+  global play to a single role's local view.
+
+Closest type-theoretic ancestor: Hancock-Setzer *Interactive Programs in
+Dependent Type Theory*. Command/Response interfaces with embedded
+observation modes mirror the four-constructor operational shape.
+
+## Concurrent processes (`Concurrent/`)
+
+### Structural layer
+
+`Concurrent.Spec` extends `Spec` with `par left right`. `Front S` is the
+type of currently enabled frontier events. `residual event` gives the
+spec after one event fires. The `diamond` theorem proves independent
+events commute. `Trace.Equiv` identifies different linearizations of
+independent events.
+
+### Dynamic processes
+
+`Process Party` is a coinductive-style stream: each step is a sequential
+`Interaction.Spec` episode, producing a residual process. `Process.Run`
+and `Process.Prefix` model infinite and finite executions. `Machine`
+provides a state-indexed transition-system frontend that compiles to
+`Process` via `Machine.toProcess`.
+
+### Coalgebraic structure
+
+Both `ProcessOver` and `Machine` are instances of the `Coalg` typeclass
+defined in
+[`PolyFun/Control/Coalgebra.lean`](../../PolyFun/Control/Coalgebra.lean).
+A `Coalg F S` is a type `S` together with `out : S → F S`, the
+categorical dual of `MonadAlgebra`.
+
+- `StepOver Γ` is a `Functor` (post-compose on `next`) and
+  `LawfulFunctor`.
+- `ProcessOver Γ` is a `Coalg (StepOver Γ)` via its `step` field.
+- `Machine.StepFun` is a `Functor` and `LawfulFunctor`.
+- `Machine` is a `Coalg Machine.StepFun` via its `Enabled` / `step`
+  fields.
+
+This reflects the Poly / ACT perspective: a process is a coalgebra for a
+polynomial endofunctor, with the step functor playing the role of the
+"interface polynomial."
+
+### Interleaving combinator
+
+`ProcessOver.interleave` factors out the binary-choice interleaving
+pattern shared by `par`, `wire`, and `plug` in `OpenProcessModel`. Given
+two processes `p₁ : ProcessOver Γ₁`, `p₂ : ProcessOver Γ₂`, context
+morphisms into a target context `Δ`, and a scheduler decoration, it
+produces a `ProcessOver Δ` with product state space `p₁.Proc × p₂.Proc`.
+
+### Control and observation
+
+`Control Party S` assigns ownership of payload moves and scheduling
+decisions. `Profile Party S` assigns `ViewMode`s to each party at
+frontier nodes. `Current.view` combines both to give a party's
+current-step interface.
+
+### Fairness, safety, liveness
+
+`Fairness.lean` defines weak and strong fairness over stable ticket
+systems. `Liveness.lean` provides temporal predicates (`AlwaysState`,
+`EventuallyState`, `InfinitelyOftenState`) and safety / admissibility
+under fairness.
+
+### Refinement and equivalence
+
+`Refinement.lean` lifts implementation runs to specification runs,
+preserving safety and event / ticket / controller traces.
+`Bisimulation.lean` and `BackwardSimulation` establish behavioral
+equivalence. Named equivalences in `Equivalence.lean` specialize to
+controller, trace, and observational comparisons.
+
+### Open systems (UC frontend)
+
+`Interface` (= `PFunctor`) and `PortBoundary` define typed I/O
+boundaries. The choice of `PFunctor` for interfaces keeps the kernel
+minimal while supporting `Packet`, `Query`, `Hom`, `comp` (Poly's
+composition product), `compUnit` (composition unit), and boundary
+equivalences.
+
+`OpenTheory` provides the compositional algebra: `map`, `par`, `wire`,
+`plug`. Lawfulness is stratified into a granular Mathlib-style class
+hierarchy. Carriers:
+
+- `HasUnit`: distinguished monoidal unit object for `par`.
+- `HasIdWire`: distinguished identity-wire builder for `wire`.
+
+Naturality:
+
+- `IsLawfulMap` / `IsLawfulPar` / `IsLawfulWire` / `IsLawfulPlug`:
+  functoriality of `map` and naturality of each combinator.
+- `IsLawful`: bundles all naturality laws.
+
+Coherence (each subsequent class adds laws on top of the previous):
+
+- `IsMonoidal`: symmetric monoidal coherence for `par` (associativity,
+  commutativity, left / right unit laws via the `HasUnit` object).
+- `IsTraced`: Joyal-Street-Verity traced symmetric monoidal structure
+  (`wire`-trace yanking, sliding, vanishing).
+- `IsCompactClosed`: compact closed structure (a `(Poly, ⊗)`-friendly
+  weakening; the strict snake equations are *not* asserted, since
+  `(Poly, ⊗)` is monoidal closed but not strictly compact closed; see
+  Spivak arXiv:2202.00534 §4.3).
+- `HasPlugWireFactor`: closure-factorization identities relating `plug`
+  to `wire` (`plug_eq_wire`, `plug_par_left`, `plug_wire_left`).
+
+`OpenProcessIso` (in `OpenProcess.lean`) provides a bisimulation-based
+equivalence for `OpenProcess`, used to state monoidal and compact-closed
+laws for the concrete `openTheory` model up to isomorphism (see
+`OpenProcessModel.lean`).
+
+`OpenSyntax/` provides three layers for free open-system expressions:
+
+- `Raw` is an inductive syntax tree whose constructors mirror the
+  `OpenTheory` operations. It is pattern-matchable and suitable for
+  inspection, transformation, and visualization.
+- `Expr` is the quotient of `Raw` by the `OpenTheory` equations,
+  yielding a lawful `OpenTheory` instance by construction.
+- `Interp` is a tagless-final (Church-encoded) structure (final model)
+  that stores a universal interpretation function and carries a lawful
+  `OpenTheory` instance.
+
+`Expr.toInterp` embeds quotiented expressions into the lawful `Interp`
+model.
+
+### Monad-parametric open processes and intrinsic samplers
+
+`OpenProcess m Party Δ`
+([`PolyFun/Interaction/UC/OpenProcess.lean`](../../PolyFun/Interaction/UC/OpenProcess.lean))
+is the runtime-facing analogue of `Concurrent.ProcessOver`: an
+`m`-parametric structure that bundles, at every step, a `Spec.Sampler m`
+for resolving that step's nondeterminism. Samplers are carried as data,
+not threaded through as an external argument. Three concrete
+consequences:
+
+1. **Samplers are a decoration, not a side argument.**
+   `Spec.Sampler m spec` is definitionally
+   `Decoration (fun X => m X) spec`
+   ([`PolyFun/Interaction/Basic/Sampler.lean`](../../PolyFun/Interaction/Basic/Sampler.lean)).
+   Every move type `X` in the spec receives an `m X` computation;
+   `sampleTranscript` folds a sampler into an `m (Transcript spec)`.
+   Universe-polymorphic at `(w, w')` so that `m : Type w → Type w'` and
+   `spec : Spec.{w}`.
+2. **`OpenProcess` carries `stepSampler` as a field.**
+   For each reachable step, `OpenProcess.stepSampler` supplies the
+   `Spec.Sampler m` that resolves that step's move choices. The
+   underlying pure structure is still a `Concurrent.ProcessOver`,
+   recoverable via `OpenProcess.toProcess`. The structural layer
+   (`StepOver`, `ProcessOver`) is left untouched.
+3. **`openTheory m Party schedulerSampler` threads samplers
+   compositionally.**
+   The monad `m` and a scheduler sampler (resolving binary-choice
+   scheduler nodes introduced by `par` / `wire` / `plug`) become
+   parameters of the concrete model. Each combinator builds the new
+   step's sampler via `Spec.Sampler.interleave` from its inputs'
+   samplers, so any law about `map` / `par` / `wire` / `plug` that holds
+   in the pure structural theory lifts to the monad-parametric one once
+   `schedulerSampler` is fixed.
+
+`Spec.Fintype` in
+[`PolyFun/Interaction/Basic/SpecFintype.lean`](../../PolyFun/Interaction/Basic/SpecFintype.lean)
+is the per-spec ornament (recursive `Fintype` + `Nonempty` for every
+move type) that lets users recover canonical uniform samplers
+(`Sampler.uniformI`) without writing one by hand.
+
+PolyFun deliberately stops here: anything that requires a probability
+monad (e.g. `processSemanticsProbComp`), an oracle simulation
+(`processSemanticsOracle`), or a UC security predicate
+(`UCSecure`, `CompEmulates`) lives downstream in
+[`Verified-zkEVM/VCV-io`](https://github.com/Verified-zkEVM/VCV-io). The
+relevant runtime / async / security files live there, not here.
+
+## Import guide
+
+Choose the minimal set for your task:
+
+```lean
+-- Sequential protocol
+import PolyFun.Interaction.Basic.Spec
+import PolyFun.Interaction.Basic.Strategy
+import PolyFun.Interaction.Basic.Append      -- if composing
+
+-- Two-party
+import PolyFun.Interaction.TwoParty.Strategy -- includes Role, Decoration
+import PolyFun.Interaction.TwoParty.Compose  -- if composing
+
+-- Multiparty
+import PolyFun.Interaction.Multiparty.Core
+import PolyFun.Interaction.Multiparty.Broadcast  -- or Directed / Profile
+
+-- Concurrent
+import PolyFun.Interaction.Concurrent.Spec
+import PolyFun.Interaction.Concurrent.Process
+
+-- UC / open systems
+import PolyFun.Interaction.UC.OpenTheory
+import PolyFun.Interaction.UC.OpenProcess
+import PolyFun.Interaction.UC.OpenProcessModel
+```
+
+## File index
+
+### `Basic/`
+
+| File | Purpose |
+|------|---------|
+| `Spec.lean` | `Spec`, `Transcript`, `ofList` |
+| `Node.lean` | `Node.Context`, `Node.Schema`, `Prefix` |
+| `Decoration.lean` | `Decoration`, `Decoration.Over`, `telescope`, `pack` / `unpack` |
+| `Syntax.lean` | `SyntaxOver`, `SyntaxOver.Family` |
+| `Shape.lean` | `ShapeOver` (functorial `SyntaxOver` with continuation map) |
+| `Interaction.lean` | `InteractionOver`, `Interaction`, `run` |
+| `Strategy.lean` | `Strategy`, `Strategy.run`, `mapOutput` |
+| `Append.lean` | `Spec.append`, transcript ops, `Strategy.comp` / `compFlat` |
+| `Replicate.lean` | `Spec.replicate`, `Strategy.iterate` |
+| `StateChain.lean` | `Spec.stateChain`, `Strategy.stateChainComp` |
+| `Chain.lean` | `Spec.Chain`, `Chain.toSpec`, `Chain.ofStateMachine` |
+| `Telescope.lean` | telescope helpers shared across composition |
+| `Ownership.lean` | `LocalView` / `LocalRunner` builders for `SyntaxOver` |
+| `MonadDecoration.lean` | `MonadDecoration`, `Strategy.withMonads`, `runWithMonads` |
+| `BundledMonad.lean` | `BundledMonad` (monad packaged for inductive data) |
+| `Sampler.lean` | `Spec.Sampler m spec := Decoration (fun X => m X) spec`, `sampleTranscript`, `Sampler.interleave`, `Sampler.uniformI` |
+| `SpecFintype.lean` | `Spec.Fintype` per-spec ornament; enables canonical `Sampler.uniformI` |
+
+### `TwoParty/`
+
+| File | Purpose |
+|------|---------|
+| `Role.lean` | `Role`, `swap`, `Action`, `Dual`, `interact` |
+| `Decoration.lean` | `RoleDecoration`, `RoleContext`, `RoleSchema`, monad contexts |
+| `Strategy.lean` | `withRoles`, `Counterpart`, `PublicCoinCounterpart`, `replay` |
+| `Syntax.lean` | role-aware syntax helpers |
+| `Compose.lean` | `compWithRoles`, `Counterpart.append`, factorization theorems |
+| `Refine.lean` | `Role.Refine`, equivalence with `Decoration.Over` |
+| `Swap.lean` | role swap involutivity and append compatibility |
+| `Examples.lean` | definitional `rfl` checks on small specs |
+
+### `Multiparty/`
+
+| File | Purpose |
+|------|---------|
+| `Core.lean` | `ViewMode`, `ObsType`, `Action`, `ViewMode.toObservation` / `Observation.toViewMode` (kernel bridges), `Multiparty.Strategy` |
+| `Observation.lean` | `Multiparty.Observation`, `top` / `bot` / `Refines` / `combine` / `postcomp` / `Action`, Mathlib order typeclasses |
+| `ObservationProfile.lean` | `Multiparty.ObservationProfile Party X := Party → Observation X` (with pointwise `Pi` order instances), `toViewProfile` |
+| `Broadcast.lean` | `PartyDecoration`, `Broadcast.Strategy` |
+| `Directed.lean` | `EdgeDecoration`, `Directed.Strategy` |
+| `Profile.lean` | `ViewProfile`, `Profile.Decoration`, `Profile.Strategy` |
+| `Examples.lean` | broadcast, directed, profile, adversarial leakage examples |
+
+### `Concurrent/`
+
+| File | Purpose |
+|------|---------|
+| `Spec.lean` | `Concurrent.Spec` (`done` / `node` / `par`), `isLive` |
+| `Frontier.lean` | `Front`, `residual`, liveness lemmas |
+| `Trace.lean` | `Trace` (finite linearization), `length` |
+| `Independence.lean` | `Independent`, `diamond` |
+| `Interleaving.lean` | `Trace.Equiv`, `cast` |
+| `Control.lean` | `Control`, `scheduler?`, `current?`, `controllers` |
+| `Profile.lean` | `Profile`, `observe`, `residual`, `frontierView` |
+| `Current.lean` | `view`, `observe`, `residualView` |
+| `Process.lean` | `NodeAuthority`, `NodeView`, `NodeProfile`, `StepOver`, `ProcessOver`, `Process`, `Functor (StepOver Γ)`, `Coalg` instance, `interleave`, `ProcessOver.{Behavior, behavior, ObsEq}` |
+| `Tree.lean` | structural concurrent syntax → `Process` |
+| `Machine.lean` | `Machine`, `Machine.toProcess`, `Machine.StepFun`, `Coalg` instance |
+| `Execution.lean` | `Trace`, `ObservedTrace` for processes |
+| `Run.lean` | `Prefix`, `Run` (infinite), controller / event extraction |
+| `Policy.lean` | `StepPolicy`, `respects`, combinators |
+| `Observation.lean` | `PackedObs`, transcript relations, observation preservation |
+| `Refinement.lean` | `ForwardSimulation`, safety / trace preservation |
+| `Bisimulation.lean` | `Bisimulation`, `BackwardSimulation`, `refl`, `symm` |
+| `Equivalence.lean` | controller, trace, observational equivalences |
+| `Fairness.lean` | `WeakFair`, `StrongFair`, temporal predicates |
+| `Liveness.lean` | `Safe`, `Satisfies`, `Admissible`, state predicates |
+| `Examples.lean` | worked examples: profiles, control, execution, policies |
+
+### `UC/`
+
+| File | Purpose |
+|------|---------|
+| `Interface.lean` | `Interface`, `PortBoundary`, `Hom`, `Equiv`, `comp` / `compUnit`, tensor / swap |
+| `OpenTheory.lean` | `OpenTheory` algebra, `IsLawful`, `HasUnit`, `HasIdWire`, `IsMonoidal`, `IsTraced`, `IsCompactClosed`, `HasPlugWireFactor` |
+| `OpenSyntax/Raw.lean` | `Raw` syntax tree, `Raw.interpret`, `Raw.Equiv` (incl. monoidal / traced / CC equations) |
+| `OpenSyntax/Interp.lean` | `Interp` (tagless-final), granular `HasUnit` / `HasIdWire` / `IsMonoidal` / `IsTraced` / `IsCompactClosed` / `HasPlugWireFactor` instances |
+| `OpenSyntax/Expr.lean` | `Expr` (quotient of `Raw`), granular `OpenTheory` lawfulness instances, `Expr.toInterp` |
+| `OpenProcess.lean` | `BoundaryAction`, `OpenNodeProfile`, `OpenNodeContext` (with polynomial-product bridge `productView`), `OpenProcess m Party Δ` (monad-parametric, with intrinsic `stepSampler`), `toProcess`, `OpenProcessIso` |
+| `OpenProcessModel.lean` | `openTheory m Party schedulerSampler` (concrete model threading `Spec.Sampler` through `map` / `par` / `wire` / `plug`), `IsLawful`, monoidal / CC laws up to `OpenProcessIso` |
+| `Emulates.lean` | `Observation`, `Emulates`, `UCSecure`. Contextual emulation and UC security stated abstractly over an `Observation` (an equivalence relation on closed systems), with no probability monad and no concrete security predicate. |
+| `Notation.lean` | UC notation helpers (`∥`, `⊞`, `⊠`, `⊗ᵇ`, `ᵛ`); see [`notation.md`](notation.md) |
+| `MachineId.lean` | machine identifiers |
+| `EnvAction.lean` | environment actions, parametric over an arbitrary monad `m` (no probability dependency) |
+| `EnvOpenProcess.lean` | open-process wrappers around `EnvAction`, also monad-parametric |
+| `CorruptionModel.lean` | corruption-model surface, parametric over `m` |
+| `MomentaryCorruption.lean` | momentary corruption surface, parametric over `m` |
+| `Leakage.lean` | leakage-oriented UC observation helpers |
+
+UC files that depended on a probability monad in VCV-io (`Computational.lean`,
+`Runtime.lean`, `AsyncRuntime.lean`, `AsyncSecurity.lean`, `Standard.lean`,
+`StdDoBridge.lean`) deliberately do **not** appear in PolyFun. They live in
+[`Verified-zkEVM/VCV-io`](https://github.com/Verified-zkEVM/VCV-io) and
+re-import the generic primitives from PolyFun.
+
+## In-tree examples
+
+- [`PolyFun/Interaction/TwoParty/Examples.lean`](../../PolyFun/Interaction/TwoParty/Examples.lean):
+  `rfl` checks that `withRoles` / `Counterpart` types unfold correctly on
+  a two-step spec.
+- [`PolyFun/Interaction/Multiparty/Examples.lean`](../../PolyFun/Interaction/Multiparty/Examples.lean):
+  pattern-matching resolvers for broadcast, directed, and profile-based
+  models; adversarial leakage and adaptive corruption.
+- [`PolyFun/Interaction/Concurrent/Examples.lean`](../../PolyFun/Interaction/Concurrent/Examples.lean):
+  small concurrent specs with profiles, control, process execution,
+  policies, and interleaving.
+
+End-to-end UC examples that involve probability monads or concrete
+cryptographic content (one-time pad, oracle protocols, etc.) live in
+VCV-io rather than PolyFun, by design.

--- a/docs/wiki/itree.md
+++ b/docs/wiki/itree.md
@@ -1,0 +1,89 @@
+# Interaction Trees
+
+This page is the agent-facing tour of `PolyFun/ITree/`. It tracks the Lean
+adaptation of *Interaction Trees: Representing Recursive and Impure Programs
+in Coq* (Xia, Zakowski, He, Hur, Malecha, Pierce, Zdancewic, POPL 2020).
+
+## Why ITrees
+
+Interaction Trees (ITrees) are a coinductive datatype for representing
+recursive and impure programs that interact with an environment through a
+fixed set of events. Coq's presentation is
+
+```coq
+CoInductive itree (E : Type → Type) (R : Type) :=
+| Ret (r : R)
+| Tau (t : itree E R)
+| Vis {X : Type} (e : E X) (k : X → itree E R).
+```
+
+In Lean we model the event signature as a *polynomial functor*
+`F : PFunctor.{u, u}` (shapes are event names, positions are answer types)
+so the resulting tree lives at a single universe `u`. ITrees themselves
+are the M-type (final coalgebra) of the one-step polynomial functor
+`Poly F α` whose shapes are pure leaves, silent steps, or visible queries.
+
+| Coq | Lean |
+|---|---|
+| `itree E R` | `ITree F α` |
+| `itreeF E R T` | `ITree.Shape F α` |
+| `RetF` / `Ret` | `ITree.Shape.pure` / `ITree.pure` |
+| `TauF` / `Tau` | `ITree.Shape.step` / `ITree.step` |
+| `VisF` / `Vis` | `ITree.Shape.query` / `ITree.query` |
+
+## File index
+
+### Core
+
+| File | Purpose |
+|------|---------|
+| [`PolyFun/ITree/Basic.lean`](../../PolyFun/ITree/Basic.lean) | `ITree F α` defined as `PFunctor.M (Poly F α)`, `Shape` (one-step view), smart constructors `pure` / `step` / `query`, `bind`, `iter`, `Monad` instance. |
+| [`PolyFun/ITree/Construct.lean`](../../PolyFun/ITree/Construct.lean) | Standard combinators: `diverge` (Coq `spin`), `forever`, `map`, `cat`, `ignore`, `burn`. Pure consequences of `bind` / `iter` / `M.corec`. |
+| [`PolyFun/ITree/Handler.lean`](../../PolyFun/ITree/Handler.lean) | `Handler E F`: choice of `F`-program for every `E`-event. Source data of the simulation operator. |
+| [`PolyFun/ITree/Sim/Defs.lean`](../../PolyFun/ITree/Sim/Defs.lean) | `ITree.simulate` (interprets every event via a handler), `ITree.mapSpec` (pure event-renaming via a `PFunctor.Lens`). Coq `interp` analogue. |
+| [`PolyFun/ITree/Sim/Facts.lean`](../../PolyFun/ITree/Sim/Facts.lean) | Algebraic facts about simulation. |
+| [`PolyFun/ITree/Rec.lean`](../../PolyFun/ITree/Rec.lean) | `mutualRec`, `fixRec` recursive procedure-call combinators. The `CallE α β` event signature describes one recursive call expecting `α` and returning `β`. |
+
+### Bisimulation
+
+| File | Purpose |
+|------|---------|
+| [`PolyFun/ITree/Bisim/Defs.lean`](../../PolyFun/ITree/Bisim/Defs.lean) | `ITree.Bisim` (strong / structural; coincides with definitional equality by the M-type universal property), `ITree.WeakBisim` (Coq `eutt`, modulo finitely many leading `step` nodes). |
+| [`PolyFun/ITree/Bisim/Bind.lean`](../../PolyFun/ITree/Bisim/Bind.lean) | Compatibility of bisimulation with `bind`. |
+| [`PolyFun/ITree/Bisim/Equiv.lean`](../../PolyFun/ITree/Bisim/Equiv.lean) | Equivalence properties of bisimulation. |
+
+### Standard events
+
+| File | Purpose |
+|------|---------|
+| [`PolyFun/ITree/Events/State.lean`](../../PolyFun/ITree/Events/State.lean) | `StateE σ`: `get` / `put`. Standard "state monad as ITree" embedding via a `simulate`-based handler interpreting `StateE σ` over `σ`. |
+| [`PolyFun/ITree/Events/Exception.lean`](../../PolyFun/ITree/Events/Exception.lean) | `ExceptE ε`: single `throw e` event with answer type `PEmpty` (no resume). Standard exception monad as ITree. |
+
+## Mental model
+
+- ITrees are exactly "programs in the signature `F`, including silent
+  steps, modulo coinductive equality". They give a single Lean datatype
+  that uniformly models pure programs, programs with effects, recursive
+  procedures, and partial / non-terminating computations.
+- A `Handler E F` is the data needed to interpret one signature inside
+  another. `simulate` is the recursive interpretation. `mapSpec` is the
+  syntactically pure case (pure event rename via a `PFunctor.Lens`).
+- Strong bisimulation `Bisim` is set to definitional equality, courtesy
+  of the M-type universal property. Reach for `WeakBisim` whenever you
+  want to ignore finitely many leading silent `step`s, which is the
+  typical "ITree equivalence" used in Coq.
+- The `Events/{State, Exception}.lean` files are the small canonical
+  examples to read first. They are also the recommended pattern for new
+  event signatures: define the polynomial, write a `Handler`, prove the
+  small algebraic facts you need.
+
+## Recovering Coq references
+
+Coq file references in module docstrings and Lean comments use the file
+names from the upstream
+[`DeepSpec/InteractionTrees`](https://github.com/DeepSpec/InteractionTrees)
+repository (`Core/ITreeDefinition.v`, `Core/Subevent.v`,
+`Core/KTree.v`, `Events/State.v`, `Events/Exception.v`, ...). Treat those
+as the canonical algebraic reference; the bibliography entry is
+`Xia-Zakowski-He-Hur-Malecha-Pierce-Zdancewic 2020` in
+[`REFERENCES.md`](../../REFERENCES.md).

--- a/docs/wiki/notation.md
+++ b/docs/wiki/notation.md
@@ -1,0 +1,56 @@
+# Notation Reference
+
+PolyFun is small enough that almost all notation lives in two places. This
+page is the cross-reference; the canonical definitions live in the
+referenced Lean source.
+
+## UC Composition Notations
+
+Scoped to `Interaction.UC` (activated by `open Interaction.UC`). Defined
+in
+[`PolyFun/Interaction/UC/Notation.lean`](../../PolyFun/Interaction/UC/Notation.lean).
+
+### Boundary-level
+
+| Notation | Meaning | Input method |
+|----------|---------|--------------|
+| `Δ₁ ⊗ᵇ Δ₂` | `PortBoundary.tensor Δ₁ Δ₂` | `\otimes ^b` |
+| `Δᵛ` | `PortBoundary.swap Δ` (dual / flip) | `\^v` |
+
+### Expression-level (typeclass-backed)
+
+Works for `Raw`, `Expr`, and `Interp` via `HasPar` / `HasWire` / `HasPlug`
+typeclasses. Each type has `@[simp]` bridge lemmas (e.g. `Raw.hasPar`)
+that normalize `HasPar.par e₁ e₂` back to `Raw.par e₁ e₂`, so existing
+simp lemmas (`interpret_par`, etc.) fire transparently.
+
+| Notation | Meaning | Prec | Input method |
+|----------|---------|------|--------------|
+| `e₁ ∥ e₂` | `HasPar.par e₁ e₂` (parallel) | 70r | `\parallel` |
+| `e₁ ⊞ e₂` | `HasWire.wire e₁ e₂` (wire) | 65r | `\boxplus` |
+| `e ⊠ k` | `HasPlug.plug e k` (plug / close) | 60r | `\boxtimes` |
+
+Precedence ensures `A ∥ B ⊞ C ⊠ K` parses as `((A ∥ B) ⊞ C) ⊠ K`.
+
+## PFunctor and FreeM Notation
+
+Most `PFunctor` / `FreeM` definitions are written in long form rather
+than via custom notation, to keep elaboration predictable. Specifically:
+
+- Sum, product, sigma, pi, tensor, and composition of polynomial
+  functors all use named definitions
+  (`PFunctor.sum`, `PFunctor.prod`, `PFunctor.sigma`, `PFunctor.pi`,
+  `PFunctor.tensor`, `PFunctor.comp`) and the corresponding ring-style
+  instance notation `+`, `*`, etc. defined in
+  [`PolyFun/PFunctor/Basic.lean`](../../PolyFun/PFunctor/Basic.lean).
+- Lens equivalence `P ≃ₚ Q` (input `\equiv p`) is defined in
+  [`PolyFun/PFunctor/Equiv/Basic.lean`](../../PolyFun/PFunctor/Equiv/Basic.lean).
+- `FreeM` uses standard monadic `do`-notation. There is no separate
+  surface syntax for `roll` / `pure`; reach for `PFunctor.FreeM.lift`
+  and `PFunctor.FreeM.liftPos` when you need to embed a single
+  polynomial step.
+
+If you find yourself wishing for new notation in PolyFun, consider
+whether the underlying name suffices first: this library leans toward
+explicit names and standard Mathlib notation, and reserves custom
+operators for the UC-composition algebra above.

--- a/docs/wiki/pfunctor.md
+++ b/docs/wiki/pfunctor.md
@@ -1,0 +1,119 @@
+# Polynomial Functors and `FreeM`
+
+This page is the agent-facing tour of `PolyFun/PFunctor/` and
+`PolyFun/Control/Comonad/Cofree.lean`. It is descriptive, not load-bearing:
+the source files are the canonical reference. Cite Lean source by file path
+plus declaration name when accuracy matters.
+
+## Why polynomial functors
+
+A **polynomial functor** is a pair `⟨A, B⟩` where
+
+- `A : Type*` is the *position* / *shape* type;
+- `B : A → Type*` is the *direction* / *arity* family.
+
+Concretely, a `PFunctor` is a generic notion of "branching tree shape":
+each shape `a : A` chooses a branching arity `B a`. This single primitive
+captures inductive types (`W`-types), free monads on signatures, M-types
+(coinductive types), event signatures for interaction trees, and the kind
+of dependent typing needed for protocol move spaces.
+
+The Spivak-Niu *Poly* category (positions and directions composed via
+`Σ` / `Π`) is the categorical home of all of these. PolyFun internalizes
+enough of that category to model:
+
+- free monads on signatures (`PFunctor.FreeM`);
+- displayed families and decorations over them
+  (`PFunctor.FreeM.Displayed`);
+- branch paths through trees (`PFunctor.FreeM.Path`);
+- the cofree comonad / M-type (`PFunctor.CofreeC`);
+- lenses and charts between polynomial functors as morphisms of two
+  natural categories on `Poly`;
+- numeric and structural ornaments (`PFunctor.Bound`).
+
+References:
+[`REFERENCES.md`](../../REFERENCES.md). Hancock-Setzer 2000,
+Altenkirch-Ghani-Hancock-McBride-Morris 2015 (*Indexed Containers*),
+Spivak-Niu 2024 (*Polynomial Functors: A General Theory of Interaction*),
+McBride 2010 / Dagand-McBride 2014 (displayed algebras / ornaments).
+
+## File index
+
+### Substrate (cycle root)
+
+| File | Purpose |
+|------|---------|
+| [`PolyFun/PFunctor/Basic.lean`](../../PolyFun/PFunctor/Basic.lean) | `PFunctor` core, `Obj`, sum / product / sigma / pi / tensor / composition, `Lens`, `selfMonomial`, ring-style `0` / `1` / `+` / `*`. |
+| [`PolyFun/PFunctor/Equiv/Basic.lean`](../../PolyFun/PFunctor/Equiv/Basic.lean) | Equivalences `P ≃ₚ Q` and canonical equivalences for sums, products, sigma / pi, tensor, composition, universe lifts. |
+| [`PolyFun/PFunctor/MFacts.lean`](../../PolyFun/PFunctor/MFacts.lean) | Facts about Mathlib's `PFunctor.M` (M-type / final coalgebra) used downstream. |
+| [`PolyFun/PFunctor/Bound.lean`](../../PolyFun/PFunctor/Bound.lean) | Roll bounds for `FreeM` (budget-based termination predicate). |
+
+### Lenses and charts
+
+| File | Purpose |
+|------|---------|
+| [`PolyFun/PFunctor/Lens/Basic.lean`](../../PolyFun/PFunctor/Lens/Basic.lean) | Properties of `Lens P Q`: extensionality, composition lemmas, action on `Obj`. |
+| [`PolyFun/PFunctor/Lens/Cartesian.lean`](../../PolyFun/PFunctor/Lens/Cartesian.lean) | Cartesian lenses (`toFunB a` is a bijection); fiberwise isomorphisms over a forward position map. |
+| [`PolyFun/PFunctor/Lens/State.lean`](../../PolyFun/PFunctor/Lens/State.lean) | Lawful state-lens specialization for the self-monomial polynomial (`get`, `put`, `PutGet` / `GetPut` / `PutPut`). |
+| [`PolyFun/PFunctor/Chart/Basic.lean`](../../PolyFun/PFunctor/Chart/Basic.lean) | Charts (forward map on both positions and directions). Chart category is isomorphic to `Set^→` and has a different monoidal structure from the lens category. |
+| [`PolyFun/PFunctor/Category.lean`](../../PolyFun/PFunctor/Category.lean) | Category-theoretic packaging where applicable. |
+
+### Free monad `FreeM`
+
+| File | Purpose |
+|------|---------|
+| [`PolyFun/PFunctor/Free/Basic.lean`](../../PolyFun/PFunctor/Free/Basic.lean) | `FreeM P α` (`pure` / `roll`), `lift`, `liftPos`, `bind`, `Monad` and `LawfulMonad` instances, eliminator combinators. |
+| [`PolyFun/PFunctor/Free/Path.lean`](../../PolyFun/PFunctor/Free/Path.lean) | `FreeM.Path s` (explicit polynomial direction at every node), `PathAlong`, `output`, `append`, `TelescopeWith` (state-indexed initial algebra). |
+| [`PolyFun/PFunctor/Free/Displayed.lean`](../../PolyFun/PFunctor/Free/Displayed.lean) | `FreeM.Displayed D s` (displayed family over a tree), `Displayed.Section` (displayed catamorphism). The substrate behind decorations, paths, and compact observations. |
+| [`PolyFun/PFunctor/Free/Displayed/Decoration.lean`](../../PolyFun/PFunctor/Free/Displayed/Decoration.lean) | `Decoration Γ s`: every node carries one `Γ a` and recursively decorates children. |
+
+### Cofree / M-type companion
+
+| File | Purpose |
+|------|---------|
+| [`PolyFun/PFunctor/Cofree.lean`](../../PolyFun/PFunctor/Cofree.lean) | `CofreeC` (cofree comonad on a `PFunctor`), built from `PFunctor.M` of the `constProd` polynomial. The dual of `FreeM`. |
+| [`PolyFun/PFunctor/Trace.lean`](../../PolyFun/PFunctor/Trace.lean) | Polynomial-trace machinery shared between `PFunctor` and downstream layers. |
+
+### Control helpers
+
+`PolyFun/Control/` is logically below `PFunctor/Free` in the import DAG and
+provides the reusable monad / comonad / coalgebra plumbing. See
+[`PolyFun/Control/`](../../PolyFun/Control/) for the full inventory:
+`Coalgebra`, `Comonad/{Basic, Cofree, Instances}`, `Lawful/Basic`,
+`Monad/{Algebra, Equiv, Free, FreeCont, Hom, Iter}`, `Trace`.
+
+## Mental model
+
+- `PFunctor` is a *small* gadget: just `(A : Type, B : A → Type)`. Almost
+  every interesting structure in PolyFun is built by combining a few of
+  these via `+` / `*` / `⊗` / `Σ` / `Π` / composition, or by taking the
+  free monad / cofree comonad / lens / chart of one.
+- `FreeM P` is the free monad on `P`. Operationally it is the inductive
+  type of well-founded `P`-branching trees with `α`-leaves. It is the
+  syntax of "programs" in the signature `P`.
+- `CofreeC P` is the cofree comonad on `P`. Coinductively, it is the
+  type of infinite, fully-decorated `P`-trees. It is the patterns/matter
+  pairing `FreeM ⊣ Cofree` from Spivak-Niu.
+- `Lens P Q` and `Chart P Q` are the two natural categorical morphisms
+  between polynomial functors. Lenses go `forward on positions, backward
+  on directions`; charts go forward on both. Both categories are useful
+  and distinct.
+- `Displayed D s` is the dependent-types view of "decorating every node
+  of a tree with extra data". `Decoration Γ s` is the special case where
+  the data only depends on the local position.
+
+## What lives where downstream
+
+- `PolyFun/ITree/` (see [`itree.md`](itree.md)) builds interaction trees
+  as the M-type of a one-step polynomial functor. It uses
+  `PolyFun/PFunctor/MFacts.lean` and the cofree apparatus.
+- `PolyFun/Interaction/Basic/` (see [`interaction.md`](interaction.md))
+  builds protocol `Spec`s as `PFunctor.FreeM Spec.basePFunctor PUnit`,
+  i.e. `PUnit`-leaved free trees on a particular base polynomial. Most
+  of the interaction framework is just a dependent-typed dressing on top
+  of `FreeM` plus `Decoration` / `Displayed`.
+
+If a concept appears redundant between layers, the substrate version
+(here, in `PFunctor/`) is almost always the load-bearing one. Downstream
+layers exist to give protocol-flavored names and ergonomics; the maths
+lives in `PFunctor/Free/` and `PFunctor/Cofree.lean`.

--- a/docs/wiki/quickstart.md
+++ b/docs/wiki/quickstart.md
@@ -19,8 +19,13 @@ lake exe cache get
 ```
 
 `./scripts/validate.sh` is the recommended convenience wrapper for routine
-local validation. By default it runs `lake build` followed by
-`./scripts/check-imports.sh`.
+local validation. By default it runs:
+
+1. `lake build`
+2. `./scripts/check-imports.sh` (umbrella `PolyFun.lean` matches the
+   tracked source tree)
+3. `python3 ./scripts/check-docs-integrity.py` (CLAUDE.md symlink and
+   tracked-markdown link resolution)
 
 ## Validation By Change Type
 
@@ -58,6 +63,7 @@ issue:
 ```bash
 lake build
 ./scripts/check-imports.sh
+python3 ./scripts/check-docs-integrity.py
 ```
 
 If you specifically need to regenerate `PolyFun.lean`, use:
@@ -76,17 +82,27 @@ To run the style lint on its own:
 
 - [`../../.github/workflows/ci.yml`](../../.github/workflows/ci.yml): runs
   `lake build` and `./scripts/validate.sh` on every push to `main` and on
-  pull requests.
+  pull requests. The `build` job is a required status check on `main`.
+- [`../../.github/workflows/check-imports.yml`](../../.github/workflows/check-imports.yml):
+  checks that `PolyFun.lean` matches the tracked source tree. `Check
+  Library File Imports` is a required status check on `main`.
+- [`../../.github/workflows/docs-integrity.yml`](../../.github/workflows/docs-integrity.yml):
+  runs `./scripts/check-docs-integrity.py` (CLAUDE.md symlink, tracked
+  markdown link resolution). `Check Docs Integrity` is a required status
+  check on `main`. This is the agent-documentation liveness check: any
+  PR that breaks an internal link in `AGENTS.md`, `README.md`,
+  `CONTRIBUTING.md`, `REFERENCES.md`, `PORTING-PLAN.md`, or any tracked
+  page under `docs/` will fail this job.
 - [`../../.github/workflows/linting.yml`](../../.github/workflows/linting.yml):
   runs `./scripts/lint-style.sh` (Mathlib-derived style linter).
-- [`../../.github/workflows/check-imports.yml`](../../.github/workflows/check-imports.yml):
-  checks that `PolyFun.lean` matches the tracked source tree.
+- [`../../.github/workflows/summary.yml`](../../.github/workflows/summary.yml):
+  optional AI-generated PR summary; gated on `GEMINI_API_KEY` repository
+  secret. Skipped (with a notice) if the secret is not set.
 - [`../../.github/workflows/release-tag.yml`](../../.github/workflows/release-tag.yml),
   [`../../.github/workflows/update.yml`](../../.github/workflows/update.yml),
-  [`../../.github/workflows/summary.yml`](../../.github/workflows/summary.yml),
   [`../../.github/workflows/review.yml`](../../.github/workflows/review.yml):
-  release tagging, dependency-update PRs, summary stats, and review-helper
-  workflows ported from
+  release tagging, dependency-update PRs, and review-helper workflows
+  ported from
   [`Verified-zkEVM/ArkLib`](https://github.com/Verified-zkEVM/ArkLib).
 
 ## Toolchain

--- a/docs/wiki/quickstart.md
+++ b/docs/wiki/quickstart.md
@@ -1,0 +1,114 @@
+# Quickstart
+
+This page is the recommended agent playbook for commands and validation.
+Use it as the main guide for routine local checks.
+
+## Recommended Validation
+
+For a convenient routine check, run:
+
+```bash
+./scripts/validate.sh
+```
+
+On a cold clone, fetch precompiled dependencies first:
+
+```bash
+lake exe cache get
+./scripts/validate.sh
+```
+
+`./scripts/validate.sh` is the recommended convenience wrapper for routine
+local validation. By default it runs `lake build` followed by
+`./scripts/check-imports.sh`.
+
+## Validation By Change Type
+
+### Existing Lean files only
+
+```bash
+./scripts/validate.sh
+```
+
+### Added, renamed, or deleted files under `PolyFun/`
+
+```bash
+git add path/to/newfile.lean
+./scripts/validate.sh
+```
+
+`./scripts/update-lib.sh` only considers tracked files, and fails fast if
+untracked `PolyFun/**/*.lean` files are present.
+
+### Lean-heavy refactors or cleanup
+
+```bash
+./scripts/validate.sh --lint
+```
+
+This adds `./scripts/lint-style.sh` to the convenience wrapper. The main CI
+build runs `validate.sh` without `--lint`, but a separate `linting.yml`
+workflow runs the style lint, so treat lint passes as required for merge.
+
+## Optional Direct Commands
+
+You can still run the underlying pieces directly when debugging a specific
+issue:
+
+```bash
+lake build
+./scripts/check-imports.sh
+```
+
+If you specifically need to regenerate `PolyFun.lean`, use:
+
+```bash
+./scripts/update-lib.sh
+```
+
+To run the style lint on its own:
+
+```bash
+./scripts/lint-style.sh
+```
+
+## CI Mapping
+
+- [`../../.github/workflows/ci.yml`](../../.github/workflows/ci.yml): runs
+  `lake build` and `./scripts/validate.sh` on every push to `main` and on
+  pull requests.
+- [`../../.github/workflows/linting.yml`](../../.github/workflows/linting.yml):
+  runs `./scripts/lint-style.sh` (Mathlib-derived style linter).
+- [`../../.github/workflows/check-imports.yml`](../../.github/workflows/check-imports.yml):
+  checks that `PolyFun.lean` matches the tracked source tree.
+- [`../../.github/workflows/release-tag.yml`](../../.github/workflows/release-tag.yml),
+  [`../../.github/workflows/update.yml`](../../.github/workflows/update.yml),
+  [`../../.github/workflows/summary.yml`](../../.github/workflows/summary.yml),
+  [`../../.github/workflows/review.yml`](../../.github/workflows/review.yml):
+  release tagging, dependency-update PRs, summary stats, and review-helper
+  workflows ported from
+  [`Verified-zkEVM/ArkLib`](https://github.com/Verified-zkEVM/ArkLib).
+
+## Toolchain
+
+Lean toolchain and Mathlib stay in sync. Both currently `v4.29.0`. When
+upgrading, update [`lean-toolchain`](../../lean-toolchain) and the
+`require mathlib` line in [`lakefile.toml`](../../lakefile.toml)
+simultaneously.
+
+## Ongoing Port from VCV-io
+
+PolyFun is being seeded from
+[`Verified-zkEVM/VCV-io`](https://github.com/Verified-zkEVM/VCV-io). The
+current port plan, file inventory, and risk register live in
+[`../../PORTING-PLAN.md`](../../PORTING-PLAN.md). Two repo-local helpers
+support follow-up resyncs:
+
+- [`../../scripts/port-from-vcvio.sh`](../../scripts/port-from-vcvio.sh):
+  wholesale copy of in-scope files from a VCV-io worktree.
+- [`../../scripts/rename-namespaces.sh`](../../scripts/rename-namespaces.sh):
+  bulk `ToMathlib.*` / `VCVio.Interaction.*` to `PolyFun.*` namespace
+  rename.
+
+These are intended for one-shot or rare resync use, not for routine
+development. Most contributions should never need to invoke them.

--- a/docs/wiki/repo-map.md
+++ b/docs/wiki/repo-map.md
@@ -1,0 +1,107 @@
+# Repo Map
+
+This repo is easiest to navigate by subtree, not by individual file name.
+Most developments cluster by layer: `PFunctor` substrate, `ITree`,
+`Interaction` framework. Cross-layer notes belong here; per-layer details
+live in the dedicated pages [`pfunctor.md`](pfunctor.md),
+[`itree.md`](itree.md), and [`interaction.md`](interaction.md).
+
+## Main Surfaces
+
+```text
+PolyFun/
+  PFunctor/          polynomial functors, charts, lenses, equivalences,
+                     M-type / cofree, free monad and displayed-free
+  ITree/             coinductive interaction trees, bisim/sim, handlers,
+                     event signatures
+  Interaction/       generic interaction framework
+    Basic/           Spec, Node, Decoration, Strategy, Append, ...
+    TwoParty/        sender/receiver roles, paired strategies
+    Multiparty/      per-party local view modes, observation kernels
+    Concurrent/      structural and dynamic concurrent semantics
+    UC/              open-process / open-theory layer (no security content)
+  Control/           monad and comonad infrastructure (Coalg, Comonad,
+                     Lawful, Free, FreeCont, Hom, Iter, Trace)
+  Logic/             small logic helpers (HEq)
+
+docs/wiki/           agent-facing notes (this directory)
+scripts/             repo utilities (validate, lint, update-lib, port helpers)
+.github/workflows/   CI workflows
+```
+
+## Conceptual Layering
+
+Imports flow strictly downward, cycles are a build error. The DAG is also
+recorded in [`AGENTS.md`](../../AGENTS.md):
+
+```text
+PFunctor/{Basic, Bound, MFacts, Equiv, Chart, Lens}
+  -> PFunctor/{Cofree, Trace}
+  -> PFunctor/Free/{Basic, Path}
+  -> PFunctor/Free/{Displayed, Displayed/Decoration}
+
+Logic/HEq, Control/{Coalgebra, Comonad, Lawful, Monad}
+  (free-standing helpers, depended on by both PFunctor and ITree)
+
+PFunctor/Free -> ITree/{Basic, Construct, Handler, Rec,
+                        Events, Sim, Bisim}
+
+PFunctor/Free + Control -> Interaction/Basic/{Spec, Node, Decoration,
+                            Syntax, Shape, Interaction, Strategy,
+                            Append, Replicate, StateChain, Chain,
+                            Telescope, Sampler, MonadDecoration,
+                            BundledMonad, Ownership, SpecFintype}
+
+Interaction/Basic -> Interaction/{TwoParty, Multiparty, Concurrent}
+
+Interaction/{Concurrent, Basic} -> Interaction/UC/{Interface,
+                                   OpenProcess, OpenProcessModel,
+                                   OpenTheory, OpenSyntax, Notation,
+                                   Emulates, MachineId, EnvAction,
+                                   EnvOpenProcess, CorruptionModel,
+                                   MomentaryCorruption, Leakage}
+```
+
+`PolyFun.lean` is a generated umbrella import file, not a hand-maintained
+module index. See [`generated-files.md`](generated-files.md).
+
+## Where To Start By Task
+
+- Working on the polynomial-functor substrate (positions / directions,
+  lenses, charts, free monad, cofree / M-type, displayed `FreeM`): start
+  in `PolyFun/PFunctor/`. See [`pfunctor.md`](pfunctor.md) for the layer
+  guide.
+- Working on coinductive interaction trees, bisimulation, simulation, or
+  event signatures: start in `PolyFun/ITree/`. See [`itree.md`](itree.md).
+- Working on the generic interaction framework (sequential `Spec`,
+  decorations, strategies, two-party, multiparty, concurrent, UC open
+  systems): start in `PolyFun/Interaction/`. See
+  [`interaction.md`](interaction.md).
+- Adding monad / comonad helpers, lawful re-exports, or free-monad
+  algebra: start in `PolyFun/Control/`.
+- Updating notation: start in `PolyFun/Interaction/UC/Notation.lean`. See
+  [`notation.md`](notation.md).
+
+## Scope Boundary: No Cryptographic Content
+
+PolyFun is intentionally *not* the place for cryptographic content.
+Probabilistic semantics, evaluation distributions, oracle-simulation
+security definitions, scheme-specific algebra, and concrete-protocol
+runtime layers all live in
+[`Verified-zkEVM/VCV-io`](https://github.com/Verified-zkEVM/VCV-io) and
+depend on this library.
+
+When in doubt, ask: *can this definition be stated against an arbitrary
+monad `m` with `[Monad m]` and friends, with no probability, no security
+predicate, and no concrete cryptographic algebra?* If the answer is yes,
+it belongs in PolyFun. If the answer is no, it belongs downstream in
+VCV-io or a more specialized repo.
+
+## Navigation Notes
+
+- `PolyFun.lean` is generated. After adding, renaming, or deleting `.lean`
+  files under `PolyFun/`, run `./scripts/update-lib.sh`.
+- Files should stay under 1500 lines unless explicitly opted out per file.
+  The long-file linter cap is enforced via the lint workflow.
+- Before assuming a file is authoritative, check whether it is source or
+  derived output. See [`generated-files.md`](generated-files.md).

--- a/scripts/check-docs-integrity.py
+++ b/scripts/check-docs-integrity.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Check PolyFun documentation integrity.
+
+Checks:
+1. `CLAUDE.md` exists and is a symlink to `AGENTS.md`.
+2. Local markdown links in tracked top-level docs and `docs/` resolve.
+
+Exit code 0 if all checks pass, 1 otherwise.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CLAUDE_PATH = REPO_ROOT / "CLAUDE.md"
+AGENTS_PATH = REPO_ROOT / "AGENTS.md"
+
+# The set of tracked markdown files we walk for link checking. Top-level
+# repo docs plus everything under `docs/`. Keep this list in sync with the
+# wiki maintenance contract in `docs/wiki/README.md`.
+TRACKED_PATHS = [
+    "AGENTS.md",
+    "CONTRIBUTING.md",
+    "README.md",
+    "REFERENCES.md",
+    "PORTING-PLAN.md",
+    "docs",
+]
+
+MARKDOWN_LINK_RE = re.compile(r"(?<!!)\[[^\]]+\]\(([^)]+)\)")
+
+
+def tracked_markdown_files() -> list[Path]:
+    result = subprocess.run(
+        ["git", "ls-files", "--", *TRACKED_PATHS],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [
+        REPO_ROOT / rel_path
+        for rel_path in result.stdout.splitlines()
+        if rel_path.endswith(".md")
+    ]
+
+
+def check_claude_symlink() -> list[str]:
+    errors: list[str] = []
+    if not AGENTS_PATH.exists():
+        errors.append("Missing AGENTS.md")
+        return errors
+    if not CLAUDE_PATH.exists() and not CLAUDE_PATH.is_symlink():
+        errors.append("Missing CLAUDE.md")
+        return errors
+    if not CLAUDE_PATH.is_symlink():
+        errors.append("CLAUDE.md must be a symlink to AGENTS.md")
+        return errors
+
+    target = Path(CLAUDE_PATH.readlink())
+    if target != Path("AGENTS.md"):
+        errors.append(f"CLAUDE.md must point to AGENTS.md, found {target}")
+    elif not CLAUDE_PATH.resolve().samefile(AGENTS_PATH):
+        errors.append("CLAUDE.md symlink does not resolve to AGENTS.md")
+    return errors
+
+
+def resolve_link(source_file: Path, raw_target: str) -> Path | None:
+    target = raw_target.strip().strip("`")
+    if not target or "://" in target or target.startswith("mailto:"):
+        return None
+
+    path_part = target.split("#", 1)[0].strip()
+    if not path_part:
+        return None
+
+    if path_part.startswith("/"):
+        return (REPO_ROOT / path_part.lstrip("/")).resolve()
+    return (source_file.parent / path_part).resolve()
+
+
+def check_markdown_links() -> list[str]:
+    errors: list[str] = []
+    for doc_file in tracked_markdown_files():
+        text = doc_file.read_text()
+        for raw_target in MARKDOWN_LINK_RE.findall(text):
+            resolved = resolve_link(doc_file, raw_target)
+            if resolved is None:
+                continue
+            if not resolved.exists():
+                rel_doc = doc_file.relative_to(REPO_ROOT)
+                errors.append(f"Broken link in {rel_doc}: {raw_target}")
+    return errors
+
+
+def main() -> int:
+    all_errors: list[str] = []
+
+    print("Checking CLAUDE.md symlink...")
+    all_errors.extend(check_claude_symlink())
+
+    print("Checking tracked markdown links...")
+    all_errors.extend(check_markdown_links())
+
+    if all_errors:
+        print(f"\n{len(all_errors)} issue(s) found:\n")
+        for err in all_errors:
+            print(f"  - {err}")
+        return 1
+
+    print("\nAll documentation integrity checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -16,6 +16,7 @@ Usage: ./scripts/validate.sh [--lint]
 Default checks:
   - lake build
   - ./scripts/check-imports.sh
+  - python3 ./scripts/check-docs-integrity.py
 
 Optional checks:
   --lint   Run ./scripts/lint-style.sh
@@ -45,6 +46,10 @@ lake build
 echo ""
 echo "# Checking umbrella imports"
 ./scripts/check-imports.sh
+
+echo ""
+echo "# Checking docs integrity"
+python3 ./scripts/check-docs-integrity.py
 
 if (( run_lint )); then
   echo ""


### PR DESCRIPTION
## Summary

Bootstraps an agent-facing wiki under `docs/wiki/`, marks PolyFun as
experimental, and lights up the agent-documentation liveness CI plus
branch protection on `main`.

### New wiki pages

Adapted from
[`Verified-zkEVM/ArkLib`](https://github.com/Verified-zkEVM/ArkLib)
and the relevant subset of
[`Verified-zkEVM/VCV-io`](https://github.com/Verified-zkEVM/VCV-io)
`docs/agents/`, tuned to PolyFun's generic, non-cryptographic scope.

| Page | Purpose |
|---|---|
| `docs/wiki/README.md` | Hub and maintenance contract. |
| `docs/wiki/quickstart.md` | Validation playbook (`validate.sh`, `update-lib.sh`, `lint-style.sh`, CI mapping). |
| `docs/wiki/repo-map.md` | Subtree map and where-to-start guide. |
| `docs/wiki/generated-files.md` | Derived outputs and source-of-truth rules. |
| `docs/wiki/pfunctor.md` | `PFunctor` substrate tour (`FreeM`, `Displayed`, `CofreeC`, lenses, charts). |
| `docs/wiki/itree.md` | ITree layer tour (`ITree`, `Handler`, `simulate`, bisimulation, standard events). |
| `docs/wiki/interaction.md` | Generic interaction framework (`Spec`, two-party, multiparty, concurrent, UC). |
| `docs/wiki/notation.md` | UC composition (`∥`, `⊞`, `⊠`) and boundary tensor / swap (`⊗ᵇ`, `ᵛ`). |
| `docs/wiki/gotchas.md` | Generic Lean traps and PolyFun-specific pitfalls. |

`interaction.md` is the largest port: derived from VCV-io's
`docs/agents/interaction.md` with all crypto-specific references
removed (no `Computational.lean`, no `Runtime.lean`, no `AsyncRuntime.lean`
/ `AsyncSecurity.lean`, no `Standard.lean`, no `StdDoBridge.lean`).
`gotchas.md` drops the probability-specific items (`spec.Fintype`,
`evalDist`, `++ₒ`, `probOutput_bind_eq_tsum`, `vcstep`, `EvalDist/`
layering) and keeps the generic Lean traps plus PolyFun-specific ones
(no crypto, `Spec.done` / `node` invariants, universe parameters across
`PFunctor` / `FreeM` / `Spec`, `do`-notation bind in Lean 4.29).

### Experimental warning and wiki maintenance contract

- `README.md`: adds an explicit experimental status block at the top
  warning that names, namespaces, module layout, and documentation
  (including this wiki) are expected to drift. Adds a Documentation
  section linking the new wiki.
- `AGENTS.md`: adds a Further Reading section indexing every wiki page
  and a Wiki Maintenance Contract section requiring future PRs that
  change commands, structure, generated-file behavior, file naming,
  namespaces, or load-bearing public APIs to update the matching wiki
  page in the same PR.

### Agent-documentation liveness CI

- `scripts/check-docs-integrity.py`: ported from
  `Verified-zkEVM/ArkLib`. Verifies the `CLAUDE.md → AGENTS.md`
  symlink and resolves every internal markdown link in tracked
  top-level docs (`AGENTS.md`, `CONTRIBUTING.md`, `README.md`,
  `REFERENCES.md`, `PORTING-PLAN.md`) and the `docs/` tree.
- `.github/workflows/docs-integrity.yml`: runs the script on every PR.
- `./scripts/validate.sh`: now invokes the docs-integrity check
  alongside `lake build` and `./scripts/check-imports.sh`.

### Failing-summary fix

- `.github/workflows/summary.yml`: gates the `lean-summary-workflow`
  action on `secrets.GEMINI_API_KEY` being non-empty, and skips the
  step (with a GitHub notice) when the secret is missing. The
  workflow uses `pull_request_target`, so this fix takes effect
  *after* this PR merges. In the meantime, `summarize` is not a
  required status check, so it does not block the merge.

### Branch protection on `main`

Configured separately via `gh api`:

- `main` is now protected. Direct pushes are blocked; all changes
  must land via pull request.
- Required status checks: `build`, `Check Library File Imports`,
  `Check Docs Integrity`. `strict` is on (PR must be up to date with
  `main` before merge).
- `enforce_admins`: false (admin emergency override retained).
- `allow_force_pushes`: false. `allow_deletions`: false.
- `required_approving_review_count`: 0 (PR required, but no approval
  gate; can be raised later).

## Test plan

- [x] `./scripts/validate.sh` (lake build + check-imports + docs-integrity)
- [x] Manual run of `python3 scripts/check-docs-integrity.py`
- [x] Manual link check for `docs/wiki/*.md` cross-references and
  `../../` references into `PolyFun/`, `AGENTS.md`, `CONTRIBUTING.md`,
  `REFERENCES.md`, `PORTING-PLAN.md`.

---

Posted by Cursor assistant (model: Claude Opus 4.7) on behalf of the user (Quang Dao) with approval.