### PR TITLE
Extract open-process boundary traces

### DIFF
--- a/PolyFun/Interaction/UC/OpenProcess.lean
+++ b/PolyFun/Interaction/UC/OpenProcess.lean
@@ -48,6 +48,10 @@ structural boundary operations land directly in the generic `Trace` API:
 `wireRight` are `Trace.mapPartial` on the appropriate sum projections. The
 empty-emission default is the trace-monoid unit `1`, which is definitionally
 the constant-`[]` trace.
+
+`OpenNodeContext.boundaryTrace` reads the emitted-packet trace from a
+decorated step transcript. It is structural only: routing, buffering, and
+probabilistic execution belong to downstream runtime interpreters.
 -/
 
 universe u v w w'
@@ -664,6 +668,29 @@ theorem map_eq_ofProductView_comp_prodMap_comp_toProductView
 
 end OpenNodeContext
 
+/-! ## Boundary trace extraction -/
+
+/--
+Extract the finite boundary-output trace emitted by a decorated open-process
+interaction transcript.
+
+The `BoundaryAction.emit` field is indexed by the move chosen at each node;
+a transcript supplies exactly those moves. The result is the ordered product
+of all emitted packets along the root-to-leaf path of the step.
+
+This is structural: it reads only the boundary actions already present in the
+open-process decoration. Runtime concerns such as buffering, delivery, and
+routing across internal wires are intentionally handled downstream.
+-/
+def OpenNodeContext.boundaryTrace
+    {Party : Type u} {Δ : PortBoundary} :
+    (spec : Spec.{w}) →
+    Decoration (OpenNodeContext Party Δ) spec →
+    Spec.Transcript spec → PFunctor.TraceList Δ.Out
+  | .done, _, _ => 1
+  | .node _ rest, ⟨node, next⟩, ⟨x, tr⟩ =>
+      node.boundary.emit x * OpenNodeContext.boundaryTrace (rest x) (next x) tr
+
 /--
 The open-world specialization of `StepOver`.
 
@@ -673,6 +700,16 @@ records both the usual controller/view data and its boundary traffic against
 -/
 abbrev OpenStep (Party : Type u) (Δ : PortBoundary) (P : Type v) :=
   StepOver (OpenNodeContext Party Δ : Spec.Node.Context.{0}) P
+
+namespace OpenStep
+
+/-- The boundary-output trace emitted by a completed open step transcript. -/
+def boundaryTrace {Party : Type u} {Δ : PortBoundary} {P : Type v}
+    (step : OpenStep Party Δ P) (tr : Spec.Transcript step.spec) :
+    PFunctor.TraceList Δ.Out :=
+  OpenNodeContext.boundaryTrace step.spec step.semantics tr
+
+end OpenStep
 
 /--
 An `m`-parametric open concurrent process exposing boundary `Δ`.

--- a/docs/wiki/interaction.md
+++ b/docs/wiki/interaction.md
@@ -135,7 +135,9 @@ content* of a single party's view.
 `OpenNodeProfile Party Δ X`
 ([`PolyFun/Interaction/UC/OpenProcess.lean`](../../PolyFun/Interaction/UC/OpenProcess.lean))
 is the open-system extension that adds one `BoundaryAction Δ X` field for
-external traffic.
+external traffic. `OpenNodeContext.boundaryTrace` extracts the finite
+outbound-packet trace emitted along a completed decorated step transcript;
+routing and probabilistic execution remain downstream runtime concerns.
 
 ### Mental picture
 
@@ -588,7 +590,7 @@ import PolyFun.Interaction.UC.OpenProcessModel
 | `OpenSyntax/Raw.lean` | `Raw` syntax tree, `Raw.interpret`, `Raw.Equiv` (incl. monoidal / traced / CC equations) |
 | `OpenSyntax/Interp.lean` | `Interp` (tagless-final), granular `HasUnit` / `HasIdWire` / `IsMonoidal` / `IsTraced` / `IsCompactClosed` / `HasPlugWireFactor` instances |
 | `OpenSyntax/Expr.lean` | `Expr` (quotient of `Raw`), granular `OpenTheory` lawfulness instances, `Expr.toInterp` |
-| `OpenProcess.lean` | `BoundaryAction`, `OpenNodeProfile`, `OpenNodeContext` (with polynomial-product bridge `productView`), `OpenProcess m Party Δ` (monad-parametric, with intrinsic `stepSampler`), `toProcess`, `OpenProcessIso` |
+| `OpenProcess.lean` | `BoundaryAction`, `OpenNodeProfile`, `OpenNodeContext` (with polynomial-product bridge `productView` and structural `boundaryTrace`), `OpenProcess m Party Δ` (monad-parametric, with intrinsic `stepSampler`), `toProcess`, `OpenProcessIso` |
 | `OpenProcessModel.lean` | `openTheory m Party schedulerSampler` (concrete model threading `Spec.Sampler` through `map` / `par` / `wire` / `plug`), `IsLawful`, monoidal / CC laws up to `OpenProcessIso` |
 | `Emulates.lean` | `Observation`, `Emulates`, `UCSecure`. Contextual emulation and UC security stated abstractly over an `Observation` (an equivalence relation on closed systems), with no probability monad and no concrete security predicate. |
 | `Notation.lean` | UC notation helpers (`∥`, `⊞`, `⊠`, `⊗ᵇ`, `ᵛ`); see [`notation.md`](notation.md) |


### PR DESCRIPTION
## Summary

- Add `OpenNodeContext.boundaryTrace` for reading the finite emitted-packet trace from a decorated open-process transcript.
- Add `OpenStep.boundaryTrace` as the step-level wrapper.
- Update the interaction wiki to document that this is structural PolyFun infrastructure, while routing and probabilistic execution remain downstream runtime concerns.

## Why

VCV-io needs a generic way to talk about emitted boundary traffic without defining probability, oracle semantics, or computational UC security in PolyFun. This PR keeps that split clean: PolyFun exposes the structural trace extractor; downstream libraries can decide how to sample transcripts and interpret the resulting traces.

## Validation

- `lake build PolyFun.Interaction.UC.OpenProcess PolyFun.Interaction.UC.OpenProcessModel`
- `git diff --check`

Posted by Cursor assistant (model: GPT-5) on behalf of the user (Quang Dao) with approval.