### PR TITLE
feat(pfunctor): book-order ⨟ notation for PointedMachine.seqComp

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "lean4.input.customTranslations": {
+    ";;": "⨟"
+  }
+}

--- a/PolyFun/IPFunctor/Chart/Basic.lean
+++ b/PolyFun/IPFunctor/Chart/Basic.lean
@@ -52,7 +52,8 @@ protected def id (P : IPFunctor.{uI, uJ, uA, uB} I J) : Chart P P where
   toFunB _ _ := id
   src_eq _ _ _ := rfl
 
-/-- Composition of charts (diagrammatic order: `c ∘c c'` applies `c'` first, then `c`). -/
+/-- Composition of charts in function-composition order: `c ∘c c'` applies `c'` first,
+then `c`. -/
 def comp {P : IPFunctor.{uI, uJ, uA₁, uB₁} I J}
     {Q : IPFunctor.{uI, uJ, uA₂, uB₂} I J}
     {R : IPFunctor.{uI, uJ, uA₃, uB₃} I J}

--- a/PolyFun/IPFunctor/Lens/Basic.lean
+++ b/PolyFun/IPFunctor/Lens/Basic.lean
@@ -53,8 +53,8 @@ protected def id (P : IPFunctor.{uI, uJ, uA, uB} I J) : Lens P P where
   toFunB _ _ := id
   src_eq _ _ _ := rfl
 
-/-- Composition of lenses (diagrammatic / functor-composition order: `l ∘ₗ l'` applies `l'`
-first, then `l`). -/
+/-- Composition of lenses in function-composition order: `l ∘ₗ l'` applies `l'` first,
+then `l`. -/
 def comp {P : IPFunctor.{uI, uJ, uA₁, uB₁} I J}
     {Q : IPFunctor.{uI, uJ, uA₂, uB₂} I J}
     {R : IPFunctor.{uI, uJ, uA₃, uB₃} I J}

--- a/PolyFun/PFunctor/Dynamical/PointedMachine.lean
+++ b/PolyFun/PFunctor/Dynamical/PointedMachine.lean
@@ -161,7 +161,9 @@ def wrap (M : PointedMachine.{u} p α β) (w : Lens p q) : PointedMachine.{u} q 
 from that value. The state set is `M₁.State ⊕ M₂.State`; phase one never reads
 out, phase two carries the final output. Only the returned `mid` value crosses
 the handoff; information from phase one's private terminal state must either be
-returned in `mid` or live in the ambient handler effect. -/
+returned in `mid` or live in the ambient handler effect. The notation is
+left-associative; this fixes how chains parse, rather than asserting
+definitional associativity. -/
 def seqComp (M₁ : PointedMachine p α mid) (M₂ : PointedMachine p mid β) : PointedMachine p α β where
   State := M₁.State ⊕ M₂.State
   expose := fun s => match s with

--- a/PolyFun/PFunctor/Dynamical/PointedMachine.lean
+++ b/PolyFun/PFunctor/Dynamical/PointedMachine.lean
@@ -24,13 +24,14 @@ machine is a `PointedMachine` over an oracle spec's polynomial).
 
 ## Sequential composition (Spivak–Niu Example 6.41)
 
-`seqComp M₁ M₂ : PointedMachine p α β` runs `M₁ : PointedMachine p α mid` until it produces a
-`mid` value, then hands off to `M₂ : PointedMachine p mid β`, over the *same* interface
-`p`. Its state set is `M₁.State ⊕ M₂.State` — the "cascading menus" two-phase
-machine. This sum is the machine-local control state; ambient resources carried
-by the handler monad (such as a random-oracle cache or transcript) are shared
-and threaded through both phases by the single `runWith`. This is the structural
-content of VCVio's `OracleMachine.seqComp` and
+`M₁ ⨟ M₂ : PointedMachine p α β` (`seqComp`, in the book's order) runs
+`M₁ : PointedMachine p α mid` until it produces a `mid` value, then hands off
+to `M₂ : PointedMachine p mid β`, over the *same* interface `p`. Its state set
+is `M₁.State ⊕ M₂.State` — the "cascading menus" two-phase machine. This sum
+is the machine-local control state; ambient resources carried by the handler
+monad (such as a random-oracle cache or transcript) are shared and threaded
+through both phases by the single `runWith`. This is the structural content of
+VCVio's `OracleMachine.seqComp` and
 the structural half of the sought `IsPolyTime.bind`: the definition (with its
 `⊕`-state) is exactly what is currently missing downstream. The complementary
 half — the Turing-machine running-time bound for the composed machine — is
@@ -155,12 +156,12 @@ def wrap (M : PointedMachine.{u} p α β) (w : Lens p q) : PointedMachine.{u} q 
 
 /-! ## Sequential composition -/
 
-/-- Sequential composition of machines over a shared interface (Spivak–Niu
-Example 6.41): run `M₁` until it outputs a `mid` value, then run `M₂` from that
-value. The state set is `M₁.State ⊕ M₂.State`; phase one never reads out, phase
-two carries the final output. As with ordinary monadic bind, only the returned
-`mid` value crosses the handoff; information from phase one's private terminal
-state must either be returned in `mid` or live in the ambient handler effect. -/
+/-- Sequential composition `M₁ ⨟ M₂` of machines over a shared interface
+(Spivak–Niu Example 6.41): run `M₁` until it outputs a `mid` value, then run `M₂`
+from that value. The state set is `M₁.State ⊕ M₂.State`; phase one never reads
+out, phase two carries the final output. Only the returned `mid` value crosses
+the handoff; information from phase one's private terminal state must either be
+returned in `mid` or live in the ambient handler effect. -/
 def seqComp (M₁ : PointedMachine p α mid) (M₂ : PointedMachine p mid β) : PointedMachine p α β where
   State := M₁.State ⊕ M₂.State
   expose := fun s => match s with
@@ -181,31 +182,33 @@ def seqComp (M₁ : PointedMachine p α mid) (M₂ : PointedMachine p mid β) : 
     | Sum.inl _ => none
     | Sum.inr s₂ => M₂.output s₂
 
+@[inherit_doc] infixl:75 " ⨟ " => seqComp
+
 @[simp] theorem seqComp_expose_inr (M₁ : PointedMachine p α mid) (M₂ : PointedMachine p mid β)
-    (s₂ : M₂.State) : (M₁.seqComp M₂).expose (Sum.inr s₂) = M₂.expose s₂ := rfl
+    (s₂ : M₂.State) : (M₁ ⨟ M₂).expose (Sum.inr s₂) = M₂.expose s₂ := rfl
 
 @[simp] theorem seqComp_expose_inl (M₁ : PointedMachine p α mid) (M₂ : PointedMachine p mid β)
-    (s₁ : M₁.State) : (M₁.seqComp M₂).expose (Sum.inl s₁) = M₁.expose s₁ := rfl
+    (s₁ : M₁.State) : (M₁ ⨟ M₂).expose (Sum.inl s₁) = M₁.expose s₁ := rfl
 
 @[simp] theorem seqComp_init (M₁ : PointedMachine p α mid) (M₂ : PointedMachine p mid β)
-    (x : α) : (M₁.seqComp M₂).init x =
+    (x : α) : (M₁ ⨟ M₂).init x =
       match M₁.output (M₁.init x) with
       | some m => Sum.inr (M₂.init m)
       | none => Sum.inl (M₁.init x) := rfl
 
 @[simp] theorem seqComp_output_inr (M₁ : PointedMachine p α mid) (M₂ : PointedMachine p mid β)
-    (s₂ : M₂.State) : (M₁.seqComp M₂).output (Sum.inr s₂) = M₂.output s₂ := rfl
+    (s₂ : M₂.State) : (M₁ ⨟ M₂).output (Sum.inr s₂) = M₂.output s₂ := rfl
 
 @[simp] theorem seqComp_output_inl (M₁ : PointedMachine p α mid) (M₂ : PointedMachine p mid β)
-    (s₁ : M₁.State) : (M₁.seqComp M₂).output (Sum.inl s₁) = none := rfl
+    (s₁ : M₁.State) : (M₁ ⨟ M₂).output (Sum.inl s₁) = none := rfl
 
 @[simp] theorem seqComp_update_inr (M₁ : PointedMachine p α mid) (M₂ : PointedMachine p mid β)
     (s₂ : M₂.State) (d : p.B (M₂.expose s₂)) :
-    (M₁.seqComp M₂).update (Sum.inr s₂) d = Sum.inr (M₂.update s₂ d) := rfl
+    (M₁ ⨟ M₂).update (Sum.inr s₂) d = Sum.inr (M₂.update s₂ d) := rfl
 
 @[simp] theorem seqComp_update_inl (M₁ : PointedMachine p α mid) (M₂ : PointedMachine p mid β)
     (s₁ : M₁.State) (d : p.B (M₁.expose s₁)) :
-    (M₁.seqComp M₂).update (Sum.inl s₁) d =
+    (M₁ ⨟ M₂).update (Sum.inl s₁) d =
       match M₁.output (M₁.update s₁ d) with
       | some m => Sum.inr (M₂.init m)
       | none => Sum.inl (M₁.update s₁ d) := rfl
@@ -265,9 +268,9 @@ plain fuel-additive law — `runWith_of_output_eq_some` supplies the fuel irrele
 needs. -/
 theorem toComp_seqComp_inl (M₁ : PointedMachine p α mid) (M₂ : PointedMachine p mid β)
     (k : ℕ) (s₁ : M₁.State) :
-    (M₁.seqComp M₂).toComp (k + 1) (Sum.inl s₁)
+    (M₁ ⨟ M₂).toComp (k + 1) (Sum.inl s₁)
       = FreeM.roll (M₁.expose s₁) (fun d =>
-          (M₁.seqComp M₂).toComp k (match M₁.output (M₁.update s₁ d) with
+          (M₁ ⨟ M₂).toComp k (match M₁.output (M₁.update s₁ d) with
             | some m => Sum.inr (M₂.init m)
             | none => Sum.inl (M₁.update s₁ d))) := rfl
 
@@ -275,7 +278,7 @@ theorem toComp_seqComp_inl (M₁ : PointedMachine p α mid) (M₂ : PointedMachi
 unrolling coincides with `M₂`'s. -/
 theorem toComp_seqComp_inr (M₁ : PointedMachine p α mid) (M₂ : PointedMachine p mid β)
     (k : ℕ) (s₂ : M₂.State) :
-    (M₁.seqComp M₂).toComp k (Sum.inr s₂) = M₂.toComp k s₂ := by
+    (M₁ ⨟ M₂).toComp k (Sum.inr s₂) = M₂.toComp k s₂ := by
   induction k generalizing s₂ with
   | zero => rfl
   | succ k ih =>
@@ -284,7 +287,7 @@ theorem toComp_seqComp_inr (M₁ : PointedMachine p α mid) (M₂ : PointedMachi
     change (match M₂.output s₂ with
           | some b => FreeM.pure (some b)
           | none => FreeM.roll (M₂.expose s₂)
-              (fun d => (M₁.seqComp M₂).toComp k (Sum.inr (M₂.update s₂ d))))
+              (fun d => (M₁ ⨟ M₂).toComp k (Sum.inr (M₂.update s₂ d))))
         = M₂.toComp (k + 1) s₂
     rw [toComp_succ]
     cases M₂.output s₂ with
@@ -588,7 +591,7 @@ variable {mid : Type uβ}
 off to `M₂`, its run coincides with `M₂`'s. -/
 theorem runWith_seqComp_inr (M₁ : PointedMachine q α mid) (M₂ : PointedMachine q mid β)
     (h : Handler m q) (k : ℕ) (s₂ : M₂.State) :
-    (M₁.seqComp M₂).runWith h k (Sum.inr s₂) = M₂.runWith h k s₂ :=
+    (M₁ ⨟ M₂).runWith h k (Sum.inr s₂) = M₂.runWith h k s₂ :=
   congrArg (FreeM.mapM h) (toComp_seqComp_inr M₁ M₂ k s₂)
 
 /-- **The fuel-exact sequential-composition law**, phase-one form: from an
@@ -602,7 +605,7 @@ theorem runWith_seqComp_inl [LawfulMonad m] (M₁ : PointedMachine q α mid)
     (M₂ : PointedMachine q mid β) (h : Handler m q) {k₁ : ℕ} (k₂ : ℕ) {s₁ : M₁.State}
     (hres₁ : M₁.ResolvesIn k₁ s₁) (hout : M₁.output s₁ = none)
     (hres₂ : ∀ y, M₂.ResolvesIn k₂ (M₂.init y)) :
-    (M₁.seqComp M₂).runWith h (k₁ + k₂) (Sum.inl s₁)
+    (M₁ ⨟ M₂).runWith h (k₁ + k₂) (Sum.inl s₁)
       = M₁.runWith h k₁ s₁ >>= fun r => match r with
           | some y => M₂.runWith h k₂ (M₂.init y)
           | none => pure none := by
@@ -612,7 +615,7 @@ theorem runWith_seqComp_inl [LawfulMonad m] (M₁ : PointedMachine q α mid)
     rcases hres₁ with hs | hf
     · simp [hout] at hs
     · rw [show k₁ + 1 + k₂ = (k₁ + k₂) + 1 from by omega,
-        (M₁.seqComp M₂).runWith_succ_of_output_eq_none h (seqComp_output_inl M₁ M₂ s₁) _,
+        (M₁ ⨟ M₂).runWith_succ_of_output_eq_none h (seqComp_output_inl M₁ M₂ s₁) _,
         M₁.runWith_succ_of_output_eq_none h hout, bind_assoc]
       refine bind_congr fun d => ?_
       cases hd : M₁.output (M₁.update s₁ d) with
@@ -629,7 +632,7 @@ state: run phase one at `k₁`, then phase two at `k₂`. -/
 theorem runWith_seqComp_init [LawfulMonad m] (M₁ : PointedMachine q α mid)
     (M₂ : PointedMachine q mid β) (h : Handler m q) {k₁ : ℕ} (k₂ : ℕ) (x : α)
     (hres₁ : M₁.ResolvesIn k₁ (M₁.init x)) (hres₂ : ∀ y, M₂.ResolvesIn k₂ (M₂.init y)) :
-    (M₁.seqComp M₂).runWith h (k₁ + k₂) ((M₁.seqComp M₂).init x)
+    (M₁ ⨟ M₂).runWith h (k₁ + k₂) ((M₁ ⨟ M₂).init x)
       = M₁.runWith h k₁ (M₁.init x) >>= fun r => match r with
           | some y => M₂.runWith h k₂ (M₂.init y)
           | none => pure none := by

--- a/PolyFunTest/PFunctor/Dynamical/PointedMachineExamples.lean
+++ b/PolyFunTest/PFunctor/Dynamical/PointedMachineExamples.lean
@@ -22,7 +22,7 @@ universe u v w
 
 namespace PFunctor
 
-variable {p : PFunctor.{u, u}} {α β mid : Type u}
+variable {p : PFunctor.{u, u}} {α β γ mid mid₁ mid₂ : Type u}
 
 /-- The two-step system shares its state set with the original. -/
 example (s : DynSystem p) : s.twoStep.State = s.State := rfl
@@ -34,6 +34,14 @@ example (M₁ : PointedMachine p α mid) (M₂ : PointedMachine p mid β) :
 /-- Sequential composition has state `M₁.State ⊕ M₂.State`. -/
 example (M₁ : PointedMachine p α mid) (M₂ : PointedMachine p mid β) :
     (M₁ ⨟ M₂).State = (M₁.State ⊕ M₂.State) := rfl
+
+/-- Chained `⨟` notation parses to the left, fixing the corresponding nested sum state. -/
+example (M₁ : PointedMachine p α mid₁) (M₂ : PointedMachine p mid₁ mid₂)
+    (M₃ : PointedMachine p mid₂ γ) : M₁ ⨟ M₂ ⨟ M₃ = (M₁ ⨟ M₂) ⨟ M₃ := rfl
+
+example (M₁ : PointedMachine p α mid₁) (M₂ : PointedMachine p mid₁ mid₂)
+    (M₃ : PointedMachine p mid₂ γ) :
+    (M₁ ⨟ M₂ ⨟ M₃).State = ((M₁.State ⊕ M₂.State) ⊕ M₃.State) := rfl
 
 /-- The second phase of `seqComp` unrolls exactly like `M₂`. -/
 example (M₁ : PointedMachine p α mid) (M₂ : PointedMachine p mid β) (s₂ : M₂.State) :

--- a/PolyFunTest/PFunctor/Dynamical/PointedMachineExamples.lean
+++ b/PolyFunTest/PFunctor/Dynamical/PointedMachineExamples.lean
@@ -11,9 +11,9 @@ public import PolyFun.PFunctor.Dynamical.Speedup
 /-!
 # Examples for two-step systems and machine composition
 
-Regression tests: `twoStep` preserves the state set, `seqComp` has `⊕`-state and
-a faithful second phase, resolution certificates compose, and the fuel-exact
-run law threads one ambient handler state through both phases.
+Regression tests: `twoStep` preserves the state set, `M₁ ⨟ M₂` (`seqComp`) has
+`⊕`-state and a faithful second phase, resolution certificates compose, and the
+fuel-exact run law threads one ambient handler state through both phases.
 -/
 
 @[expose] public section
@@ -27,20 +27,24 @@ variable {p : PFunctor.{u, u}} {α β mid : Type u}
 /-- The two-step system shares its state set with the original. -/
 example (s : DynSystem p) : s.twoStep.State = s.State := rfl
 
+/-- The `⨟` notation is diagrammatic sequential composition. -/
+example (M₁ : PointedMachine p α mid) (M₂ : PointedMachine p mid β) :
+    M₁ ⨟ M₂ = M₁.seqComp M₂ := rfl
+
 /-- Sequential composition has state `M₁.State ⊕ M₂.State`. -/
 example (M₁ : PointedMachine p α mid) (M₂ : PointedMachine p mid β) :
-    (M₁.seqComp M₂).State = (M₁.State ⊕ M₂.State) := rfl
+    (M₁ ⨟ M₂).State = (M₁.State ⊕ M₂.State) := rfl
 
 /-- The second phase of `seqComp` unrolls exactly like `M₂`. -/
 example (M₁ : PointedMachine p α mid) (M₂ : PointedMachine p mid β) (s₂ : M₂.State) :
-    (M₁.seqComp M₂).toComp 3 (Sum.inr s₂) = M₂.toComp 3 s₂ :=
+    (M₁ ⨟ M₂).toComp 3 (Sum.inr s₂) = M₂.toComp 3 s₂ :=
   PointedMachine.toComp_seqComp_inr M₁ M₂ 3 s₂
 
 /-- The first phase exposes `M₁` and hands off to `M₂` exactly on `M₁`'s output. -/
 example (M₁ : PointedMachine p α mid) (M₂ : PointedMachine p mid β) (s₁ : M₁.State) :
-    (M₁.seqComp M₂).toComp 1 (Sum.inl s₁)
+    (M₁ ⨟ M₂).toComp 1 (Sum.inl s₁)
       = FreeM.roll (M₁.expose s₁) (fun d =>
-          (M₁.seqComp M₂).toComp 0 (match M₁.output (M₁.update s₁ d) with
+          (M₁ ⨟ M₂).toComp 0 (match M₁.output (M₁.update s₁ d) with
             | some m => Sum.inr (M₂.init m)
             | none => Sum.inl (M₁.update s₁ d))) :=
   PointedMachine.toComp_seqComp_inl M₁ M₂ 0 s₁

--- a/docs/wiki/notation.md
+++ b/docs/wiki/notation.md
@@ -55,9 +55,15 @@ than via custom notation, to keep elaboration predictable. Specifically:
   at `infixl:75`. This is the book's diagrammatic composition order
   (left machine runs first), the same `⨟` used throughout
   `docs/reading/`; its intentional use is recorded as a narrow exception in
-  `scripts/nolints-style.txt`. Note `∘ₗ` on lenses is
-  *anti*-diagrammatic (`l ∘ₗ l'` applies `l'` first); extending `⨟` to
-  lenses/charts is planned alongside the `DynSystem`-as-lens re-cut.
+  `scripts/nolints-style.txt`. The `\;;` translation is a PolyFun workspace
+  setting in [`.vscode/settings.json`](../../.vscode/settings.json), rather than
+  a built-in Lean input abbreviation. Because the operator is left-associative,
+  `M₁ ⨟ M₂ ⨟ M₃` parses as `(M₁ ⨟ M₂) ⨟ M₃`, whose state is
+  `(M₁.State ⊕ M₂.State) ⊕ M₃.State`. This parsing convention does not
+  assert that the two possible associations of machine composition are
+  definitionally equal. Note `∘ₗ` on lenses is in function-composition
+  order (`l ∘ₗ l'` applies `l'` first); extending `⨟` to lenses/charts is
+  planned alongside the `DynSystem`-as-lens re-cut.
 
 If you find yourself wishing for new notation in PolyFun, consider
 whether the underlying name suffices first: this library leans toward

--- a/docs/wiki/notation.md
+++ b/docs/wiki/notation.md
@@ -49,8 +49,18 @@ than via custom notation, to keep elaboration predictable. Specifically:
   surface syntax for `roll` / `pure`; reach for `PFunctor.FreeM.lift`
   and `PFunctor.FreeM.liftPos` when you need to embed a single
   polynomial step.
+- Machine sequential composition `M₁ ⨟ M₂` (input `\;;`, U+2A1F) is
+  `PointedMachine.seqComp`, defined in
+  [`PolyFun/PFunctor/Dynamical/PointedMachine.lean`](../../PolyFun/PFunctor/Dynamical/PointedMachine.lean)
+  at `infixl:75`. This is the book's diagrammatic composition order
+  (left machine runs first), the same `⨟` used throughout
+  `docs/reading/`; its intentional use is recorded as a narrow exception in
+  `scripts/nolints-style.txt`. Note `∘ₗ` on lenses is
+  *anti*-diagrammatic (`l ∘ₗ l'` applies `l'` first); extending `⨟` to
+  lenses/charts is planned alongside the `DynSystem`-as-lens re-cut.
 
 If you find yourself wishing for new notation in PolyFun, consider
 whether the underlying name suffices first: this library leans toward
 explicit names and standard Mathlib notation, and reserves custom
-operators for the UC-composition algebra above.
+operators for the UC-composition algebra above (plus the book's `⨟`
+for machine composition).

--- a/scripts/nolints-style.txt
+++ b/scripts/nolints-style.txt
@@ -1,0 +1,2 @@
+-- Spivak–Niu's diagrammatic sequential-composition notation (PolyFun PR #18).
+PolyFun/PFunctor/Dynamical/PointedMachine.lean : line 26 : ERR_UNICODE : This line contains a unicode character that is not on the allowlist '⨟' (U+2a1f). For adding new symbols see `Mathlib.Linter.TextBased.UnicodeLinter.othersInMathlib`.


### PR DESCRIPTION
Stacked on #17. This PR adds the book-order sequential-composition notation for PointedMachine and hardens its user-facing contract.

- `M₁ ⨟ M₂` is `PointedMachine.seqComp`, with the left machine running first.
- The operator is explicitly left-associative. Triple-composition tests fix the parse and resulting state nesting as `(M₁.State ⊕ M₂.State) ⊕ M₃.State`; no definitional associativity claim is made.
- The PolyFun workspace provides the `;;` custom Lean input translation through `.vscode/settings.json`; the wiki distinguishes this from a built-in Lean abbreviation.
- Existing chart/lens docs now describe their operators accurately as function-composition order.
- The Unicode linter exception remains narrow and explicit.

Not included: a lens/chart overload for `⨟`. That belongs with the later DynSystem-as-lens layer, where its composition direction and combined overload tests can be reviewed together.

Validated with focused builds, full delegated tests, docs/import checks, and style lint.