### PR TITLE
feat(dynamical): game wiring — responders, eval-games, Kleisli runs

### DIFF
--- a/PolyFun.lean
+++ b/PolyFun.lean
@@ -110,8 +110,10 @@ import PolyFun.PFunctor.Comonoid
 import PolyFun.PFunctor.Dynamical.Basic
 import PolyFun.PFunctor.Dynamical.Behavior
 import PolyFun.PFunctor.Dynamical.Combinators
+import PolyFun.PFunctor.Dynamical.Game
 import PolyFun.PFunctor.Dynamical.PointedMachine
 import PolyFun.PFunctor.Dynamical.Refinement
+import PolyFun.PFunctor.Dynamical.Responder
 import PolyFun.PFunctor.Dynamical.Run
 import PolyFun.PFunctor.Dynamical.RunN
 import PolyFun.PFunctor.Dynamical.Safety

--- a/PolyFun/PFunctor/Dynamical/Game.lean
+++ b/PolyFun/PFunctor/Dynamical/Game.lean
@@ -1,0 +1,284 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+module
+
+public import PolyFun.PFunctor.Dynamical.Responder
+public import PolyFun.PFunctor.Dynamical.Combinators
+public import PolyFun.PFunctor.Lens.Duoidal
+
+/-!
+# Games: challengers wired against adversaries along evaluation
+
+A **game** pairs a challenger, whose interface is an internal hom `q ⊸ r`
+(Spivak–Niu Ex 4.78), with an adversary playing `q`. Wiring the two along the
+evaluation lens `Lens.eval : (q ⊸ r) ⊗ q ⟹ r` (`DynSystem.game`) yields a single
+system over the outer interface `r`; equivalently — definitionally — it is the
+uncurried challenger applied to the adversary (`game_eq_uncurry`), the
+tensor–hom adjunction in dynamical clothing. When the challenger is a
+`Responder` (`r = X`) the game is closed and runs autonomously
+(`DynSystem.closedGame`), the deterministic shadow of VCVio's `wireKStep`
+wiring. There is no separate scored-game structure: a win readout is a state (or
+Moore) readout on the closed run, and the win-bit form is the
+`r := monomial Bool PUnit` instance of `game`.
+
+Monadic runs against handlers are provided in two strengths: `kleisliStep` /
+`kleisliIterate` drive a system with a stateless handler in a monad `m` (VCVio's
+`wireKStep` / `wireKIterate` are the `m := SPMF` instances), and `stepWith` /
+`iterWith` drive it with a *stateful* handler in `StateT σ m`, the handler state
+first in the pair. The two agree along `StateT.lift` (`stepWith_lift`), and at
+`m := Id` a responder's handler recovers the closed game
+(`stepWith_toStateHandler`). The load-bearing export is
+`PointedMachine.runWith_run_succ_of_output_eq_none`, the machine-vs-responder
+step law that unrolls a machine's fuelled `runWith` through `stepWith` of its
+dynamical core.
+
+Two-phase (commit-then-guess) games arrive by substitution: `Lens.eval₂` runs
+two evaluations in sequence after reshuffling along the duoidal interchange
+`Lens.duoidalLens` (Spivak–Niu Eq 6.86), `DynSystem.orderPair` orders two
+single-phase adversaries into a `q₁ ◃ q₂` player along `Lens.orderingLens`
+(Ex 6.85), and `DynSystem.game₂` wires a two-phase challenger against a
+two-phase adversary. `Lens.compOuter`, `Lens.compInner`, and `Lens.compPullback`
+(Ex 6.40) are the
+intro/elim rules for the two-phase challenger interface.
+-/
+
+@[expose] public section
+
+universe u v uA uB uA₁ uB₁ uA₂ uB₂
+
+namespace PFunctor
+
+namespace DynSystem
+
+/-! ## The game former -/
+
+section Game
+
+variable {S : Type u} {T : Type v} {q r : PFunctor.{uA, uB}}
+
+/-- Wire a challenger over the internal hom `q ⊸ r` against an adversary playing
+`q`, along the evaluation lens (Spivak–Niu Ex 4.78): at each step the challenger
+commits to a lens `q ⟹ r`, the adversary picks a `q`-position, and the composite
+exposes the resulting `r`-position; the incoming `r`-direction is answered back
+through the committed lens. VCVio's `Challenger`-vs-adversary wiring is the
+Kleisli consumer of this former. -/
+def game (chal : DynSystem S (q ⊸ r)) (adv : DynSystem T q) : DynSystem (S × T) r :=
+  wire₂ (Lens.eval q r) chal adv
+
+@[simp] theorem game_expose (chal : DynSystem S (q ⊸ r)) (adv : DynSystem T q)
+    (s : S) (t : T) :
+    (game chal adv).expose (s, t) = (chal.expose s).toFunA (adv.expose t) := rfl
+
+@[simp] theorem game_update (chal : DynSystem S (q ⊸ r)) (adv : DynSystem T q)
+    (s : S) (t : T) (d : r.B ((game chal adv).expose (s, t))) :
+    (game chal adv).update (s, t) d
+      = (chal.update s ⟨adv.expose t, d⟩,
+          adv.update t ((chal.expose s).toFunB (adv.expose t) d)) := rfl
+
+theorem game_eq_wire₂ (chal : DynSystem S (q ⊸ r)) (adv : DynSystem T q) :
+    game chal adv = wire₂ (Lens.eval q r) chal adv := rfl
+
+end Game
+
+/-- The game former is evaluation of the uncurried challenger: wiring along
+`Lens.eval` is the tensor–hom adjunction in dynamical clothing. Stated with the
+challenger's state universe identified with the interface universes, as
+`Lens.uncurry` requires. -/
+theorem game_eq_uncurry {S : Type u} {T : Type v} {q r : PFunctor.{u, u}}
+    (chal : DynSystem S (q ⊸ r)) (adv : DynSystem T q) :
+    game chal adv = (Lens.comp (Lens.uncurry chal) (Lens.id (selfMonomial S) ⊗ₗ adv) :
+      Lens (selfMonomial S ⊗ selfMonomial T) r) := rfl
+
+/-! ## Closed games -/
+
+section Game
+
+variable {S : Type u} {T : Type v} {q : PFunctor.{uA, uB}}
+
+/-- Close a responder against an adversary: the `r = X` instance of `game` runs
+autonomously, so the pair steps by "adversary queries, responder answers". This
+is the deterministic shadow of VCVio's `wireKStep`; a win condition is a state
+readout on the closed run (for a Moore win bit, instantiate `game` at
+`r := monomial Bool PUnit` instead). -/
+def closedGame (R : Responder S q) (adv : DynSystem T q) : Closed (S × T) :=
+  game R adv
+
+@[simp] theorem closedGame_step (R : Responder S q) (adv : DynSystem T q) (s : S) (t : T) :
+    (closedGame R adv).step (s, t)
+      = (R.next s (adv.expose t), adv.update t (R.answer s (adv.expose t))) := rfl
+
+end Game
+
+/-! ## Kleisli runs against monadic handlers -/
+
+section Kleisli
+
+variable {q : PFunctor.{uA, u}} {S σ : Type u} {m : Type u → Type v} [Monad m]
+
+/-- One step of a system driven by a stateless monadic handler: resolve the
+exposed position in `m` and update. VCVio's `wireKStep` is the `m := SPMF`
+instance. -/
+def kleisliStep (h : Handler m q) (A : DynSystem S q) (s : S) : m S :=
+  (fun d => A.update s d) <$> h (A.expose s)
+
+/-- `n` monadic steps of a system against a stateless handler. VCVio's
+`wireKIterate` is the `m := SPMF` instance. -/
+def kleisliIterate (h : Handler m q) (A : DynSystem S q) : ℕ → S → m S
+  | 0, s => pure s
+  | n + 1, s => kleisliStep h A s >>= kleisliIterate h A n
+
+@[simp] theorem kleisliIterate_zero (h : Handler m q) (A : DynSystem S q) (s : S) :
+    kleisliIterate h A 0 s = pure s := rfl
+
+theorem kleisliIterate_succ (h : Handler m q) (A : DynSystem S q) (n : ℕ) (s : S) :
+    kleisliIterate h A (n + 1) s = kleisliStep h A s >>= kleisliIterate h A n := rfl
+
+/-- One step of a system driven by a *stateful* handler: the handler threads its
+own state `σ` alongside the system's, handler state first in the pair. -/
+def stepWith (h : Handler (StateT σ m) q) (A : DynSystem S q) (p : σ × S) : m (σ × S) :=
+  (fun dt => (dt.2, A.update p.2 dt.1)) <$> h (A.expose p.2) p.1
+
+/-- `n` steps of a system against a stateful handler, threading the handler
+state. -/
+def iterWith (h : Handler (StateT σ m) q) (A : DynSystem S q) : ℕ → σ × S → m (σ × S)
+  | 0, p => pure p
+  | n + 1, p => stepWith h A p >>= iterWith h A n
+
+@[simp] theorem iterWith_zero (h : Handler (StateT σ m) q) (A : DynSystem S q) (p : σ × S) :
+    iterWith h A 0 p = pure p := rfl
+
+theorem iterWith_succ (h : Handler (StateT σ m) q) (A : DynSystem S q) (n : ℕ) (p : σ × S) :
+    iterWith h A (n + 1) p = stepWith h A p >>= iterWith h A n := rfl
+
+/-- A stateless handler lifted into the state monad steps the system as
+`kleisliStep` does and carries the handler state unchanged. -/
+theorem stepWith_lift [LawfulMonad m] (h₀ : Handler m q) (A : DynSystem S q) (p : σ × S) :
+    stepWith (fun a => StateT.lift (h₀ a)) A p
+      = (fun s' => (p.1, s')) <$> kleisliStep h₀ A p.2 := by
+  simp only [stepWith, kleisliStep, StateT.lift, map_eq_pure_bind, bind_assoc, pure_bind]
+
+/-- A lifted stateless handler runs as `kleisliIterate` does, carrying the
+handler state unchanged. -/
+theorem iterWith_lift [LawfulMonad m] (h₀ : Handler m q) (A : DynSystem S q) (n : ℕ)
+    (p : σ × S) :
+    iterWith (fun a => StateT.lift (h₀ a)) A n p
+      = (fun s' => (p.1, s')) <$> kleisliIterate h₀ A n p.2 := by
+  induction n generalizing p with
+  | zero => simp
+  | succ n ih =>
+    rw [iterWith_succ, kleisliIterate_succ, stepWith_lift]
+    simp only [bind_map_left, map_bind]
+    exact bind_congr fun s' => ih (p.1, s')
+
+/-- Running a system against a responder's stateful handler is stepping the
+closed game: `stepWith` at `m := Id` is `closedGame`'s step. -/
+theorem stepWith_toStateHandler (R : Responder σ q) (A : DynSystem S q) (p : σ × S) :
+    stepWith (m := Id) R.toStateHandler A p = (closedGame R A).step p := rfl
+
+/-- The `Id` run against a responder's stateful handler computes the closed
+game's trajectory. -/
+theorem iterWith_toStateHandler (R : Responder σ q) (A : DynSystem S q) (n : ℕ) (p : σ × S) :
+    iterWith (m := Id) R.toStateHandler A n p = pure ((closedGame R A).iterate p n) := by
+  induction n generalizing p with
+  | zero => rfl
+  | succ n ih =>
+    change iterWith (m := Id) R.toStateHandler A n (stepWith (m := Id) R.toStateHandler A p) = _
+    rw [stepWith_toStateHandler, ih]
+    rfl
+
+end Kleisli
+
+end DynSystem
+
+/-! ## The machine-vs-responder step law -/
+
+namespace PointedMachine
+
+section RunBridge
+
+variable {q : PFunctor.{uA, u}} {α β : Type u} {σ : Type u} {m : Type u → Type v} [Monad m]
+
+/-- **The machine-vs-responder step law**: on an unresolved state, one unit of
+fuel of a machine's `runWith` against a stateful handler — read in
+state-transformer form — is one `DynSystem.stepWith` of the machine's dynamical
+core, bound into the rest of the run. Downstream machine-game step lemmas are
+instances of this law at concrete monads (`m := SPMF` for VCVio's wiring). -/
+theorem runWith_run_succ_of_output_eq_none [LawfulMonad m] (M : PointedMachine q α β)
+    (h : Handler (StateT σ m) q) {s : M.State} (hs : M.output s = none) (k : ℕ) (t : σ) :
+    (M.runWith h (k + 1) s).run t
+      = DynSystem.stepWith h M.toDynSystem (t, s) >>= fun p => (M.runWith h k p.2).run p.1 := by
+  rw [M.runWith_succ_of_output_eq_none h hs k]
+  simp only [DynSystem.stepWith, bind_map_left]
+  rfl
+
+end RunBridge
+
+end PointedMachine
+
+/-! ## Two-phase games
+
+Commit-then-guess games by substitution: the challenger plays
+`(q₁ ⊸ r₁) ◃ (q₂ ⊸ r₂)` — a phase-one responder lens whose continuation, fed the
+phase-one transcript, is a phase-two responder lens — and the adversary plays
+`q₁ ◃ q₂`. -/
+
+namespace Lens
+
+/-- The **two-phase evaluation wiring**: reshuffle a two-phase challenger against
+a two-phase adversary along the duoidal interchange `duoidalLens` (Spivak–Niu
+Eq 6.86), so the phase-one pair and phase-two pair each meet in an evaluation
+lens (Ex 4.78), run in sequence. -/
+def eval₂ (q₁ r₁ q₂ r₂ : PFunctor.{uA, uB}) :
+    Lens (((q₁ ⊸ r₁) ◃ (q₂ ⊸ r₂)) ⊗ (q₁ ◃ q₂)) (r₁ ◃ r₂) :=
+  (eval q₁ r₁ ◃ₗ eval q₂ r₂) ∘ₗ duoidalLens (q₁ ⊸ r₁) (q₂ ⊸ r₂) q₁ q₂
+
+end Lens
+
+namespace DynSystem
+
+section OrderPair
+
+variable {T₁ : Type u} {T₂ : Type v} {q₁ : PFunctor.{uA₁, uB₁}} {q₂ : PFunctor.{uA₂, uB₂}}
+
+/-- Order two systems into a single two-phase system along `Lens.orderingLens`
+(Spivak–Niu Ex 6.85): the pair plays `q₁ ◃ q₂`, phase one first. **The second
+phase cannot see the first phase's answer within one composite step**: before
+ordering, the two phases were simultaneous (`tensor`), and the ordering lens
+makes the phase-two position constant in the phase-one direction. A
+same-step-adaptive second phase (e.g. a guesser reading the commit phase's
+answer) must instead be built directly as a system over `q₁ ◃ q₂`. -/
+def orderPair (A₁ : DynSystem T₁ q₁) (A₂ : DynSystem T₂ q₂) :
+    DynSystem (T₁ × T₂) (q₁ ◃ q₂) :=
+  wrap (Lens.orderingLens q₁ q₂) (A₁.tensor A₂)
+
+@[simp] theorem orderPair_expose (A₁ : DynSystem T₁ q₁) (A₂ : DynSystem T₂ q₂)
+    (st : T₁ × T₂) :
+    (orderPair A₁ A₂).expose st = ⟨A₁.expose st.1, fun _ => A₂.expose st.2⟩ := rfl
+
+@[simp] theorem orderPair_update (A₁ : DynSystem T₁ q₁) (A₂ : DynSystem T₂ q₂)
+    (st : T₁ × T₂) (d : (q₁ ◃ q₂).B ((orderPair A₁ A₂).expose st)) :
+    (orderPair A₁ A₂).update st d = (A₁.update st.1 d.1, A₂.update st.2 d.2) := rfl
+
+end OrderPair
+
+section Game₂
+
+variable {S : Type u} {T : Type v} {q₁ r₁ q₂ r₂ : PFunctor.{uA, uB}}
+
+/-- Wire a two-phase challenger against a two-phase adversary along
+`Lens.eval₂`: commit phase, then guess phase, exposed on the outer interface
+`r₁ ◃ r₂`. The challenger's interface has `Lens.toCompTriple` /
+the composite-lens accessors (Spivak–Niu Ex 6.40) as its elimination rules; VCVio's
+`Challenger₂` is the Kleisli consumer of this former. -/
+def game₂ (chal : DynSystem S ((q₁ ⊸ r₁) ◃ (q₂ ⊸ r₂))) (adv : DynSystem T (q₁ ◃ q₂)) :
+    DynSystem (S × T) (r₁ ◃ r₂) :=
+  wire₂ (Lens.eval₂ q₁ r₁ q₂ r₂) chal adv
+
+end Game₂
+
+end DynSystem
+
+end PFunctor

--- a/PolyFun/PFunctor/Dynamical/Responder.lean
+++ b/PolyFun/PFunctor/Dynamical/Responder.lean
@@ -1,0 +1,155 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+module
+
+public import PolyFun.PFunctor.InternalHom
+public import PolyFun.PFunctor.Dynamical.PointedMachine
+
+/-!
+# Responders: stateful answerers as systems over the internal hom
+
+A **responder** for an interface `q` receives `q`-positions (queries) and returns
+`q`-directions (answers), updating an internal state as it goes. Following
+Spivak–Niu, *Polynomial Functors: A General Theory of Interaction* (Ex 4.78),
+this is exactly a dynamical system over the internal hom `q ⊸ X`: by `ihom_X_A`
+the positions of `q ⊸ X` are the sections of `q`, so at each state the responder
+*commits* to an answer for every possible query, and a direction of `q ⊸ X` over
+a committed section carries only the query actually asked (its `X`-component is
+trivial). The dynamical accessors under responder names are
+
+* `Responder.committed : S → Section q` — the answer-section exposed at a state;
+* `Responder.answer : S → (a : q.A) → q.B a` — the committed answer to a query;
+* `Responder.next : S → q.A → S` — the state update on hearing a query.
+
+A responder is the deterministic challenger side of a game before Kleisli
+weighting: wiring it against an adversary along `Lens.eval` closes the system
+(`DynSystem.game` / `DynSystem.closedGame`). The `equivStateHandler` bridge
+identifies responders with handlers in the state monad `StateT S Id` — Mealy
+machines in Kleisli form — of which VCVio's `ProbResponder` (the `WireK` layer)
+is the bundled probabilistic `m := SPMF` sibling.
+-/
+
+@[expose] public section
+
+universe u v uA uB
+
+namespace PFunctor
+
+/-- A **responder** with states `S` for the interface `q`: a dynamical system over
+the internal hom `q ⊸ X` (Spivak–Niu Ex 4.78). By `ihom_X_A` its exposed
+positions are the sections of `q` — at each state the responder commits to an
+answer for every possible query — and a direction over a committed section is
+just a query, so `update` evolves the state by the query heard. -/
+abbrev Responder (S : Type u) (q : PFunctor.{uA, uB}) : Type _ :=
+  DynSystem S (q ⊸ X.{uA, uB})
+
+namespace Responder
+
+variable {S : Type u} {q : PFunctor.{uA, uB}}
+
+/-- The answer-section a responder commits to at state `s`: its exposed position,
+read as a `Section q` through `ihom_X_A`. -/
+def committed (R : Responder S q) (s : S) : Section q :=
+  DynSystem.expose R s
+
+/-- The answer a responder gives at state `s` to the query `a`: the direction its
+committed section selects at `a`. -/
+def answer (R : Responder S q) (s : S) (a : q.A) : q.B a :=
+  (DynSystem.expose R s).toFunB a PUnit.unit
+
+/-- The responder's next state after hearing the query `a` at state `s`. -/
+def next (R : Responder S q) (s : S) (a : q.A) : S :=
+  DynSystem.update R s ⟨a, PUnit.unit⟩
+
+/-- Build a responder from an answer map and a next-state map. -/
+def mk' (ans : (s : S) → (a : q.A) → q.B a) (nxt : S → q.A → S) : Responder S q :=
+  (fun s => sectionLens (ans s)) ⇆ (fun s d => nxt s d.1)
+
+@[simp] theorem answer_mk' (ans : (s : S) → (a : q.A) → q.B a) (nxt : S → q.A → S)
+    (s : S) (a : q.A) : (mk' ans nxt).answer s a = ans s a := rfl
+
+@[simp] theorem next_mk' (ans : (s : S) → (a : q.A) → q.B a) (nxt : S → q.A → S)
+    (s : S) (a : q.A) : (mk' ans nxt).next s a = nxt s a := rfl
+
+@[simp] theorem expose_mk' (ans : (s : S) → (a : q.A) → q.B a) (nxt : S → q.A → S)
+    (s : S) : DynSystem.expose (mk' ans nxt) s = sectionLens (ans s) := rfl
+
+@[simp] theorem committed_mk' (ans : (s : S) → (a : q.A) → q.B a) (nxt : S → q.A → S)
+    (s : S) : (mk' ans nxt).committed s = sectionLens (ans s) := rfl
+
+/-- `answer` reads the committed section at the query asked. -/
+theorem answer_eq_committed (R : Responder S q) (s : S) (a : q.A) :
+    R.answer s a = (R.committed s).toFunB a PUnit.unit := rfl
+
+/-- A responder's raw lens update reads only the query component of a direction —
+the `X`-component is trivial. Definitional, by sigma and unit eta. -/
+@[simp] theorem update_eq_next (R : Responder S q) (s : S)
+    (d : (q ⊸ X).B (DynSystem.expose R s)) :
+    DynSystem.update R s d = R.next s d.1 := rfl
+
+/-! ## Stateless responders -/
+
+/-- The stateless responder answering along a fixed section of `q`. -/
+def ofSection (σ : Section q) : Responder PUnit.{v + 1} q :=
+  (fun _ => σ) ⇆ (fun _ _ => PUnit.unit)
+
+@[simp] theorem committed_ofSection (σ : Section q) (s : PUnit.{v + 1}) :
+    (ofSection σ).committed s = σ := rfl
+
+/-- The stateless responder answering along a fixed deterministic handler
+(`Handler Id q` is a section of `q` unbundled). -/
+def ofHandler (h : Handler Id q) : Responder PUnit.{v + 1} q :=
+  mk' (fun _ => h) (fun _ _ => PUnit.unit)
+
+/-- A deterministic handler responds exactly as its section lens does. -/
+theorem ofHandler_eq_ofSection (h : Handler Id q) :
+    (ofHandler h : Responder PUnit.{v + 1} q) = ofSection (sectionLens h) := rfl
+
+end Responder
+
+/-! ## The Kleisli–Mealy bridge
+
+A responder with states `S` is the same data as a handler in the state monad
+`StateT S Id`, i.e. a Mealy machine `(a : q.A) → S → q.B a × S` in Kleisli form.
+The direction universe is pinned to the state's (`q : PFunctor.{uA, u}`,
+`S : Type u`) so the state monad applies. VCVio's `ProbResponder` is the bundled
+probabilistic `m := SPMF` sibling of this bridge. -/
+
+namespace Responder
+
+section KleisliMealy
+
+variable {q : PFunctor.{uA, u}} {S : Type u}
+
+/-- Read a responder as a stateful handler: answer the query from the current
+state and thread the next state. -/
+def toStateHandler (R : Responder S q) : Handler (StateT S Id) q :=
+  fun a s => (R.answer s a, R.next s a)
+
+/-- Bundle a stateful handler as a responder. -/
+def ofStateHandler (h : Handler (StateT S Id) q) : Responder S q :=
+  mk' (fun s a => (h a s).1) (fun s a => (h a s).2)
+
+/-- The **Kleisli–Mealy bridge**: responders with states `S` for `q` are exactly
+the stateful handlers in `StateT S Id`, with both round-trips definitional.
+VCVio's `ProbResponder` is the bundled `m := SPMF` sibling of this equivalence. -/
+def equivStateHandler : Responder S q ≃ Handler (StateT S Id) q where
+  toFun := toStateHandler
+  invFun := ofStateHandler
+  left_inv _ := rfl
+  right_inv _ := rfl
+
+@[simp] theorem equivStateHandler_apply (R : Responder S q) :
+    equivStateHandler R = R.toStateHandler := rfl
+
+@[simp] theorem equivStateHandler_symm_apply (h : Handler (StateT S Id) q) :
+    equivStateHandler.symm h = ofStateHandler h := rfl
+
+end KleisliMealy
+
+end Responder
+
+end PFunctor

--- a/PolyFunTest/PFunctor/Dynamical/GameExamples.lean
+++ b/PolyFunTest/PFunctor/Dynamical/GameExamples.lean
@@ -1,0 +1,160 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+module
+
+public import PolyFun.PFunctor.Dynamical.Game
+public import PolyFun.PFunctor.Lens.Composite
+
+/-!
+# Examples for responders, games, and two-phase games
+
+Regression tests: the `game` / `closedGame` step equations and the
+responder eta canaries hold by `rfl`, `stepWith` at `m := Id` is the closed
+game's step, a concrete counting-responder game runs by `rfl`, the Moore
+win-bit game is the `monomial Bool PUnit` instance of `game`, and a
+deterministic PrivK-shaped `game₂` (challenger as a composite lens,
+adversary via `orderPair`) computes one composite step by `rfl`.
+-/
+
+@[expose] public section
+
+universe u v
+
+namespace PFunctor
+
+/-! ## Structural canaries -/
+
+section Canaries
+
+variable {S T : Type u} {q r : PFunctor.{u, u}}
+
+/-- The game's exposed position is the committed challenger lens applied to the
+adversary's position. -/
+example (chal : DynSystem S (q ⊸ r)) (adv : DynSystem T q) (s : S) (t : T) :
+    (DynSystem.game chal adv).expose (s, t) = (chal.expose s).toFunA (adv.expose t) := rfl
+
+/-- The game's update: the challenger hears the adversary's query with the outer
+direction; the adversary hears the committed lens's pulled-back answer. -/
+example (chal : DynSystem S (q ⊸ r)) (adv : DynSystem T q) (s : S) (t : T)
+    (d : r.B ((DynSystem.game chal adv).expose (s, t))) :
+    (DynSystem.game chal adv).update (s, t) d
+      = (chal.update s ⟨adv.expose t, d⟩,
+          adv.update t ((chal.expose s).toFunB (adv.expose t) d)) := rfl
+
+/-- The closed game steps by "adversary queries, responder answers". -/
+example (R : Responder S q) (adv : DynSystem T q) (s : S) (t : T) :
+    (DynSystem.closedGame R adv).step (s, t)
+      = (R.next s (adv.expose t), adv.update t (R.answer s (adv.expose t))) := rfl
+
+/-- The game former is the uncurried challenger (tensor–hom adjunction). -/
+example (chal : DynSystem S (q ⊸ r)) (adv : DynSystem T q) :
+    DynSystem.game chal adv
+      = (Lens.comp (Lens.uncurry chal) (Lens.id (selfMonomial S) ⊗ₗ adv) :
+          Lens (selfMonomial S ⊗ selfMonomial T) r) := rfl
+
+/-- Eta canary: a responder's raw lens update reads only the query component. -/
+example (R : Responder S q) (s : S) (d : (q ⊸ X).B (DynSystem.expose R s)) :
+    DynSystem.update R s d = R.next s d.1 := rfl
+
+/-- Eta canaries: the Kleisli–Mealy round-trips are definitional. -/
+example (R : Responder S q) : Responder.ofStateHandler R.toStateHandler = R := rfl
+
+example (h : Handler (StateT S Id) q) :
+    Responder.toStateHandler (Responder.ofStateHandler h) = h := rfl
+
+example (R : Responder S q) :
+    Responder.equivStateHandler.symm (Responder.equivStateHandler R) = R := rfl
+
+/-- `stepWith` against a responder's stateful handler, at `m := Id`, is the
+closed game's step. -/
+example (R : Responder T q) (A : DynSystem S q) (p : T × S) :
+    DynSystem.stepWith (m := Id) R.toStateHandler A p
+      = (DynSystem.closedGame R A).step p := rfl
+
+end Canaries
+
+/-! ## A concrete closed game: counting responder vs doubling adversary -/
+
+/-- The counting responder over `ℕ X^ ℕ`: answers every query with its running
+count and increments it. -/
+def countingResponder : Responder ℕ (monomial ℕ ℕ) :=
+  Responder.mk' (fun s _ => s) (fun s _ => s + 1)
+
+/-- The doubling adversary over `ℕ X^ ℕ`: queries its state, stores double the
+answer it hears. -/
+def doublingAdversary : DynSystem ℕ (monomial ℕ ℕ) :=
+  DynSystem.mk' (fun t => t) (fun _ (a : ℕ) => 2 * a)
+
+/-- Three closed-game steps, computed by `rfl`:
+`(0, 5) ↦ (1, 0) ↦ (2, 2) ↦ (3, 4)`. -/
+example : (DynSystem.closedGame countingResponder doublingAdversary).iterate (0, 5) 3
+    = (3, 4) := rfl
+
+/-! ## The Moore win-bit game: `game` at `r := monomial Bool PUnit` -/
+
+/-- A challenger with a Moore win bit: the adversary wins when its query matches
+the secret; every answer leaks the secret, and the secret never changes. -/
+def secretMatchChallenger : DynSystem ℕ (monomial ℕ ℕ ⊸ monomial Bool PUnit) :=
+  DynSystem.mk' (fun s => (fun (qy : ℕ) => qy == s) ⇆ (fun _ _ => s)) (fun s _ => s)
+
+/-- The win-bit game *is* a Moore machine: `game` at `r := monomial Bool PUnit`
+lands in `MooreMachine (S × T) Bool PUnit`, no scored-game structure needed. -/
+def secretMatchGame : MooreMachine (ℕ × ℕ) Bool PUnit :=
+  DynSystem.game secretMatchChallenger doublingAdversary
+
+example : secretMatchGame.output (3, 3) = true := rfl
+
+example : secretMatchGame.output (3, 4) = false := rfl
+
+/-- Close the Moore game with trivial feedback and step it: the challenger keeps
+its secret, the adversary stores double the leaked secret. -/
+example : (MooreMachine.feedback (fun _ => PUnit.unit) secretMatchGame).step (3, 3)
+    = (3, 6) := rfl
+
+/-! ## A deterministic PrivK-shaped two-phase game
+
+Commit phase `(Bool × Bool) X^ Bool`: the adversary submits a message-bit pair
+and hears the "ciphertext" `m_b`. Guess phase `Bool X^ PUnit`: the adversary
+submits a guess and the outer interface `Bool X^ PUnit` exposes the win bit.
+The challenger is written directly as the corresponding composite lens, and
+the two single-phase adversaries are ordered by `orderPair` — so the guesser
+cannot see the ciphertext within the composite step, as documented there. -/
+
+/-- The PrivK challenger, from its destructor triple: state is the secret bit
+`b`; commit phase answers `m_b`; guess phase exposes `guess == b`. -/
+def privKChallenger :
+    DynSystem Bool ((monomial (Bool × Bool) Bool ⊸ X.{0, 0})
+      ◃ (monomial Bool PUnit ⊸ monomial Bool PUnit)) :=
+  (fun b =>
+    ⟨sectionLens (fun mm => cond b mm.2 mm.1),
+      fun _ => (fun (guess : Bool) => guess == b) ⇆ (fun _ _ => PUnit.unit)⟩) ⇆
+    fun b _ => b
+
+/-- The commit-phase adversary: submits the fixed message pair `(false, true)`. -/
+def commitAdversary : DynSystem PUnit (monomial (Bool × Bool) Bool) :=
+  DynSystem.mk' (fun _ => (false, true)) (fun _ _ => PUnit.unit)
+
+/-- The guess-phase adversary: guesses its own (fixed) state bit. -/
+def guessAdversary : DynSystem Bool (monomial Bool PUnit) :=
+  DynSystem.mk' (fun t => t) (fun t _ => t)
+
+/-- The full PrivK-shaped game: challenger against the ordered adversary pair. -/
+def privKGame : DynSystem (Bool × (PUnit × Bool)) (X.{0, 0} ◃ monomial Bool PUnit) :=
+  DynSystem.game₂ privKChallenger (DynSystem.orderPair commitAdversary guessAdversary)
+
+/-- With secret `true` and message pair `(false, true)`, guessing `true` wins:
+the composite position's continuation carries the win bit. -/
+example : (privKGame.expose (true, (PUnit.unit, true))).2 PUnit.unit = true := rfl
+
+/-- Guessing `false` against secret `true` loses. -/
+example : (privKGame.expose (true, (PUnit.unit, false))).2 PUnit.unit = false := rfl
+
+/-- One composite step of the game, by `rfl`: every participant here is
+stationary, so the state is unchanged. -/
+example : privKGame.update (true, (PUnit.unit, true)) ⟨PUnit.unit, PUnit.unit⟩
+    = (true, (PUnit.unit, true)) := rfl
+
+end PFunctor

--- a/PolyFunTest/PFunctor/Dynamical/ResponderExamples.lean
+++ b/PolyFunTest/PFunctor/Dynamical/ResponderExamples.lean
@@ -1,0 +1,63 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+module
+
+public import PolyFun.PFunctor.Dynamical.Responder
+
+/-!
+# Examples for responders (stateful answerers over the internal hom)
+
+Regression tests for `PFunctor/Dynamical/Responder.lean`: the `committed` /
+`answer` / `next` accessors, the stateless `ofSection` / `ofHandler`
+constructors, and the Kleisli–Mealy bridge `equivStateHandler` with its
+definitional round-trips.
+-/
+
+@[expose] public section
+
+namespace PFunctor
+namespace Responder.Examples
+
+/-- A query interface with a single query type answered by a natural number. -/
+abbrev q : PFunctor.{0, 0} := monomial PUnit Nat
+
+/-- A responder that returns its state as the answer to every query and
+increments its state on each query. -/
+def echoResponder : Responder Nat q :=
+  Responder.mk' (fun s _ => s) (fun s _ => s + 1)
+
+example : echoResponder.answer 5 PUnit.unit = (5 : Nat) := rfl
+
+example : echoResponder.next 5 PUnit.unit = 6 := rfl
+
+/-- `answer` reads the committed section at the query asked. -/
+example (s : Nat) (a : PUnit) :
+    echoResponder.answer s a = (echoResponder.committed s).toFunB a PUnit.unit := rfl
+
+/-! ## Stateless responders -/
+
+/-- A deterministic handler yields the same responder as its section lens. -/
+example (h : Handler Id q) :
+    (Responder.ofHandler h : Responder PUnit.{1} q) =
+      Responder.ofSection (sectionLens h) := rfl
+
+/-! ## The Kleisli–Mealy bridge -/
+
+/-- The `Responder ≃ Handler (StateT S Id)` bridge round-trips definitionally. -/
+example (R : Responder Nat q) :
+    Responder.equivStateHandler.symm (Responder.equivStateHandler R) = R := rfl
+
+example (h : Handler (StateT Nat Id) q) :
+    Responder.equivStateHandler (Responder.equivStateHandler.symm h) = h := rfl
+
+/-- The forward direction of the bridge answers from the state and threads the
+next state, i.e. it is a Mealy step in Kleisli form. -/
+example (s : Nat) (a : PUnit) :
+    echoResponder.toStateHandler a s = (echoResponder.answer s a, echoResponder.next s a) :=
+  rfl
+
+end Responder.Examples
+end PFunctor

--- a/docs/reading/roadmap.md
+++ b/docs/reading/roadmap.md
@@ -531,3 +531,32 @@ and axiom-count comparisons go in papers verbatim, favorable or not.
   index-equality-test base machine away from general. Next: Phase C (cofree
   comonoid, mate = `M.corec`) with the CPA hybrid ladder (P8) as its pays-rent
   test.
+- 2026-07-11 (cont.): **Game-wiring package landed** (PR #20, the A1 payoff
+  proper). Two new modules: `Dynamical/Responder.lean` (`Responder S q :=
+  DynSystem S (q ⊸ X)` — positions are committed answer-sections via
+  `ihom_X_A`; accessors `committed`/`answer`/`next`; the Kleisli–Mealy
+  `equivStateHandler : Responder S q ≃ Handler (StateT S Id) q` with `rfl`
+  round-trips) and `Dynamical/Game.lean` (`game := wire₂ (Lens.eval q r)`,
+  `closedGame` its autonomous `r = X` instance, `game_eq_uncurry` the
+  adjunction reading; monadic runs `kleisliStep`/`kleisliIterate` and the
+  stateful-handler `stepWith`/`iterWith` with the responder/handler state
+  *first* in the pair; the machine-vs-responder step law
+  `PointedMachine.runWith_run_succ_of_output_eq_none`; two-phase
+  `Lens.eval₂ = (eval ◃ₗ eval) ∘ₗ duoidalLens` (Eq 6.86), `orderPair`
+  (Ex 6.85, guess phase cannot see the commit answer within a composite
+  step), and `game₂`). All designed `rfl` canaries held on first compile —
+  the double-eta `update_eq_next`, both `equivStateHandler` round-trips,
+  `game_expose`/`game_update`/`closedGame_step`, `stepWith_toStateHandler`
+  at `m := Id`, and the PrivK-shaped `game₂` composite step in
+  `PolyFunTest/PFunctor/Dynamical/GameExamples.lean`. Design decision
+  recorded: no scored-game structure — a win readout is a state readout on
+  the closed run, and the Moore win-bit form is the `r := monomial Bool
+  PUnit` instance of `game`. One universe finding: `Lens.uncurry` is
+  single-universe-pair, so `game_eq_uncurry` pins the challenger state
+  universe to the interfaces'. **Pays-rent slot (open):** falsifiable test
+  = the downstream VCVio PR deletes `wireKStep`/`wireKIterate`/
+  `kleisliStep`/`kleisliIterate` as definitions (they become instances of
+  `stepWith`/`iterWith`/`kleisliStep` at `m := SPMF`, modulo the
+  responder-first order flip) and derives its machine-game step lemmas
+  from `runWith_run_succ_of_output_eq_none`; verdict to be recorded at
+  VCVio landing.

--- a/docs/reading/vcv-connection.md
+++ b/docs/reading/vcv-connection.md
@@ -35,6 +35,18 @@ become the *same* wiring along `eval`, with the SPMF-Kleisli lift as the only
 VCVio-side residue. The two are flagged in-source as un-unified siblings
 (`WireK.lean:42-44`); A1 is their common parent.
 
+**Status (2026-07-11): upstream half landed.** `Responder S q`
+(`PFunctor/Dynamical/Responder.lean`, systems over `q ⊸ X` with the
+Kleisli–Mealy `equivStateHandler` bridge), the game formers
+`DynSystem.game` / `closedGame` (`PFunctor/Dynamical/Game.lean`, wiring
+along `eval`, with `game_eq_uncurry` the adjunction reading), the monadic
+runs `kleisliStep` / `kleisliIterate` / `stepWith` / `iterWith`, and the
+machine-vs-responder step law
+`PointedMachine.runWith_run_succ_of_output_eq_none` are all in place, plus
+the two-phase `Lens.eval₂` / `orderPair` / `game₂` (Eq 6.86 + Ex 6.85).
+Remaining VCVio-side residue: the `m := SPMF` instance (ProbResponder as
+the bundled Kleisli sibling) and `QueryLog` transcripts.
+
 ### Vertical–cartesian factorization (Prop 5.51–5.63 → A3)
 
 Sub-spec inclusions in VCVio are cartesian lenses, and the paper's Thm 5.1

--- a/docs/wiki/notation.md
+++ b/docs/wiki/notation.md
@@ -49,6 +49,13 @@ than via custom notation, to keep elaboration predictable. Specifically:
   surface syntax for `roll` / `pure`; reach for `PFunctor.FreeM.lift`
   and `PFunctor.FreeM.liftPos` when you need to embed a single
   polynomial step.
+- The internal hom of the tensor product `q ⊸ r` (input `\multimap`,
+  U+22B8) is `PFunctor.ihom`, defined in
+  [`PolyFun/PFunctor/InternalHom.lean`](../../PolyFun/PFunctor/InternalHom.lean)
+  at `infixr:60`, scoped to the `PFunctor` namespace. Its positions are
+  the lenses `q ⇆ r` (Spivak–Niu Ex 4.78); `Responder S q` and the game
+  formers in `PolyFun/PFunctor/Dynamical/{Responder, Game}.lean` are
+  dynamical systems over `q ⊸ X` and `q ⊸ r`.
 - Machine sequential composition `M₁ ⨟ M₂` (input `\;;`, U+2A1F) is
   `PointedMachine.seqComp`, defined in
   [`PolyFun/PFunctor/Dynamical/PointedMachine.lean`](../../PolyFun/PFunctor/Dynamical/PointedMachine.lean)

--- a/docs/wiki/repo-map.md
+++ b/docs/wiki/repo-map.md
@@ -46,7 +46,8 @@ Logic/HEq, Control/{Coalgebra, Comonad, Lawful, Monad}
   (free-standing helpers, depended on by both PFunctor and ITree)
 
 PFunctor/{Lens, Cofree, M} + Control/Coalgebra
-  -> PFunctor/Dynamical/{Basic, Safety, Combinators, Run, Trajectory}
+  -> PFunctor/Dynamical/{Basic, Safety, Combinators, Responder, Game,
+                         Run, Trajectory}
   -> PFunctor/Dynamical/Behavior
 
 PFunctor/Free -> ITree/{Basic, Construct, Handler, Rec,


### PR DESCRIPTION
Stacked on #19 (DynSystem-as-lens). The game-wiring package: security games as dynamical systems, per the Spivak–Niu eval-wiring picture.

## What

- **`Dynamical/Responder.lean`** — `Responder S q := DynSystem S (q ⊸ X)`: the deterministic stateful responder as a system over the internal hom (Ex 4.78). By `ihom_X_A` its positions are committed answer-sections; a direction carries only the query asked. Accessors `committed`/`answer`/`next`/`mk'` (all-rfl simp lemmas, including the double-eta `update_eq_next`), stateless corners `ofSection`/`ofHandler`, and `equivStateHandler : Responder S q ≃ Handler (StateT S Id) q` with rfl round-trips — responders ARE Mealy machines in Kleisli form; VCVio's `ProbResponder` is the bundled `m := SPMF` sibling.
- **`Dynamical/Game.lean`** —
  - `game chal adv := wire₂ (Lens.eval q r) chal adv : DynSystem (S × T) r` with rfl-computed `game_expose`/`game_update`, and the adjunction reading `game_eq_uncurry` (a challenger is a stateful wiring diagram).
  - `closedGame : Closed (S × T)` at `r := X` — the deterministic shadow of VCVio's `wireKStep`. Win readout = state readout on the closed run; the Moore win-bit form is the `r := monomial Bool PUnit` *instance* (no scored-game structure).
  - Kleisli runs: `kleisliStep`/`kleisliIterate` (memoryless) and `stepWith`/`iterWith` against stateful handlers `Handler (StateT σ m) q` (responder state FIRST in `σ × S`), with the stateless-lift and `Id`-collapse laws, and the master machine-vs-responder step law `PointedMachine.runWith_run_succ_of_output_eq_none` (every lawful monad). Deliberately NO new monadic-responder type — a monadic responder is already a `Handler` at a `StateT` monad.
  - Two-phase: `Lens.eval₂ = (eval ◃ₗ eval) ∘ₗ duoidalLens` (Eq 6.86), `orderPair` (Ex 6.85 — the guess phase cannot see the commit answer within a composite step, documented), `game₂`; `CompTriple` named as the two-phase challenger intro/elim.
- **`PolyFunTest/PFunctor/Dynamical/GameExamples.lean`** — rfl canaries (all designed rfls held on first compile), a counting-responder game iterated by rfl, the Moore win-bit instance closed via `feedback`, and a deterministic PrivK-shaped `game₂` via `ofCompTriple`.
- Docs: roadmap session entry with an **open pays-rent slot** (falsifiable test: the downstream VCVio PR deletes its hand-rolled `wireKStep`/`wireKIterate`/`kleisliStep`/`kleisliIterate` as definitions and derives its machine-game step lemmas from the master law); vcv-connection A1 update; `⊸` registered in notation.md (it was unlisted).

## Notes for review

- Universe finding: `Lens.curry`/`uncurry` are declared at one shared universe pair, so `game_eq_uncurry` pins the challenger state universe to the interfaces'. Generalizing `InternalHom` to two pairs would restore full generality — deliberately not done here.
- Consumer contract: `stepWith`/`iterWith` put responder/handler state first; VCVio's existing `wireKStep` is adversary-first and flips in the downstream PR (it has zero consumers today).

Gate: `lake build --wfail`, `lake lint`, `lake test`, `lake exe lint-style`, import/docs integrity scripts — all green; zero sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)