### PR TITLE
feat(pfunctor): FreeM.mapM universal property & naturality along a monad morphism (B6)

### DIFF
--- a/PolyFun/Control/Monad/Hom.lean
+++ b/PolyFun/Control/Monad/Hom.lean
@@ -206,3 +206,24 @@ protected def pure (m) [Monad m] [LawfulMonad m] : Id →ᵐ m where
     MonadHom.pure m x = pure x.run := rfl
 
 end MonadHom
+
+namespace StateT
+
+variable {m : Type u → Type v} {n : Type u → Type w} [Monad m] [Monad n]
+  [LawfulMonad m] [LawfulMonad n] {σ α : Type u}
+
+/-- `StateT σ` is functorial on monad morphisms: a monad morphism `φ : m →ᵐ n` lifts to a monad
+morphism `StateT σ m →ᵐ StateT σ n`, acting on the underlying state-run and threading the state
+unchanged. This transports the naturality of a fold (e.g. `FreeM.mapM_natural`) through a *stateful*
+handler — the form a `StateT`-threaded semantic morphism (such as an evaluation-distribution map)
+needs. -/
+def mapHom (φ : m →ᵐ n) : StateT σ m →ᵐ StateT σ n where
+  toFun _ x := StateT.mk fun s => φ (x.run s)
+  toFun_pure' a := by ext s; simp
+  toFun_bind' x y := by ext s; simp
+
+omit [LawfulMonad m] [LawfulMonad n] in
+@[simp] lemma run_mapHom (φ : m →ᵐ n) (x : StateT σ m α) (s : σ) :
+    (StateT.mapHom φ x).run s = φ (x.run s) := rfl
+
+end StateT

--- a/PolyFun/PFunctor/Free/Basic.lean
+++ b/PolyFun/PFunctor/Free/Basic.lean
@@ -311,7 +311,87 @@ protected def mapMHom' (s : NatHom P.Obj m) : FreeM P →ᵐ m where
 @[simp] lemma mapMHom'_toFun_eq (s : NatHom P.Obj m) :
     (FreeM.mapMHom' s).toFun α = FreeM.mapM (fun t => s ⟨t, id⟩) := rfl
 
+/-! ## Universal property and naturality of the fold
+
+`FreeM.mapM s` is the universal fold: the *unique* monad homomorphism out of `FreeM P` extending a
+handler `s` (`mapMHom_unique`), and it is *natural* in the target monad — post-composing with a
+monad morphism `φ : m →ᵐ n` is the fold of the post-composed handler (`mapM_natural`,
+`mapMHom_comp`). This is the freeness of `FreeM P`; downstream it lets a semantic monad morphism
+(e.g. an evaluation-distribution map) be pushed through a fold uniformly, rather than re-run by
+induction per interpretation. -/
+
+variable {n : Type uB → Type u} [Monad n] [LawfulMonad n]
+
+/-- **Universal property of `FreeM.mapM`** (freeness of `FreeM P`): a monad homomorphism out of
+`FreeM P` is determined by its action on generators. If `F : FreeM P →ᵐ m` agrees with `s` on every
+`FreeM.liftA a`, then `F = FreeM.mapMHom s`. So handlers `(a : P.A) → m (P.B a)` are in bijection
+with monad homomorphisms `FreeM P →ᵐ m` — the universal property behind `simulateQ`. -/
+theorem mapMHom_unique (F : FreeM P →ᵐ m) (h : ∀ a, F (FreeM.liftA a) = s a) :
+    F = FreeM.mapMHom s := by
+  refine MonadHom.ext' fun β x => ?_
+  induction x with
+  | pure x => exact F.mmap_pure x
+  | roll a r ih =>
+    change F (FreeM.roll a r) = FreeM.mapM s (FreeM.roll a r)
+    rw [mapM_roll, show (FreeM.roll a r : FreeM P β) = FreeM.liftA a >>= r from rfl,
+      MonadHom.mmap_bind, h]
+    exact bind_congr fun d => ih d
+
+omit [LawfulMonad m] [LawfulMonad n] in
+/-- **Naturality of the fold along a monad morphism**: pushing a monad morphism `φ : m →ᵐ n` through
+`FreeM.mapM s` is the fold of the post-composed handler `fun a => φ (s a)` — the value-level
+naturality square of the universal fold. -/
+@[simp] theorem mapM_natural (φ : m →ᵐ n) (x : FreeM P α) :
+    φ (FreeM.mapM s x) = FreeM.mapM (fun a => φ (s a)) x := by
+  induction x with
+  | pure x => exact φ.mmap_pure x
+  | roll a r ih => simp only [mapM_roll, MonadHom.mmap_bind, ih]
+
+/-- Bundled form of `mapM_natural`: composing the fold monad-homomorphism `FreeM.mapMHom s` with a
+monad morphism `φ` is the fold of the post-composed handler. -/
+theorem mapMHom_comp (φ : m →ᵐ n) :
+    φ ∘ₘ FreeM.mapMHom s = FreeM.mapMHom (fun a => φ (s a)) :=
+  MonadHom.ext' fun β x => by simp only [MonadHom.comp_apply, mapMHom_toFun_eq, mapM_natural]
+
 end mapM
+
+section stateNaturality
+
+variable {m : Type uB → Type v} {n : Type uB → Type u} [Monad m] [Monad n] {σ : Type uB}
+  {α : Type uB}
+
+/-- **Stateful naturality of the fold**: running a fold whose stateful handler is post-composed by
+a `StateT`-lifted monad morphism `StateT.mapHom φ` is `φ` applied to the run of the original fold —
+the shape a `StateT`-threaded semantic morphism (e.g. an evaluation-distribution map through a
+stateful handler) instantiates, collapsing a per-interpretation induction to one use of
+`mapM_natural`. -/
+theorem run_mapM_mapHom (φ : m →ᵐ n) (impl : (a : P.A) → StateT σ m (P.B a))
+    (x : FreeM P α) (s : σ) :
+    (FreeM.mapM (fun a => StateT.mapHom φ (impl a)) x).run s = φ ((FreeM.mapM impl x).run s) := by
+  rw [← mapM_natural impl (StateT.mapHom φ) x, StateT.run_mapHom]
+
+end stateNaturality
+
+section idFold
+
+variable {α : Type uB}
+
+/-- The fold with the canonical re-lifting handler `FreeM.liftA` is the identity: interpreting each
+position back into the free monad recovers the tree (equivalently `FreeM.mapMHom FreeM.liftA` is the
+identity homomorphism, `mapMHom_liftA`). The upstream form of `simulateQ` of the identity handler
+being the identity — a corollary of the universal property. -/
+@[simp] theorem mapM_liftA_eq_self (x : FreeM P α) : FreeM.mapM FreeM.liftA x = x := by
+  induction x with
+  | pure y => rfl
+  | roll a r ih =>
+    rw [mapM_roll]
+    change FreeM.roll a (fun u => FreeM.mapM FreeM.liftA (r u)) = FreeM.roll a r
+    exact congrArg (FreeM.roll a) (funext ih)
+
+theorem mapMHom_liftA : FreeM.mapMHom (P := P) (m := FreeM P) FreeM.liftA = MonadHom.id (FreeM P) :=
+  MonadHom.ext' fun _ x => by simp
+
+end idFold
 
 end FreeM
 

--- a/PolyFunTest/PFunctor/FreeMapMNaturality.lean
+++ b/PolyFunTest/PFunctor/FreeMapMNaturality.lean
@@ -1,0 +1,67 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+module
+
+public import PolyFun.PFunctor.Free.Basic
+
+/-!
+# Examples: universal property and naturality of the free-monad fold
+
+Regression tests for the universal property and naturality of `FreeM.mapM` along a monad morphism:
+`mapMHom_unique`, `mapM_natural`, `mapMHom_comp`, `run_mapM_mapHom`, `mapM_liftA_eq_self`,
+`mapMHom_liftA`, and `StateT.mapHom`. These are the upstream shape of the fold-naturality bridges
+that VCVio's `simulateQ` / `evalDist` layer instantiates at `φ := evalDist`.
+-/
+
+@[expose] public section
+
+open PFunctor
+
+namespace PolyFunTest.FreeMapM
+
+/-- A small concrete polynomial for the canaries: two positions, `Bool`-many directions each. -/
+def P : PFunctor := ⟨Bool, fun _ => Bool⟩
+
+variable {m n : Type → Type} [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n]
+
+/-- **Naturality** of the fold along a monad morphism applies. -/
+example (s : (a : P.A) → m (P.B a)) (φ : m →ᵐ n) {α : Type} (x : FreeM P α) :
+    φ (FreeM.mapM s x) = FreeM.mapM (fun a => φ (s a)) x :=
+  FreeM.mapM_natural s φ x
+
+/-- **Bundled naturality**: `φ ∘ₘ mapMHom s = mapMHom (φ ∘ s)`. -/
+example (s : (a : P.A) → m (P.B a)) (φ : m →ᵐ n) :
+    φ ∘ₘ FreeM.mapMHom s = FreeM.mapMHom (fun a => φ (s a)) :=
+  FreeM.mapMHom_comp s φ
+
+/-- **Universal property**: a monad hom out of `FreeM P` agreeing with `s` on generators is
+`mapMHom s`. -/
+example (s : (a : P.A) → m (P.B a)) (F : FreeM P →ᵐ m) (h : ∀ a, F (FreeM.liftA a) = s a) :
+    F = FreeM.mapMHom s :=
+  FreeM.mapMHom_unique s F h
+
+/-- The identity handler folds to the identity homomorphism. -/
+example : FreeM.mapMHom (m := FreeM P) FreeM.liftA = MonadHom.id (FreeM P) :=
+  FreeM.mapMHom_liftA
+
+/-- The identity handler folds any tree to itself. -/
+example {α : Type} (x : FreeM P α) : FreeM.mapM FreeM.liftA x = x :=
+  FreeM.mapM_liftA_eq_self x
+
+/-- **Stateful naturality**: `φ` pushed through a `StateT`-threaded fold. -/
+example (φ : m →ᵐ n) {σ α : Type} (impl : (a : P.A) → StateT σ m (P.B a))
+    (x : FreeM P α) (s : σ) :
+    (FreeM.mapM (fun a => StateT.mapHom φ (impl a)) x).run s = φ ((FreeM.mapM impl x).run s) :=
+  FreeM.run_mapM_mapHom φ impl x s
+
+/-- A concrete push-through: lifting `Id → Option` commutes with the fold — the shape a semantic
+monad morphism (e.g. an evaluation-distribution map) instantiates. -/
+example (s : (a : P.A) → Id (P.B a)) (x : FreeM P Bool) :
+    MonadHom.ofLift Id Option (FreeM.mapM s x)
+      = FreeM.mapM (fun a => MonadHom.ofLift Id Option (s a)) x :=
+  FreeM.mapM_natural s (MonadHom.ofLift Id Option) x
+
+end PolyFunTest.FreeMapM

--- a/docs/reading/roadmap.md
+++ b/docs/reading/roadmap.md
@@ -560,3 +560,11 @@ and axiom-count comparisons go in papers verbatim, favorable or not.
   responder-first order flip) and derives its machine-game step lemmas
   from `runWith_run_succ_of_output_eq_none`; verdict to be recorded at
   VCVio landing.
+- 2026-07-11 (**B6**, fold universal property and monad-morphism naturality):
+  added `FreeM.mapMHom_unique`, `FreeM.mapM_natural`, and `mapMHom_comp`, plus
+  `StateT.mapHom` / `run_mapHom` and the composed `FreeM.run_mapM_mapHom` law.
+  The identity-handler laws `mapM_liftA_eq_self` and `mapMHom_liftA` complete
+  the basic universal-property API. Regression coverage lives in
+  `PolyFunTest/PFunctor/FreeMapMNaturality.lean`. Downstream payoff to check:
+  VCVio should be able to bundle `evalDist` as a monad hom and replace its
+  hand-proved `simulateQ` fold-naturality family with these generic laws.


### PR DESCRIPTION
Stacked on #20 (`dtumad/game-wiring`). Roadmap ticket **B6** — the universal property of the fold and its naturality along a monad morphism.

## What

`FreeM.mapM` (VCV-io's `simulateQ`) is the universal fold out of the free monad `FreeM P`, but only its object-level API existed. This adds the missing 2-cell laws:

- **`FreeM.mapMHom_unique`** — freeness: a `MonadHom` out of `FreeM P` is determined by its action on generators (`FreeM.liftA`); so handlers `(a : P.A) → m (P.B a)` biject with `FreeM P →ᵐ m`.
- **`FreeM.mapM_natural`** / **`mapMHom_comp`** — naturality along `φ : m →ᵐ n`: `φ (mapM s x) = mapM (φ ∘ s) x`.
- **`StateT.mapHom (φ : m →ᵐ n) : StateT σ m →ᵐ StateT σ n`** (+ `run_mapHom`) and **`FreeM.run_mapM_mapHom`** — `StateT σ` is functorial on `MonadHom`, giving the `StateT`-transported form of the naturality square.
- **`FreeM.mapM_liftA_eq_self`** / **`mapMHom_liftA`** — the identity handler folds to the identity.

The `MonadHom` / `→ᵐ` / `∘ₘ` layer and the bundled `mapMHom` were already upstream; only the laws were missing. Lives in `PFunctor/Free/Basic.lean` (+ `StateT.mapHom` in `Control/Monad/Hom.lean`) — no new imports / DAG change.

## Grounding & pays-rent

Spivak–Niu Ch 7: `FreeM P` as the free ◃-monoid, handlers / `mapMHom` as monoid morphisms — the universal property behind `simulateQ`. Falsifiable pays-rent test (downstream VCV-io): bundle `evalDist` as `ProbComp →ᵐ SPMF` (`MonadHom.ofLift`) and collapse the hand-proved `simulateQ` / `evalDist` fold-naturality family — each an `OracleComp.inductionOn` — to one-liners at `φ := evalDist`.

Regression: `PolyFunTest/PFunctor/FreeMapMNaturality.lean`. Roadmap B6 verdict appended. `lake build && lake lint && lake test --wfail` green, zero sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)