### PR TITLE
feat(dynamical): seqComp_State carrier-reduction simp lemma

### DIFF
--- a/PolyFun/PFunctor/Dynamical/PointedMachine.lean
+++ b/PolyFun/PFunctor/Dynamical/PointedMachine.lean
@@ -205,6 +205,12 @@ def seqComp (M₁ : PointedMachine p α mid) (M₂ : PointedMachine p mid β) : 
 
 @[inherit_doc] infixl:75 " ⨟ " => seqComp
 
+/-- The carrier of a sequential composition is the sum of the two carriers. A `@[simp]` `rfl`
+bridge so the composed machine's `State` reduces in downstream goals (the `PointedMachine.State`
+field is otherwise opaque to `simp`/instance resolution, blocking rewriting through it). -/
+@[simp] theorem seqComp_State (M₁ : PointedMachine p α mid) (M₂ : PointedMachine p mid β) :
+    (M₁ ⨟ M₂).State = (M₁.State ⊕ M₂.State) := rfl
+
 @[simp] theorem seqComp_expose_inr (M₁ : PointedMachine p α mid) (M₂ : PointedMachine p mid β)
     (s₂ : M₂.State) : (M₁ ⨟ M₂).expose (Sum.inr s₂) = M₂.expose s₂ := rfl
 


### PR DESCRIPTION
Stacked on #21 (`dtumad/mapmhom-naturality`). Carrier-reducibility discipline for the bundled-machine layer.

## What

`PointedMachine.seqComp` composes its two carriers as `M₁.State ⊕ M₂.State` in a `State` field, but had no `@[simp]` lemma exposing it — so the composed machine's `State` stayed opaque to `simp` / instance resolution, blocking rewriting through it downstream. Adds **`@[simp] seqComp_State`** (rfl), alongside the existing `seqComp_expose` / `output` / `update` lemmas.

The discipline: for a bundled dynamical-system former that hides a carrier behind a `State` field, ship a `@[simp] rfl` bridge so downstream goals reduce through it. (`DynSystem`'s own combinators already expose the carrier as an explicit parameter; `PointedMachine.seqComp` is the one former composing carriers via a field.)

`lake build && lake lint && lake test --wfail` green, zero sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)