### PR TITLE
docs: fix Spivak–Niu citations, honest FreeM/Cofree wording, DAG sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,10 +90,18 @@ PFunctor/{Basic, Bound, M, Equiv, Chart, Lens}
   → PFunctor/Free/{Basic, Path}
   → PFunctor/Free/{Displayed, Displayed/Decoration}
 
+PFunctor/Lens/{Basic, Cartesian, State}
+  → PFunctor/Lens/{Composite, Distributivity, Factorization, Duoidal}
+  → PFunctor/{InternalHom, CartesianClosed, Adjunctions, Comonoid}
+
 PFunctor/{Lens, Cofree, M} + Control/Coalgebra
-  → PFunctor/Dynamical/{Basic, Safety, Combinators, Run, Trajectory,
-                        Simulation, Refinement}
-  → PFunctor/Dynamical/{Behavior, PointedMachine, RunN}
+  → PFunctor/Dynamical/{Basic, Safety, Combinators, Run, Speedup, Trajectory}
+  → PFunctor/Dynamical/{Behavior, Simulation, RunN, PointedMachine}
+  → PFunctor/Dynamical/{Refinement, Responder, Game}
+
+  (Dynamical also draws on PFunctor/Comonoid and PFunctor/Free/Basic
+   for RunN and PointedMachine, PFunctor/InternalHom for Responder, and
+   PFunctor/Lens/Duoidal for Game.)
 
 Control/Monad/Indexed, PFunctor/Free/Basic
   → IPFunctor/Basic → IPFunctor/Free/{Basic, Indexed}
@@ -112,9 +120,10 @@ PFunctor/Free + Control → Interaction/Basic/{Spec, Node, Decoration,
                             Telescope, Sampler, MonadDecoration,
                             BundledMonad, Ownership, SpecFintype}
 
-Interaction/Basic + PFunctor/Dynamical
-  → Interaction/{TwoParty, Multiparty, Concurrent}
-  (processes and machines are dynamical systems over their step polynomials)
+Interaction/Basic → Interaction/{TwoParty, Multiparty}
+Interaction/Basic + PFunctor/Dynamical → Interaction/Concurrent
+  (concurrent processes and machines are dynamical systems over their step
+   polynomials; TwoParty/Multiparty do not depend on PFunctor/Dynamical)
 
 Interaction/{Concurrent, Basic} → Interaction/UC/{Interface,
                                   OpenProcess, OpenProcessModel,
@@ -273,9 +282,9 @@ Highlights:
   free interaction structure on a polynomial container.
 - Altenkirch-Ghani-Hancock-McBride-Morris 2015 — *Indexed Containers*
   (JFP 25, e5).
-- Spivak-Niu 2024 — *Polynomial Functors: A General Theory of
-  Interaction* (MIT Press); the patterns/matter pairing
-  `FreeM ⊣ Cofree`.
+- Spivak-Niu 2025 — *Polynomial Functors: A General Theory of
+  Interaction* (Cambridge University Press); the pattern-runs-on-matter
+  module structure of `FreeM` over `Cofree`.
 - Xia-Zakowski-He-Hur-Malecha-Pierce-Zdancewic 2020 —
   *Interaction Trees* (POPL).
 - Escardó-Oliva 2023 — games as type trees (TCS 974).

--- a/PolyFun/Interaction/Basic/Spec.lean
+++ b/PolyFun/Interaction/Basic/Spec.lean
@@ -79,8 +79,9 @@ representation.
   free interaction structure on a polynomial container
 * Altenkirch–Ghani–Hancock–McBride–Morris (2015), *Indexed Containers*,
   Journal of Functional Programming 25, e5
-* Spivak–Niu (2024), *Polynomial Functors: A General Theory of
-  Interaction*, MIT Press; the patterns/matter pairing `FreeM ⊣ Cofree`
+* Spivak–Niu (2025), *Polynomial Functors: A General Theory of
+  Interaction*, Cambridge University Press; the pattern-runs-on-matter
+  module structure of `FreeM` over `Cofree`
 * Escardó–Oliva (2023, TCS 974), games as type trees
 * McBride (2010); Dagand–McBride (2014), displayed algebras / ornaments
 -/

--- a/PolyFun/PFunctor/Adjunctions.lean
+++ b/PolyFun/PFunctor/Adjunctions.lean
@@ -11,8 +11,8 @@ public import PolyFun.PFunctor.Lens.Basic
 # Hom-set adjunctions for trivial-interface polynomial functors
 
 This file records the "trivial interface" hom-set equivalences of Spivak–Niu
-*Polynomial Functors: A General Theory of Interaction* (MIT Press, 2024),
-§5.1. Each computes the set of lenses out of, or into, one of the
+*Polynomial Functors: A General Theory of Interaction* (Cambridge University
+Press, 2025), §5.1. Each computes the set of lenses out of, or into, one of the
 distinguished polynomial functors `0`, `1`, `X = y`, a constant `C A`, or a
 linear `linear A` by a concrete data type. These are the hom-isomorphisms
 witnessing the adjoint quadruple `linear ⊣ (−)(1) ⊣ C ⊣ (−)(0)` together with
@@ -39,8 +39,11 @@ the sections/principal-monomial refinements.
 
 The equivalences are stated as bare `Equiv`s between `Lens` types and concrete
 types, matching the observation of the reading notes (§5.1) that none of these
-hom-isos needs category-theory packaging to be useful; the dynamical layer
-uses `homFromX` and `homToConst` pervasively for points and event maps.
+hom-isos needs category-theory packaging to be useful.
+
+These hom-isomorphisms are reference API: book-completeness formalizations of
+the §5.1 trivial-interface adjunctions, staged for downstream (VCV-io)
+consumers and exercised in `PolyFunTest/PFunctor/Adjunctions.lean`.
 
 Both directions of `homFromX` and `homToLinear` hold definitionally
 (`PUnit`/`Prod` eta), so their inverse laws are `rfl`. The three equivalences

--- a/PolyFun/PFunctor/CartesianClosed.lean
+++ b/PolyFun/PFunctor/CartesianClosed.lean
@@ -38,6 +38,12 @@ transposes live in `PFunctor.Lens`.
   round-trip.
 - `CartesianClosed.curryEquiv` — the resulting equivalence of lens types.
 
+These transposes are reference API: a book-completeness formalization of the
+§5.3 cartesian exponential (Thm 5.31), exercised in
+`PolyFunTest/PFunctor/CartesianClosed.lean` and staged for a downstream
+consumer. The `curry` / `eval` / `uncurry` used elsewhere in PolyFun (e.g.
+`Game.lean`) are instead the `⊗`-internal-hom ones in `InternalHom.lean`.
+
 All three of `p`, `q`, `r` live in a single universe `PFunctor.{uA, uB}`, since
 `exp` requires its two arguments in a common universe and the adjunction is
 stated within the one category `Poly.{uA, uB}`.

--- a/PolyFun/PFunctor/Comonoid.lean
+++ b/PolyFun/PFunctor/Comonoid.lean
@@ -77,10 +77,12 @@ namespace Comonoid
 
 /-! ## The `n`-fold comultiplication `δ^{(n)}` -/
 
-/-- The canonical `n`-fold comultiplication `δ^{(n)} : c ⇆ c^{◃n}` of a comonoid
-(Spivak–Niu Prop 7.20), recursively `δ^{(0)} = ε` and
-`δ^{(n+1)} = (id ◃ δ^{(n)}) ∘ δ`. The comonoid data underneath the `n`-step run
-`PFunctor.DynSystem.nStep`. -/
+/-- The `n`-fold comultiplication `δ^{(n)} : c ⇆ c^{◃n}` of a comonoid, defined
+recursively by `δ^{(0)} = ε` and `δ^{(n+1)} = (id ◃ δ^{(n)}) ∘ δ`
+(Spivak–Niu Prop 7.20). Only the definitional unfolders `comultN_zero` /
+`comultN_succ` are proved here; the canonicity of Prop 7.20(d) — that every
+bracketing of the `n`-fold comultiplication agrees — is a follow-on. This is
+the comonoid data underneath the `n`-step run `PFunctor.DynSystem.nStep`. -/
 def comultN (C : Comonoid.{uA, uB}) : (n : ℕ) → Lens C.carrier (compNth C.carrier n)
   | 0 => C.counit
   | n + 1 => (Lens.id C.carrier ◃ₗ C.comultN n) ∘ₗ C.comult
@@ -95,7 +97,10 @@ def comultN (C : Comonoid.{uA, uB}) : (n : ℕ) → Lens C.carrier (compNth C.ca
 /-- A comonoid **is a state system** when, at every object, its codomain map
 `d ↦ cod d` (the second component of `δ`'s position action) is a bijection: from
 each object there is exactly one morphism to each object (a contractible
-groupoid). A predicate, never a field (Spivak–Niu Ex 7.22). -/
+groupoid). A predicate, never a field (Spivak–Niu Ex 7.22).
+
+Reference API: exercised in `PolyFunTest/PFunctor/Comonoid.lean`, staged for
+downstream state-system consumers. -/
 def IsStateSystem (C : Comonoid.{uA, uB}) : Prop :=
   ∀ a : C.carrier.A, Function.Bijective (C.comult.toFunA a).2
 

--- a/PolyFun/PFunctor/Lens/Duoidal.lean
+++ b/PolyFun/PFunctor/Lens/Duoidal.lean
@@ -122,7 +122,12 @@ def duoidalLens (p : PFunctor.{uA₁, uB₁}) (p' : PFunctor.{uA₂, uB₂})
 These are the special cases in which `orderingLens` is an isomorphism, i.e. the
 two monoidal products agree outright. In each case one of the factors has a
 unique continuation into the other, so the ordering of moves carries no
-information. -/
+information.
+
+These catalogue isos are reference API — book-completeness formalizations of
+Example 6.84, exercised in `PolyFunTest/PFunctor/Lens/Duoidal.lean`. The
+load-bearing formers of this file are `orderingLens` and `duoidalLens` above
+(consumed by `PolyFun/PFunctor/Dynamical/Game.lean`). -/
 
 namespace Equiv
 

--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -41,11 +41,14 @@ Used in: `PolyFun/PFunctor/Free/Path.lean`,
 
 David I. Spivak and Nelson Niu.
 *Polynomial Functors: A Mathematical Theory of Interaction*.
-Cambridge University Press, 2024 (preprint: arXiv:2202.00534).
+Cambridge University Press, London Mathematical Society Lecture Note
+Series 498, 2025 (DOI 10.1017/9781009576734; preprint: arXiv:2202.00534).
 
 The polynomial-functor calculus, charts, lenses, the composition product,
-the free monad / cofree comonad pair (`FreeM ⊣ Cofree`), and the slogan
-"pattern runs on matter".
+the free-monad / cofree-comonad pairing, and the slogan "pattern runs on
+matter". (The pairing is the module structure of Libkind–Spivak below, not
+an adjunction; PolyFun formalizes `LawfulMonad (FreeM P)` and
+`LawfulComonad (CofreeC F)` separately.)
 
 Used in: `PolyFun/PFunctor/Trace.lean`, `PolyFun/PFunctor/Lens/State.lean`,
 `PolyFun/PFunctor/Free/Path.lean`, the dynamical-systems layer in
@@ -62,7 +65,8 @@ cofree comonad comonad*.
 arXiv:2208.12504, 2022.
 
 Free polynomial monads as terminating decision trees, with the
-`FreeM ⊣ Cofree` adjunction made explicit.
+free-monad-as-module-over-cofree-comonad structure made explicit (a module
+action, not an adjunction).
 
 Used in: `PolyFun/PFunctor/Free/Path.lean`.
 

--- a/docs/reading/corrections.md
+++ b/docs/reading/corrections.md
@@ -7,14 +7,6 @@ with the commit/PR that fixed them.
 
 ## Open
 
-1. **PolyFun `FreeM ⊣ Cofree` over-claim.**
-   `PolyFun/Interaction/Basic/Spec.lean:83` and `REFERENCES.md:65` describe
-   the "patterns/matter pairing `FreeM ⊣ Cofree`" as if present; no
-   adjunction is formalized anywhere in PolyFun (only `LawfulMonad (FreeM P)`
-   and `LawfulComonad (CofreeC F)` separately). Fix wording now or land the
-   adjunction (roadmap Phase C) — whichever comes first; wiki maintenance
-   contract applies.
-
 2. **Polytime encoding model (in-flight repair on `dtumad/k-l-examples`).**
    The earlier existential-encoding `EncPolyTime` model admitted an
    advice-collapse and an encoding-caching triviality
@@ -49,11 +41,16 @@ with the commit/PR that fixed them.
    must reconcile the framing (the pitch becomes: both sides over one
    substrate, with the free/cofree pairing between them).
 
-7. **Spivak–Niu publisher wrong in repo docs.** `REFERENCES.md` and
-   `AGENTS.md`/`CLAUDE.md` cite the book as "MIT Press 2024"; the published
-   edition is Cambridge University Press, LMS Lecture Note Series 498, 2025
-   (DOI 10.1017/9781009576734; arXiv 2312.00990 remains the preprint). Fix
-   in the next docs pass.
+8. **Spivak–Niu arXiv id / subtitle inconsistency.** The book's preprint is
+   cited two ways across the repo: arXiv:2312.00990 with subtitle "A General
+   Theory of Interaction" (roadmap, this bibliography's highlights) versus
+   arXiv:2202.00534 with subtitle "A Mathematical Theory of Interaction"
+   (`REFERENCES.md` SN24 entry, `docs/wiki/interaction.md:433`,
+   `PolyFun/Control/Trace.lean`, `PolyFun/PFunctor/Trace.lean`,
+   `PolyFun/PFunctor/Dynamical/Basic.lean`). Reconcile to a single canonical
+   id + subtitle once verified against arXiv; deferred from the 2026-07-12
+   hygiene pass to avoid guessing which posting each `Trace`/§4.3 citation
+   actually intends.
 
 ## Watch (potential over-claims to avoid in future writing)
 
@@ -82,4 +79,15 @@ with the commit/PR that fixed them.
 
 ## Resolved
 
-- (none yet)
+- **Item 1 (`FreeM ⊣ Cofree` over-claim).** Wording fixed on
+  `dtumad/cleanup-hygiene`: `PolyFun/Interaction/Basic/Spec.lean`,
+  `REFERENCES.md`, and `AGENTS.md`/`CLAUDE.md` now describe the
+  pattern-runs-on-matter *module structure* (Libkind–Spivak) rather than an
+  adjunction, and note that PolyFun formalizes `LawfulMonad (FreeM P)` /
+  `LawfulComonad (CofreeC F)` separately. Formalizing the true `U ⊣ 𝒯`
+  adjunction (Thm 8.45) remains roadmap Phase C.
+- **Item 7 (Spivak–Niu publisher).** Corrected to Cambridge University Press,
+  LMS Lecture Note Series 498, 2025 (DOI 10.1017/9781009576734) on
+  `dtumad/cleanup-hygiene` across `REFERENCES.md`, `AGENTS.md`/`CLAUDE.md`, and
+  `PolyFun/PFunctor/Adjunctions.lean`. The arXiv-id/subtitle inconsistency
+  surfaced during that pass is tracked separately as open item 8.

--- a/docs/wiki/pfunctor.md
+++ b/docs/wiki/pfunctor.md
@@ -55,8 +55,15 @@ McBride 2010 / Dagand-McBride 2014 (displayed algebras / ornaments).
 | [`PolyFun/PFunctor/Lens/Basic.lean`](../../PolyFun/PFunctor/Lens/Basic.lean) | Properties of `Lens P Q`: extensionality, composition lemmas, action on `Obj`. |
 | [`PolyFun/PFunctor/Lens/Cartesian.lean`](../../PolyFun/PFunctor/Lens/Cartesian.lean) | Cartesian lenses (`toFunB a` is a bijection); fiberwise isomorphisms over a forward position map. |
 | [`PolyFun/PFunctor/Lens/State.lean`](../../PolyFun/PFunctor/Lens/State.lean) | Lawful state-lens specialization for the self-monomial polynomial (`get`, `put`, `PutGet` / `GetPut` / `PutPut`). |
+| [`PolyFun/PFunctor/Lens/Composite.lean`](../../PolyFun/PFunctor/Lens/Composite.lean) | Lenses into a composite `q ◃ r`: the `CompTriple` destructor `Lens p (q ◃ r) ≃ (φ^q, φ^r, φ♯)` (Ex 6.40) via `toCompTriple` / `ofCompTriple`; `Lens.compNthMap` (φ^◁n) with its `zero` / `succ` / `id` laws. |
+| [`PolyFun/PFunctor/Lens/Distributivity.lean`](../../PolyFun/PFunctor/Lens/Distributivity.lean) | Left-distributivity of `◃`: `prodCompDistrib` (6.49) and `scalarCompDistrib` (Ex 6.55) lens equivalences, `homMonomialEquiv` (6.65) `Lens (monomial A B) p ≃ (A → p.Obj B)`, and the Ex 6.56 right-distributivity failure. Reuses object-level `sumCompDistrib` / `sigmaCompDistrib`. |
+| [`PolyFun/PFunctor/Lens/Factorization.lean`](../../PolyFun/PFunctor/Lens/Factorization.lean) | Vertical–cartesian factorization (Prop 5.52/5.53): `IsVertical`, `factorMid` / `factorVert` / `factorCart` with `factorCart_comp_factorVert = l`; closure of `IsVertical` / `IsCartesian` under `+` / `×` / `⊗`; `equivOfVerticalCartesian` (the intersection is an iso). |
+| [`PolyFun/PFunctor/Lens/Duoidal.lean`](../../PolyFun/PFunctor/Lens/Duoidal.lean) | The `⊗ → ◃` ordering lens `orderingLens` (Ex 6.85, cartesian) and the duoidal interchange lens `duoidalLens` (6.86); the Ex 6.84 catalogue of `⊗`/`◃` coincidences as `≃ₗ` formers (reference API). |
 | [`PolyFun/PFunctor/Chart/Basic.lean`](../../PolyFun/PFunctor/Chart/Basic.lean) | Charts (forward map on both positions and directions). Chart category is isomorphic to `Set^→` and has a different monoidal structure from the lens category. |
 | [`PolyFun/PFunctor/Category.lean`](../../PolyFun/PFunctor/Category.lean) | Category-theoretic packaging where applicable. |
+| [`PolyFun/PFunctor/InternalHom.lean`](../../PolyFun/PFunctor/InternalHom.lean) | The `⊗`-internal hom `ihom q r` = `[q, r]` (Ex 4.78; positions are lenses `q ⇆ r`), the evaluation lens `Lens.eval`, and the tensor–hom adjunction `curry` / `uncurry` / `curryEquiv : Lens (p ⊗ q) r ≃ Lens p (ihom q r)`; `ihomSum`, `ihomX`. |
+| [`PolyFun/PFunctor/CartesianClosed.lean`](../../PolyFun/PFunctor/CartesianClosed.lean) | Cartesian-closed structure w.r.t. the categorical product `*`: the exponential `exp`'s `CartesianClosed.eval` / `curry` / `uncurry` (Thm 5.31). Reference API — the load-bearing `⊗`-transposes are in `InternalHom.lean`. |
+| [`PolyFun/PFunctor/Adjunctions.lean`](../../PolyFun/PFunctor/Adjunctions.lean) | Trivial-interface hom-set equivalences (Thm 5.4 family): `homFromZero` / `homToOne` / `homFromX` / `homToConst` / `homToLinear`. Reference API. |
 | [`PolyFun/PFunctor/Comonoid.lean`](../../PolyFun/PFunctor/Comonoid.lean) | Comonoids in `(Poly, ◃, y)` (= small categories, Def 7.14): `Comonoid` structure with counit/comult and the lens laws; the state comonoid `stateComonoid S` on `Sy^S`; `IsStateSystem` (Ex 7.22); the `n`-fold comultiplication `comultN` = `δ^{(n)}` (Prop 7.20). |
 
 ### Dynamical systems (Spivak–Niu Ch. 4)
@@ -75,6 +82,8 @@ McBride 2010 / Dagand-McBride 2014 (displayed algebras / ornaments).
 | [`PolyFun/PFunctor/Dynamical/RunN.lean`](../../PolyFun/PFunctor/Dynamical/RunN.lean) | `DynSystem.nStep` = `Run_n(φ) = δ^{(n)} ⨟ φ^{◁n}` (§7.1.5) over the composition power `compNth p n`; `twoStep_toLens_eq` collapses `n = 2` to `twoStep`. |
 | [`PolyFun/PFunctor/Dynamical/Simulation.lean`](../../PolyFun/PFunctor/Dynamical/Simulation.lean) | `DynSystem.IsSimulation` (step-synchronized relation) with `behavior_eq_of_isSimulation` — related states have equal `behavior`, via `M.corec_eq_corec`; `isSimulation_graph` / `behavior_coalgHom` — coalgebra morphisms are the functional simulations. |
 | [`PolyFun/PFunctor/Dynamical/Refinement.lean`](../../PolyFun/PFunctor/Dynamical/Refinement.lean) | Operational `DynSystem.ForwardSimulation` between bare systems, with `mapRun` and its transport lemmas; `SafetyRefinement` extends it with initial-state coverage, assumption preservation, and safety reflection; `ReverseSafetyRefinement` / `MutualSafetyRefinement` package one- and two-way safety refinement; `ForwardSimulation.ofIsSimulation` embeds `IsSimulation` at `StepRel.sync`. Instantiated by the concurrent refinement layers. |
+| [`PolyFun/PFunctor/Dynamical/Responder.lean`](../../PolyFun/PFunctor/Dynamical/Responder.lean) | `Responder S q := DynSystem S (q ⊸ X)`: state systems whose positions are committed answer-sections (`committed` / `answer` / `next`); the Kleisli–Mealy `equivStateHandler : Responder S q ≃ Handler (StateT S Id) q` with `rfl` round-trips. |
+| [`PolyFun/PFunctor/Dynamical/Game.lean`](../../PolyFun/PFunctor/Dynamical/Game.lean) | Game wiring: `DynSystem.game := wire₂ (Lens.eval q r)` and its autonomous `closedGame`, `game_eq_uncurry` (the adjunction reading); monadic runs `kleisliStep` / `kleisliIterate` / `stepWith` / `iterWith`; two-phase `Lens.eval₂` / `orderPair` / `game₂` (Eq 6.86 / Ex 6.85). |
 | [`PolyFun/ITree/Unfold.lean`](../../PolyFun/ITree/Unfold.lean) | `DynSystem.toITree`: unfold a dynamical system into an all-query interaction tree; `M.toITree` embeds behaviour trees. |
 | [`PolyFunTest/PFunctor/Dynamical/Examples.lean`](../../PolyFunTest/PFunctor/Dynamical/Examples.lean) | Worked examples / regression tests (counter, parity automaton, mode-dependent `gate`, feedback / stream behaviour, the `univ`-system `toggle`, generic runs, `choiceProd`, behaviour / ITree unfolding). |
 
@@ -113,8 +122,10 @@ provides the reusable monad / comonad / coalgebra plumbing. See
   type of well-founded `P`-branching trees with `α`-leaves. It is the
   syntax of "programs" in the signature `P`.
 - `CofreeC P` is the cofree comonad on `P`. Coinductively, it is the
-  type of infinite, fully-decorated `P`-trees. It is the patterns/matter
-  pairing `FreeM ⊣ Cofree` from Spivak-Niu.
+  type of infinite, fully-decorated `P`-trees. `FreeM` and `CofreeC` carry
+  the pattern-runs-on-matter *module structure* of Libkind–Spivak (a module
+  action, not an adjunction); PolyFun formalizes `LawfulMonad (FreeM P)` and
+  `LawfulComonad (CofreeC F)` separately.
 - `Lens P Q` and `Chart P Q` are the two natural categorical morphisms
   between polynomial functors. Lenses go `forward on positions, backward
   on directions`; charts go forward on both. Both categories are useful

--- a/docs/wiki/repo-map.md
+++ b/docs/wiki/repo-map.md
@@ -45,10 +45,18 @@ PFunctor/{Basic, Bound, M, Equiv, Chart, Lens}
 Logic/HEq, Control/{Coalgebra, Comonad, Lawful, Monad}
   (free-standing helpers, depended on by both PFunctor and ITree)
 
+PFunctor/Lens/{Basic, Cartesian, State}
+  -> PFunctor/Lens/{Composite, Distributivity, Factorization, Duoidal}
+  -> PFunctor/{InternalHom, CartesianClosed, Adjunctions, Comonoid}
+
 PFunctor/{Lens, Cofree, M} + Control/Coalgebra
-  -> PFunctor/Dynamical/{Basic, Safety, Combinators, Responder, Game,
-                         Run, Trajectory}
-  -> PFunctor/Dynamical/Behavior
+  -> PFunctor/Dynamical/{Basic, Safety, Combinators, Run, Speedup, Trajectory}
+  -> PFunctor/Dynamical/{Behavior, Simulation, RunN, PointedMachine}
+  -> PFunctor/Dynamical/{Refinement, Responder, Game}
+
+  (Dynamical also draws on PFunctor/Comonoid and PFunctor/Free/Basic
+   for RunN and PointedMachine, PFunctor/InternalHom for Responder, and
+   PFunctor/Lens/Duoidal for Game.)
 
 PFunctor/Free -> ITree/{Basic, Construct, Handler, Rec,
                         Events, Sim, Bisim}
@@ -60,8 +68,10 @@ PFunctor/Free + Control -> Interaction/Basic/{Spec, Node, Decoration,
                             Telescope, Sampler, MonadDecoration,
                             BundledMonad, Ownership, SpecFintype}
 
-Interaction/Basic + PFunctor/Dynamical
-  -> Interaction/{TwoParty, Multiparty, Concurrent}
+Interaction/Basic -> Interaction/{TwoParty, Multiparty}
+Interaction/Basic + PFunctor/Dynamical -> Interaction/Concurrent
+  (concurrent processes and machines are dynamical systems over their step
+   polynomials; TwoParty/Multiparty do not depend on PFunctor/Dynamical)
 
 Interaction/{Concurrent, Basic} -> Interaction/UC/{Interface,
                                    OpenProcess, OpenProcessModel,


### PR DESCRIPTION
First of a three-PR **regroup & remediation** stack on top of the current PR stack (#15–#22), from a read-only duplication/debt/integration audit. Docs-and-docstrings only; build/lint/test unaffected.

## What

- **Citations & slogan.** Drop the mathematically-wrong `FreeM ⊣ Cofree` *adjunction* slogan in favour of the Libkind–Spivak *module-structure* wording (the formalized facts are `LawfulMonad (FreeM P)` and `LawfulComonad (CofreeC F)` separately), and correct the book citation to **Cambridge University Press, LMS Lecture Note Series 498, 2025** — across `Interaction/Basic/Spec.lean`, `REFERENCES.md`, `AGENTS.md`/`CLAUDE.md`, and `docs/wiki/pfunctor.md`. Resolves `corrections.md` items 1 & 7; logs the newly-found arXiv-id/subtitle inconsistency (`2202.00534` / "A Mathematical Theory" vs `2312.00990` / "A General Theory") as **open item 8** rather than guessing a fix.
- **Docstring accuracy.** Soften `Comonoid.comultN`'s unbacked "canonical (Prop 7.20)" claim (only the `rfl` unfolders exist); drop the false "used pervasively" note in `Adjunctions.lean`; acknowledge the unconsumed Spivak–Niu book-completeness lemmas (Adjunctions, CartesianClosed, Duoidal catalogue, `IsStateSystem`) as **reference API** so they don't read as accidental dead code.
- **DAG + index sync.** Bring **both** module-DAG copies (`AGENTS.md`, `docs/wiki/repo-map.md`) up to date with the new lens-algebra / Dynamical modules, correct the Dynamical prerequisite set, and **scope the "processes and machines are dynamical systems" edge to `Concurrent`** (TwoParty/Multiparty do not import `PFunctor/Dynamical`). Add the 9 missing file rows to `pfunctor.md`.

## Not in scope

Deferred math (fuel-exact `bind`, `comultN` canonicity, `curryEquiv`) and the systemic arXiv/subtitle sweep (tracked as corrections item 8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)