### PR TITLE
test(dynamical): cover safety metadata and run simulation

### DIFF
--- a/PolyFun/Interaction/Concurrent/Equivalence.lean
+++ b/PolyFun/Interaction/Concurrent/Equivalence.lean
@@ -26,6 +26,12 @@ provides their `refl`, `symm`, and `trans` operations, and records the immediate
 preservation lemmas for finite run prefixes. Trace and ticket transitivity use
 one shared map on the intermediate system, making the compared observation
 type explicit rather than hiding a change of representation.
+
+Each `*_eq` preservation lemma is a thin equivalence-level wrapper around the
+generic simulation-level `DynSystem.ForwardSimulation.*_mapRun`, specialized at
+`equiv.forth`. Keeping the packaged form lets protocol proofs transport
+observations directly from an equivalence without first projecting a forward
+simulation.
 -/
 
 universe u v w

--- a/PolyFunTest/PFunctor/Dynamical/SafetyExamples.lean
+++ b/PolyFunTest/PFunctor/Dynamical/SafetyExamples.lean
@@ -1,0 +1,78 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+module
+
+public import PolyFun.PFunctor.Dynamical.Safety
+
+/-!
+# Examples for safety metadata and concrete-step relations
+
+Regression tests for the metadata deliberately kept outside `DynSystem`:
+`SafetySpec`, `Labeled`, `Ticketed`, and the basic `StepRel` operations.
+-/
+
+@[expose] public section
+
+namespace PFunctor
+namespace DynSystem.Examples
+
+/-- A two-state system over the terminal interface. -/
+def toggle : DynSystem Bool X.{0, 0} :=
+  DynSystem.mk' (fun _ => PUnit.unit) (fun state _ => !state)
+
+/-- A safety problem with one initial state and default-true policy predicates. -/
+def toggleSafety : DynSystem.SafetySpec X.{0, 0} where
+  State := Bool
+  toDynSystem := toggle
+  init state := state = false
+
+example : toggleSafety.init false := rfl
+example (state : Bool) : toggleSafety.assumptions state := trivial
+example (state : Bool) : toggleSafety.safe state := trivial
+example (state : Bool) : toggleSafety.expose state = toggle.expose state := rfl
+example (state : Bool) : toggleSafety.update state PUnit.unit = !state := rfl
+
+/-- Event labels may expose stable information about the source transition. -/
+def toggleLabeled : DynSystem.Labeled X.{0, 0} where
+  State := Bool
+  toDynSystem := toggle
+  Event := Bool
+  event state _ := state
+
+example (state : Bool) : toggleLabeled.event state PUnit.unit = state := rfl
+
+/-- Tickets may identify scheduling obligations independently of directions. -/
+def toggleTicketed : DynSystem.Ticketed X.{0, 0} where
+  State := Bool
+  toDynSystem := toggle
+  Ticket := Unit
+  ticket _ _ := ()
+
+example (state : Bool) : toggleTicketed.ticket state PUnit.unit = () := rfl
+
+section StepRelations
+
+variable {S₁ S₂ : Type} {p₁ p₂ : PFunctor.{0, 0}}
+  {system₁ : DynSystem S₁ p₁} {system₂ : DynSystem S₂ p₂}
+
+example (rel : DynSystem.StepRel system₁ system₂)
+    (step₁ : system₁.Step) (step₂ : system₂.Step) :
+    DynSystem.StepRel.reverse rel step₂ step₁ ↔ rel step₁ step₂ := Iff.rfl
+
+example (first second : DynSystem.StepRel system₁ system₂)
+    (step₁ : system₁.Step) (step₂ : system₂.Step) :
+    DynSystem.StepRel.inter first second step₁ step₂ ↔
+      first step₁ step₂ ∧ second step₁ step₂ := Iff.rfl
+
+end StepRelations
+
+/-- Synchronized matching relates a concrete step to itself. -/
+example (state : Bool) :
+    DynSystem.StepRel.sync toggle toggle ⟨state, PUnit.unit⟩ ⟨state, PUnit.unit⟩ :=
+  ⟨rfl, HEq.rfl⟩
+
+end DynSystem.Examples
+end PFunctor

--- a/PolyFunTest/PFunctor/Dynamical/SimulationExamples.lean
+++ b/PolyFunTest/PFunctor/Dynamical/SimulationExamples.lean
@@ -67,6 +67,29 @@ example (D : DynSystem S p) :
     DynSystem.ForwardSimulation D D (DynSystem.StepRel.sync D D) :=
   DynSystem.ForwardSimulation.ofIsSimulation (idSim D)
 
+/-- Every dynamical system operationally simulates itself. -/
+def selfSimulation (D : DynSystem S p) : DynSystem.ForwardSimulation D D :=
+  DynSystem.ForwardSimulation.reflTop D
+
+/-- Mapping a run preserves the simulation relation at every step. -/
+example {SImpl SSpec : Type u} {impl : DynSystem SImpl p} {spec : DynSystem SSpec p}
+    {matchStep : DynSystem.StepRel impl spec}
+    (sim : DynSystem.ForwardSimulation impl spec matchStep)
+    (run : DynSystem.Run impl) {initialSpec : SSpec}
+    (hrel : sim.stateRel run.initial initialSpec) (n : ℕ) :
+    sim.stateRel (run.state n) ((sim.mapRun run hrel).state n) :=
+  sim.stateRel_mapRun run hrel n
+
+/-- The mapped run also satisfies the requested concrete-step relation. -/
+example {SImpl SSpec : Type u} {impl : DynSystem SImpl p} {spec : DynSystem SSpec p}
+    {matchStep : DynSystem.StepRel impl spec}
+    (sim : DynSystem.ForwardSimulation impl spec matchStep)
+    (run : DynSystem.Run impl) {initialSpec : SSpec}
+    (hrel : sim.stateRel run.initial initialSpec) (n : ℕ) :
+    matchStep ⟨run.state n, run.dir n⟩
+      ⟨(sim.mapRun run hrel).state n, (sim.mapRun run hrel).dir n⟩ :=
+  sim.match_mapRun run hrel n
+
 /-- The same synchronized simulation lifts to safety refinement once the three
 verification-policy obligations are supplied. -/
 example (D : DynSystem S p) :


### PR DESCRIPTION
## What changed

- Add focused examples for `SafetySpec`, `Labeled`, `Ticketed`, and the current concrete-step `StepRel` algebra.
- Exercise `ForwardSimulation.reflTop` and both run-transport guarantees, `stateRel_mapRun` and `match_mapRun`.
- Explain why Concurrent equivalence keeps its convenient `*_eq` wrappers over the generic simulation transport API.

## Removed from the old stack

- Responder coverage moved down to PR #20 and has already merged.
- The stale `System` / `DirRel` examples were ported to `SafetySpec` / `StepRel`; no compatibility layer is restored.
- The duplicate composition memo commit is dropped because its content already landed in PR #26.
- The roadmap entry describing the old stack topology and the rejected Simulation-file merge is dropped.

## Validation

- `lake test`
- `lake exe lint-style`
- `./scripts/check-imports.sh`
- `python3 ./scripts/check-docs-integrity.py`