### PR TITLE
refactor(pfunctor): streamline lens constructions

### DIFF
--- a/PolyFun/PFunctor/Adjunctions.lean
+++ b/PolyFun/PFunctor/Adjunctions.lean
@@ -89,7 +89,7 @@ lens `X ⇆ p` picks a single position of `p` via `toFunA PUnit.unit`, and its
 `toFunB` is forced (every direction of `X` is `PUnit.unit`). -/
 def homFromX : Lens X.{uA₁, uB₁} p ≃ p.A where
   toFun l := l.toFunA PUnit.unit
-  invFun a := (fun _ => a) ⇆ (fun _ _ => PUnit.unit)
+  invFun := Lens.fromX
   left_inv _ := rfl
   right_inv _ := rfl
 
@@ -98,7 +98,7 @@ def homFromX : Lens X.{uA₁, uB₁} p ≃ p.A where
 positions `p.A → A`; its backward map is forced since `C A` has no directions. -/
 def homToConst {A : Type uA₂} : Lens p (C A : PFunctor.{uA₂, uB₁}) ≃ (p.A → A) where
   toFun l := l.toFunA
-  invFun f := f ⇆ (fun _ => PEmpty.elim)
+  invFun := Lens.toConst
   left_inv l := by
     refine Lens.ext _ _ (fun a => rfl) (fun a => ?_)
     funext d
@@ -113,7 +113,7 @@ of `p`. -/
 def homToLinear {A : Type uA₂} :
     Lens p (linear A : PFunctor.{uA₂, uB₁}) ≃ ((p.A → A) × ((a : p.A) → p.B a)) where
   toFun l := (l.toFunA, fun a => l.toFunB a PUnit.unit)
-  invFun fg := fg.1 ⇆ (fun a _ => fg.2 a)
+  invFun fg := Lens.toLinear fg.1 fg.2
   left_inv _ := rfl
   right_inv _ := rfl
 

--- a/PolyFun/PFunctor/Chart/Basic.lean
+++ b/PolyFun/PFunctor/Chart/Basic.lean
@@ -178,30 +178,28 @@ construction. -/
 /-- Left injection chart `inl : P → P + Q`. -/
 def inl {P : PFunctor.{uA₁, uB}} {Q : PFunctor.{uA₂, uB}} :
     Chart.{uA₁, uB, max uA₁ uA₂, uB} P (P + Q) :=
-  Sum.inl ⇉ (fun _ d => d)
+  Sum.inl ⇉ fun _ => id
 
 /-- Right injection chart `inr : Q → P + Q`. -/
 def inr {P : PFunctor.{uA₁, uB}} {Q : PFunctor.{uA₂, uB}} :
     Chart.{uA₂, uB, max uA₁ uA₂, uB} Q (P + Q) :=
-  Sum.inr ⇉ (fun _ d => d)
+  Sum.inr ⇉ fun _ => id
 
 /-- Copairing of charts `[c₁, c₂]c : P + Q → R`. -/
 def sumPair {P : PFunctor.{uA₁, uB}} {Q : PFunctor.{uA₂, uB}} {R : PFunctor.{uA₃, uB₃}}
     (c₁ : Chart P R) (c₂ : Chart Q R) :
     Chart.{max uA₁ uA₂, uB, uA₃, uB₃} (P + Q) R :=
-  (Sum.elim c₁.toFunA c₂.toFunA) ⇉
-    (fun a d => match a with
-      | Sum.inl pa => c₁.toFunB pa d
-      | Sum.inr qa => c₂.toFunB qa d)
+  Sum.elim c₁.toFunA c₂.toFunA ⇉ fun
+    | .inl pa => c₁.toFunB pa
+    | .inr qa => c₂.toFunB qa
 
 /-- Parallel application of charts for coproduct `c₁ ⊎c c₂ : P + Q → R + W`. -/
 def sumMap {P : PFunctor.{uA₁, uB₁}} {Q : PFunctor.{uA₂, uB₁}} {R : PFunctor.{uA₃, uB₃}}
     {W : PFunctor.{uA₄, uB₃}} (c₁ : Chart P R) (c₂ : Chart Q W) :
     Chart.{max uA₁ uA₂, uB₁, max uA₃ uA₄, uB₃} (P + Q) (R + W) :=
-  (Sum.map c₁.toFunA c₂.toFunA) ⇉
-    (fun psum => match psum with
-      | Sum.inl pa => c₁.toFunB pa
-      | Sum.inr qa => c₂.toFunB qa)
+  Sum.map c₁.toFunA c₂.toFunA ⇉ fun
+    | .inl pa => c₁.toFunB pa
+    | .inr qa => c₂.toFunB qa
 
 /-! ### Tensor (`⊗`) — the chart category's binary product
 
@@ -230,8 +228,8 @@ def tensorPair {P : PFunctor.{uA₁, uB₁}} {Q : PFunctor.{uA₂, uB₂}} {R : 
 def tensorMap {P : PFunctor.{uA₁, uB₁}} {Q : PFunctor.{uA₂, uB₂}} {R : PFunctor.{uA₃, uB₃}}
     {W : PFunctor.{uA₄, uB₄}} (c₁ : Chart P R) (c₂ : Chart Q W) :
     Chart.{max uA₁ uA₂, max uB₁ uB₂, max uA₃ uA₄, max uB₃ uB₄} (P ⊗ Q) (R ⊗ W) :=
-  (Prod.map c₁.toFunA c₂.toFunA) ⇉
-    (fun pq pb => (c₁.toFunB pq.1 pb.1, c₂.toFunB pq.2 pb.2))
+  Prod.map c₁.toFunA c₂.toFunA ⇉
+    fun (pa, qa) => Prod.map (c₁.toFunB pa) (c₂.toFunB qa)
 
 /-! ### Polynomial product (`*`) — *not* the chart categorical product
 
@@ -246,10 +244,8 @@ For categorical projections / pairing, use `⊗` instead. -/
 def prodMap {P : PFunctor.{uA₁, uB₁}} {Q : PFunctor.{uA₂, uB₂}} {R : PFunctor.{uA₃, uB₃}}
     {W : PFunctor.{uA₄, uB₄}} (c₁ : Chart P R) (c₂ : Chart Q W) :
     Chart.{max uA₁ uA₂, max uB₁ uB₂, max uA₃ uA₄, max uB₃ uB₄} (P * Q) (R * W) :=
-  (Prod.map c₁.toFunA c₂.toFunA) ⇉
-    (fun pq psum => match psum with
-      | Sum.inl pb => Sum.inl (c₁.toFunB pq.1 pb)
-      | Sum.inr qb => Sum.inr (c₂.toFunB pq.2 qb))
+  Prod.map c₁.toFunA c₂.toFunA ⇉
+    fun (pa, qa) => Sum.map (c₁.toFunB pa) (c₂.toFunB qa)
 
 /-! ### Indexed colimits and limits
 
@@ -537,15 +533,15 @@ def xTensor : X ⊗ P ≃c P where
 
 /-- Tensor product with `0` is zero (left) -/
 def zeroTensor : 0 ⊗ P ≃c 0 where
-  toChart := (fun a => PEmpty.elim a.1) ⇉ (fun a _ => PEmpty.elim a.1)
-  invChart := PEmpty.elim ⇉ (fun a _ => PEmpty.elim a)
+  toChart := (fun a => PEmpty.elim a.1) ⇉ fun a => PEmpty.elim a.1
+  invChart := PEmpty.elim ⇉ fun a => PEmpty.elim a
   left_inv := by ext ⟨a, _⟩ <;> exact PEmpty.elim a
   right_inv := by ext a <;> exact PEmpty.elim a
 
 /-- Tensor product with `0` is zero (right) -/
 def tensorZero : P ⊗ 0 ≃c 0 where
-  toChart := (fun a => PEmpty.elim a.2) ⇉ (fun a _ => PEmpty.elim a.2)
-  invChart := PEmpty.elim ⇉ (fun a _ => PEmpty.elim a)
+  toChart := (fun a => PEmpty.elim a.2) ⇉ fun a => PEmpty.elim a.2
+  invChart := PEmpty.elim ⇉ fun a => PEmpty.elim a
   left_inv := by ext ⟨_, b⟩ <;> exact PEmpty.elim b
   right_inv := by ext a <;> exact PEmpty.elim a
 
@@ -570,28 +566,12 @@ def tensorCongr {P : PFunctor.{uA₁, uB₁}} {Q : PFunctor.{uA₂, uB₂}}
 def tensorSumDistrib {P : PFunctor.{uA₁, uB₁}} {Q R : PFunctor.{uA₂, uB₂}} :
     Chart.Equiv.{max uA₁ uA₂, max uB₁ uB₂, max uA₁ uA₂, max uB₁ uB₂}
       (P ⊗ (Q + R)) ((P ⊗ Q) + (P ⊗ R)) where
-  toChart :=
-    (fun ⟨p, qr⟩ => match qr with
-      | Sum.inl q => Sum.inl (p, q)
-      | Sum.inr r => Sum.inr (p, r)) ⇉
-    (fun ⟨_, qr⟩ pb => match qr with
-      | Sum.inl _ => pb
-      | Sum.inr _ => pb)
-  invChart :=
-    (Sum.elim
-      (fun ⟨p, q⟩ => (p, Sum.inl q))
-      (fun ⟨p, r⟩ => (p, Sum.inr r))) ⇉
-    (fun pqpr pb => match pqpr with
-      | Sum.inl _ => pb
-      | Sum.inr _ => pb)
-  left_inv := by
-    refine Chart.ext _ _ ?_ ?_
-    · intro a; rcases a with ⟨_, _ | _⟩ <;> rfl
-    · intro a; funext _; rcases a with ⟨_, _ | _⟩ <;> rfl
-  right_inv := by
-    refine Chart.ext _ _ ?_ ?_
-    · intro a; rcases a <;> rfl
-    · intro a; funext _; rcases a <;> rfl
+  toChart := (fun (p, qr) => qr.map (p, ·) (p, ·)) ⇉
+    (fun | ⟨_, .inl _⟩ | ⟨_, .inr _⟩ => id)
+  invChart := Sum.elim (Prod.map id Sum.inl) (Prod.map id Sum.inr) ⇉
+    (fun | .inl _ | .inr _ => id)
+  left_inv := by ext ⟨_, qr⟩ <;> cases qr <;> rfl
+  right_inv := by ext pqpr <;> cases pqpr <;> rfl
 
 /-- Right distributivity of tensor product over coproduct.
 
@@ -599,28 +579,12 @@ def tensorSumDistrib {P : PFunctor.{uA₁, uB₁}} {Q R : PFunctor.{uA₂, uB₂
 def sumTensorDistrib {P : PFunctor.{uA₁, uB₁}} {Q R : PFunctor.{uA₂, uB₂}} :
     Chart.Equiv.{max uA₁ uA₂, max uB₁ uB₂, max uA₁ uA₂, max uB₁ uB₂}
       ((Q + R) ⊗ P) ((Q ⊗ P) + (R ⊗ P)) where
-  toChart :=
-    (fun ⟨qr, p⟩ => match qr with
-      | Sum.inl q => Sum.inl (q, p)
-      | Sum.inr r => Sum.inr (r, p)) ⇉
-    (fun ⟨qr, _⟩ pb => match qr with
-      | Sum.inl _ => pb
-      | Sum.inr _ => pb)
-  invChart :=
-    (Sum.elim
-      (fun ⟨q, p⟩ => (Sum.inl q, p))
-      (fun ⟨r, p⟩ => (Sum.inr r, p))) ⇉
-    (fun qprp pb => match qprp with
-      | Sum.inl _ => pb
-      | Sum.inr _ => pb)
-  left_inv := by
-    refine Chart.ext _ _ ?_ ?_
-    · intro a; rcases a with ⟨_ | _, _⟩ <;> rfl
-    · intro a; funext _; rcases a with ⟨_ | _, _⟩ <;> rfl
-  right_inv := by
-    refine Chart.ext _ _ ?_ ?_
-    · intro a; rcases a <;> rfl
-    · intro a; funext _; rcases a <;> rfl
+  toChart := (fun (qr, p) => qr.map (·, p) (·, p)) ⇉
+    (fun | ⟨.inl _, _⟩ | ⟨.inr _, _⟩ => id)
+  invChart := Sum.elim (Prod.map Sum.inl id) (Prod.map Sum.inr id) ⇉
+    (fun | .inl _ | .inr _ => id)
+  left_inv := by ext ⟨qr, _⟩ <;> cases qr <;> rfl
+  right_inv := by ext qprp <;> cases qprp <;> rfl
 
 end Equiv
 
@@ -670,8 +634,8 @@ def prodCongr {P : PFunctor.{uA₁, uB₁}} {Q : PFunctor.{uA₂, uB₂}}
 /-- Commutativity of the polynomial product. -/
 def prodComm (P : PFunctor.{uA₁, uB₁}) (Q : PFunctor.{uA₂, uB₂}) :
     Chart.Equiv.{max uA₁ uA₂, max uB₁ uB₂, max uA₁ uA₂, max uB₁ uB₂} (P * Q) (Q * P) where
-  toChart := Prod.swap ⇉ (fun _ d => d.swap)
-  invChart := Prod.swap ⇉ (fun _ d => d.swap)
+  toChart := Prod.swap ⇉ fun _ => Sum.swap
+  invChart := Prod.swap ⇉ fun _ => Sum.swap
   left_inv := by
     refine Chart.ext _ _ ?_ ?_
     · intro _; rfl
@@ -686,9 +650,9 @@ def prodAssoc :
     Chart.Equiv.{max uA₁ uA₂ uA₃, max uB₁ uB₂ uB₃, max uA₁ uA₂ uA₃, max uB₁ uB₂ uB₃}
       ((P * Q) * R) (P * (Q * R)) where
   toChart := (_root_.Equiv.prodAssoc _ _ _).toFun ⇉
-    (fun _ d => (_root_.Equiv.sumAssoc _ _ _).toFun d)
+    (fun _ => (_root_.Equiv.sumAssoc _ _ _).toFun)
   invChart := (_root_.Equiv.prodAssoc _ _ _).invFun ⇉
-    (fun _ d => (_root_.Equiv.sumAssoc _ _ _).invFun d)
+    (fun _ => (_root_.Equiv.sumAssoc _ _ _).invFun)
   left_inv := by
     refine Chart.ext _ _ ?_ ?_
     · intro _; rfl
@@ -704,15 +668,15 @@ def prodAssoc :
 
 /-- Polynomial-product with `0` is `0` (right). -/
 def prodZero : P * 0 ≃c 0 where
-  toChart := (fun a => PEmpty.elim a.2) ⇉ (fun a _ => PEmpty.elim a.2)
-  invChart := PEmpty.elim ⇉ (fun a _ => PEmpty.elim a)
+  toChart := (fun a => PEmpty.elim a.2) ⇉ fun a => PEmpty.elim a.2
+  invChart := PEmpty.elim ⇉ fun a => PEmpty.elim a
   left_inv := by ext ⟨_, b⟩ <;> exact PEmpty.elim b
   right_inv := by ext a <;> exact PEmpty.elim a
 
 /-- Polynomial-product with `0` is `0` (left). -/
 def zeroProd : 0 * P ≃c 0 where
-  toChart := (fun a => PEmpty.elim a.1) ⇉ (fun a _ => PEmpty.elim a.1)
-  invChart := PEmpty.elim ⇉ (fun a _ => PEmpty.elim a)
+  toChart := (fun a => PEmpty.elim a.1) ⇉ fun a => PEmpty.elim a.1
+  invChart := PEmpty.elim ⇉ fun a => PEmpty.elim a
   left_inv := by ext ⟨a, _⟩ <;> exact PEmpty.elim a
   right_inv := by ext a <;> exact PEmpty.elim a
 
@@ -722,34 +686,12 @@ def zeroProd : 0 * P ≃c 0 where
 def prodSumDistrib {P : PFunctor.{uA₁, uB₁}} {Q R : PFunctor.{uA₂, uB₂}} :
     Chart.Equiv.{max uA₁ uA₂, max uB₁ uB₂, max uA₁ uA₂, max uB₁ uB₂}
       (P * (Q + R)) ((P * Q) + (P * R)) where
-  toChart :=
-    (fun ⟨p, qr⟩ => match qr with
-      | Sum.inl q => Sum.inl (p, q)
-      | Sum.inr r => Sum.inr (p, r)) ⇉
-    (fun ⟨_, qr⟩ d => match qr, d with
-      | Sum.inl _, Sum.inl pb => Sum.inl pb
-      | Sum.inl _, Sum.inr qb => Sum.inr qb
-      | Sum.inr _, Sum.inl pb => Sum.inl pb
-      | Sum.inr _, Sum.inr rb => Sum.inr rb)
-  invChart :=
-    (Sum.elim
-      (fun ⟨p, q⟩ => (p, Sum.inl q))
-      (fun ⟨p, r⟩ => (p, Sum.inr r))) ⇉
-    (fun pqpr d => match pqpr, d with
-      | Sum.inl _, Sum.inl pb => Sum.inl pb
-      | Sum.inl _, Sum.inr qb => Sum.inr qb
-      | Sum.inr _, Sum.inl pb => Sum.inl pb
-      | Sum.inr _, Sum.inr rb => Sum.inr rb)
-  left_inv := by
-    refine Chart.ext _ _ ?_ ?_
-    · intro a; rcases a with ⟨_, _ | _⟩ <;> rfl
-    · intro a; funext d
-      rcases a with ⟨_, _ | _⟩ <;> rcases d <;> rfl
-  right_inv := by
-    refine Chart.ext _ _ ?_ ?_
-    · intro a; rcases a <;> rfl
-    · intro a; funext d
-      rcases a <;> rcases d <;> rfl
+  toChart := (fun (p, qr) => qr.map (p, ·) (p, ·)) ⇉
+    (fun | ⟨_, .inl _⟩ | ⟨_, .inr _⟩ => id)
+  invChart := Sum.elim (Prod.map id Sum.inl) (Prod.map id Sum.inr) ⇉
+    (fun | .inl _ | .inr _ => id)
+  left_inv := by ext ⟨_, qr⟩ <;> cases qr <;> rfl
+  right_inv := by ext pqpr <;> cases pqpr <;> rfl
 
 /-- Right distributivity of polynomial product over coproduct.
 
@@ -757,34 +699,12 @@ def prodSumDistrib {P : PFunctor.{uA₁, uB₁}} {Q R : PFunctor.{uA₂, uB₂}}
 def sumProdDistrib {P : PFunctor.{uA₁, uB₁}} {Q R : PFunctor.{uA₂, uB₂}} :
     Chart.Equiv.{max uA₁ uA₂, max uB₁ uB₂, max uA₁ uA₂, max uB₁ uB₂}
       ((Q + R) * P) ((Q * P) + (R * P)) where
-  toChart :=
-    (fun ⟨qr, p⟩ => match qr with
-      | Sum.inl q => Sum.inl (q, p)
-      | Sum.inr r => Sum.inr (r, p)) ⇉
-    (fun ⟨qr, _⟩ d => match qr, d with
-      | Sum.inl _, Sum.inl qb => Sum.inl qb
-      | Sum.inl _, Sum.inr pb => Sum.inr pb
-      | Sum.inr _, Sum.inl rb => Sum.inl rb
-      | Sum.inr _, Sum.inr pb => Sum.inr pb)
-  invChart :=
-    (Sum.elim
-      (fun ⟨q, p⟩ => (Sum.inl q, p))
-      (fun ⟨r, p⟩ => (Sum.inr r, p))) ⇉
-    (fun qprp d => match qprp, d with
-      | Sum.inl _, Sum.inl qb => Sum.inl qb
-      | Sum.inl _, Sum.inr pb => Sum.inr pb
-      | Sum.inr _, Sum.inl rb => Sum.inl rb
-      | Sum.inr _, Sum.inr pb => Sum.inr pb)
-  left_inv := by
-    refine Chart.ext _ _ ?_ ?_
-    · intro a; rcases a with ⟨_ | _, _⟩ <;> rfl
-    · intro a; funext d
-      rcases a with ⟨_ | _, _⟩ <;> rcases d <;> rfl
-  right_inv := by
-    refine Chart.ext _ _ ?_ ?_
-    · intro a; rcases a <;> rfl
-    · intro a; funext d
-      rcases a <;> rcases d <;> rfl
+  toChart := (fun (qr, p) => qr.map (·, p) (·, p)) ⇉
+    (fun | ⟨.inl _, _⟩ | ⟨.inr _, _⟩ => id)
+  invChart := Sum.elim (Prod.map Sum.inl id) (Prod.map Sum.inr id) ⇉
+    (fun | .inl _ | .inr _ => id)
+  left_inv := by ext ⟨qr, _⟩ <;> cases qr <;> rfl
+  right_inv := by ext qprp <;> cases qprp <;> rfl
 
 end Equiv
 
@@ -945,8 +865,8 @@ def piZero [Inhabited I] {F : I → PFunctor.{uA, uB}} (F_zero : ∀ i, F i = 0)
     rw [F_zero (default : I)] at hf
     exact hf.elim
   refine
-    { toChart := isEmptyElim ⇉ (fun a _ => isEmptyElim a)
-      invChart := PEmpty.elim ⇉ (fun a _ => PEmpty.elim a)
+    { toChart := isEmptyElim ⇉ fun a => isEmptyElim a
+      invChart := PEmpty.elim ⇉ fun a => PEmpty.elim a
       left_inv := by
         refine Chart.ext _ _ ?_ ?_
         · intro a; exact isEmptyElim a

--- a/PolyFun/PFunctor/Dynamical/Basic.lean
+++ b/PolyFun/PFunctor/Dynamical/Basic.lean
@@ -333,7 +333,7 @@ abbrev Section (p : PFunctor.{uA, uB}) : Type _ := Lens p X.{uA, uB}
 /-- The section `p ⟹ X` picking the direction `σ a` at each position `a`. Unpacking
 a `Section p`, the position map is trivial and the direction map is `σ`. -/
 def sectionLens {p : PFunctor.{uA, uB}} (σ : (a : p.A) → p.B a) : Section p :=
-  (fun _ => PUnit.unit) ⇆ (fun a _ => σ a)
+  Lens.toLinear (fun _ => PUnit.unit) σ
 
 /-- A **closed** dynamical system on states `S` is an `X`-system: its interface is
 the composition unit, so the dynamics reduce to a pure state endofunction. -/

--- a/PolyFun/PFunctor/Dynamical/Combinators.lean
+++ b/PolyFun/PFunctor/Dynamical/Combinators.lean
@@ -129,8 +129,8 @@ interleaves them one step at a time; scheduled interleavings of processes are
 wrappers of this combinator. -/
 def choiceProd (s : DynSystem S p) (t : DynSystem T q) :
     DynSystem (S × T) (prod p q) :=
-  (fun st => (s.expose st.1, t.expose st.2)) ⇆ fun st =>
-    Sum.elim (fun d => (s.update st.1 d, st.2)) (fun d => (st.1, t.update st.2 d))
+  Prod.map s.expose t.expose ⇆ fun (ss, ts) =>
+    Sum.elim (fun d => (s.update ss d, ts)) (fun d => (ss, t.update ts d))
 
 @[simp] theorem choiceProd_expose (s : DynSystem S p) (t : DynSystem T q) (st : S × T) :
     (s.choiceProd t).expose st = (s.expose st.1, t.expose st.2) := rfl

--- a/PolyFun/PFunctor/Dynamical/DynComputation.lean
+++ b/PolyFun/PFunctor/Dynamical/DynComputation.lean
@@ -57,7 +57,7 @@ def denote (M : DynComputation.{u} p α β) (input : α) : Resumption p β :=
 `C β`. -/
 def ofFn (f : α → β) : DynComputation.{uβ} p α β where
   State := β
-  toDynSystem := (fun value => Sum.inl value) ⇆ fun _ direction => PEmpty.elim direction
+  toDynSystem := Sum.inl ⇆ fun _ => PEmpty.elim
   init := f
 
 @[simp] theorem ofFn_State (f : α → β) : (ofFn (p := p) f).State = β := rfl

--- a/PolyFun/PFunctor/Dynamical/Responder.lean
+++ b/PolyFun/PFunctor/Dynamical/Responder.lean
@@ -95,7 +95,7 @@ the `X`-component is trivial. Definitional, by sigma and unit eta. -/
 
 /-- The stateless responder answering along a fixed section of `q`. -/
 def ofSection (σ : Section q) : Responder PUnit.{v + 1} q :=
-  (fun _ => σ) ⇆ (fun _ _ => PUnit.unit)
+  Lens.fromX σ
 
 @[simp] theorem committed_ofSection (σ : Section q) (s : PUnit.{v + 1}) :
     (ofSection σ).committed s = σ := rfl

--- a/PolyFun/PFunctor/Equiv/Basic.lean
+++ b/PolyFun/PFunctor/Equiv/Basic.lean
@@ -164,8 +164,8 @@ def sumProdDistrib (P : PFunctor.{uA₁, uB₁}) (Q : PFunctor.{uA₂, uB₁}) (
     ((P + Q) * R : PFunctor.{max uA₁ uA₂ uA₃, max uB₁ uB₂}) ≃ₚ
     ((P * R) + (Q * R) : PFunctor.{max uA₁ uA₂ uA₃, max uB₁ uB₂}) where
   equivA := _root_.Equiv.sumProdDistrib P.A Q.A R.A
-  equivB := fun ⟨a, _⟩ =>
-    Sum.casesOn a (fun _ => _root_.Equiv.refl _) (fun _ => _root_.Equiv.refl _)
+  equivB := fun
+    | ⟨.inl _, _⟩ | ⟨.inr _, _⟩ => _root_.Equiv.refl _
 
 /-- Product distributes over sum: `P * (Q + R) ≃ₚ (P * Q) + (P * R)`
 
@@ -175,8 +175,8 @@ def prodSumDistrib (R : PFunctor.{uA₃, uB₂}) :
     (P * (Q + R) : PFunctor.{max uA₁ uA₂ uA₃, max uB₁ uB₂}) ≃ₚ
     ((P * Q) + (P * R) : PFunctor.{max uA₁ uA₂ uA₃, max uB₁ uB₂}) where
   equivA := _root_.Equiv.prodSumDistrib P.A Q.A R.A
-  equivB := fun ⟨_, a⟩ =>
-    Sum.casesOn a (fun _ => _root_.Equiv.refl _) (fun _ => _root_.Equiv.refl _)
+  equivB := fun
+    | ⟨_, .inl _⟩ | ⟨_, .inr _⟩ => _root_.Equiv.refl _
 
 end Prod
 
@@ -602,16 +602,16 @@ def sumTensorDistrib (P : PFunctor.{uA₁, uB₁}) (Q : PFunctor.{uA₂, uB₁})
     ((P + Q : PFunctor.{max uA₁ uA₂, uB₁}) ⊗ R) ≃ₚ
     ((P ⊗ R) + (Q ⊗ R) : PFunctor.{max uA₁ uA₂ uA₃, max uB₁ uB₂}) where
   equivA := _root_.Equiv.sumProdDistrib P.A Q.A R.A
-  equivB := fun ⟨a, _⟩ =>
-    Sum.casesOn a (fun _ => _root_.Equiv.refl _) (fun _ => _root_.Equiv.refl _)
+  equivB := fun
+    | ⟨.inl _, _⟩ | ⟨.inr _, _⟩ => _root_.Equiv.refl _
 
 /-- Tensor product distributes over sum: `P ⊗ (Q + R) ≃ₚ (P ⊗ Q) + (P ⊗ R)` -/
 def tensorSumDistrib (R : PFunctor.{uA₃, uB₂}) :
     (P ⊗ (Q + R : PFunctor.{max uA₂ uA₃, uB₂})) ≃ₚ
     ((P ⊗ Q) + (P ⊗ R) : PFunctor.{max uA₁ uA₂ uA₃, max uB₁ uB₂}) where
   equivA := _root_.Equiv.prodSumDistrib P.A Q.A R.A
-  equivB := fun ⟨_, a⟩ =>
-    Sum.casesOn a (fun _ => _root_.Equiv.refl _) (fun _ => _root_.Equiv.refl _)
+  equivB := fun
+    | ⟨_, .inl _⟩ | ⟨_, .inr _⟩ => _root_.Equiv.refl _
 
 end Tensor
 

--- a/PolyFun/PFunctor/InternalHom.lean
+++ b/PolyFun/PFunctor/InternalHom.lean
@@ -63,8 +63,8 @@ variable {p : PFunctor.{pA, pB}} {q : PFunctor.{qA, qB}}
 back to the pair `(⟨j, d⟩, f.toFunB j d)`. -/
 def eval (q : PFunctor.{qA, qB}) (r : PFunctor.{rA, rB}) :
     Lens (ihom q r ⊗ q) r :=
-  (fun fj => fj.1.toFunA fj.2) ⇆
-    (fun fj d => (⟨fj.2, d⟩, fj.1.toFunB fj.2 d))
+  (fun (f, j) => f.toFunA j) ⇆
+    fun (f, j) d => (⟨j, d⟩, f.toFunB j d)
 
 /-- Currying: a lens `p ⊗ q ⇆ r` transposes to a lens `p ⇆ ihom q r`. This is
 the forward direction of the tensor–hom adjunction. -/
@@ -75,8 +75,8 @@ def curry (φ : Lens (p ⊗ q) r) : Lens p (ihom q r) :=
 /-- Uncurrying: a lens `p ⇆ ihom q r` transposes to a lens `p ⊗ q ⇆ r`. Inverse
 to `curry`. -/
 def uncurry (ψ : Lens p (ihom q r)) : Lens (p ⊗ q) r :=
-  (fun ij => (ψ.toFunA ij.1).toFunA ij.2) ⇆
-    (fun ij d => (ψ.toFunB ij.1 ⟨ij.2, d⟩, (ψ.toFunA ij.1).toFunB ij.2 d))
+  (fun (i, j) => (ψ.toFunA i).toFunA j) ⇆
+    fun (i, j) d => (ψ.toFunB i ⟨j, d⟩, (ψ.toFunA i).toFunB j d)
 
 /-- The tensor–hom adjunction as an equivalence of hom-sets:
 `Lens (p ⊗ q) r ≃ Lens p (ihom q r)`. -/
@@ -103,7 +103,7 @@ end Lens
 direction of `[y, r]` at that lens is a direction of `r`. -/
 def ihomX (r : PFunctor.{uA, uB}) : ihom X r ≃ₗ r where
   toLens := (fun f => f.toFunA PUnit.unit) ⇆ (fun _f d => ⟨PUnit.unit, d⟩)
-  invLens := (fun a => (fun _ => a) ⇆ (fun _ _ => PUnit.unit)) ⇆ (fun _ d => d.2)
+  invLens := Lens.fromX ⇆ fun _ ⟨_, d⟩ => d
   left_inv := rfl
   right_inv := rfl
 

--- a/PolyFun/PFunctor/Lens/Basic.lean
+++ b/PolyFun/PFunctor/Lens/Basic.lean
@@ -122,38 +122,73 @@ def initial {P : PFunctor.{uA, uB}} : Lens 0 P :=
 
 /-- The (unique) terminal lens from any functor `P` to the unit functor `1`. -/
 def terminal {P : PFunctor.{uA, uB}} : Lens P 1 :=
-  (fun _ => PUnit.unit) ⇆ (fun _ => PEmpty.elim)
+  (fun _ => PUnit.unit) ⇆ fun _ => PEmpty.elim
 
 alias fromZero := initial
 alias toOne := terminal
 
+/-- Construct a lens from the variable polynomial by selecting a position. The
+backward map is uniquely determined by the unit direction of `X`. -/
+def fromX {P : PFunctor.{uA, uB}} (a : P.A) : Lens X.{uA₁, uB₁} P :=
+  (fun _ => a) ⇆ fun _ _ => PUnit.unit
+
+@[simp] theorem fromX_toFunA {P : PFunctor.{uA, uB}} (a : P.A) (u : PUnit) :
+    (fromX a : Lens X.{uA₁, uB₁} P).toFunA u = a := rfl
+
+@[simp] theorem fromX_toFunB {P : PFunctor.{uA, uB}} (a : P.A) (u : PUnit)
+    (d : P.B a) :
+    (fromX a : Lens X.{uA₁, uB₁} P).toFunB u d = PUnit.unit := rfl
+
+/-- Construct a lens into a constant polynomial from its position map. The
+backward map is uniquely determined by the empty direction type. -/
+def toConst {P : PFunctor.{uA, uB}} {A : Type uA₂} (f : P.A → A) :
+    Lens P (C A : PFunctor.{uA₂, uB₁}) :=
+  f ⇆ fun _ => PEmpty.elim
+
+@[simp] theorem toConst_toFunA {P : PFunctor.{uA, uB}} {A : Type uA₂}
+    (f : P.A → A) (a : P.A) :
+    (toConst f : Lens P (C A : PFunctor.{uA₂, uB₁})).toFunA a = f a := rfl
+
+/-- Construct a lens into a linear polynomial from a position map and a choice
+of source direction over every position. -/
+def toLinear {P : PFunctor.{uA, uB}} {A : Type uA₂}
+    (f : P.A → A) (choose : (a : P.A) → P.B a) :
+    Lens P (linear A : PFunctor.{uA₂, uB₁}) :=
+  f ⇆ fun a _ => choose a
+
+@[simp] theorem toLinear_toFunA {P : PFunctor.{uA, uB}} {A : Type uA₂}
+    (f : P.A → A) (choose : (a : P.A) → P.B a) (a : P.A) :
+    (toLinear f choose : Lens P (linear A : PFunctor.{uA₂, uB₁})).toFunA a = f a := rfl
+
+@[simp] theorem toLinear_toFunB {P : PFunctor.{uA, uB}} {A : Type uA₂}
+    (f : P.A → A) (choose : (a : P.A) → P.B a) (a : P.A) (u : PUnit) :
+    (toLinear f choose : Lens P (linear A : PFunctor.{uA₂, uB₁})).toFunB a u = choose a := rfl
+
 /-- Left injection lens `inl : P → P + Q` -/
 def inl {P : PFunctor.{uA₁, uB}} {Q : PFunctor.{uA₂, uB}} :
     Lens.{uA₁, uB, max uA₁ uA₂, uB} P (P + Q) :=
-  Sum.inl ⇆ (fun _ d => d)
+  Sum.inl ⇆ fun _ => id
 
 /-- Right injection lens `inr : Q → P + Q` -/
 def inr {P : PFunctor.{uA₁, uB}} {Q : PFunctor.{uA₂, uB}} :
     Lens.{uA₂, uB, max uA₁ uA₂, uB} Q (P + Q) :=
-  Sum.inr ⇆ (fun _ d => d)
+  Sum.inr ⇆ fun _ => id
 
 /-- Copairing of lenses `[l₁, l₂]ₗ : P + Q → R` -/
 def sumPair {P : PFunctor.{uA₁, uB}} {Q : PFunctor.{uA₂, uB}} {R : PFunctor.{uA₃, uB₃}}
     (l₁ : Lens P R) (l₂ : Lens Q R) :
     Lens.{max uA₁ uA₂, uB, uA₃, uB₃} (P + Q) R :=
-  (Sum.elim l₁.toFunA l₂.toFunA) ⇆
-    (fun a d => match a with
-      | Sum.inl pa => l₁.toFunB pa d
-      | Sum.inr qa => l₂.toFunB qa d)
+  Sum.elim l₁.toFunA l₂.toFunA ⇆ fun
+    | .inl pa => l₁.toFunB pa
+    | .inr qa => l₂.toFunB qa
 
 /-- Parallel application of lenses for coproduct `l₁ ⊎ l₂ : P + Q → R + W` -/
 def sumMap {P : PFunctor.{uA₁, uB₁}} {Q : PFunctor.{uA₂, uB₁}} {R : PFunctor.{uA₃, uB₃}}
     {W : PFunctor.{uA₄, uB₃}} (l₁ : Lens P R) (l₂ : Lens Q W) :
     Lens.{max uA₁ uA₂, uB₁, max uA₃ uA₄, uB₃} (P + Q) (R + W) :=
-  (Sum.map l₁.toFunA l₂.toFunA) ⇆
-    (fun psum => match psum with
-      | Sum.inl pa => l₁.toFunB pa
-      | Sum.inr qa => l₂.toFunB qa)
+  Sum.map l₁.toFunA l₂.toFunA ⇆ fun
+    | .inl pa => l₁.toFunB pa
+    | .inr qa => l₂.toFunB qa
 
 /-- Dependent copairing of lenses over `sigma`: `Σ i, F i → R`. -/
 def sigmaExists {I : Type v} {F : I → PFunctor.{uA₁, uB₁}} {R : PFunctor.{uA₂, uB₂}}
@@ -172,12 +207,12 @@ def sigmaMap {I : Type v} {F : I → PFunctor.{uA₁, uB₁}} {G : I → PFuncto
 /-- Projection lens `fst : P * Q → P` -/
 def fst {P : PFunctor.{uA₁, uB₁}} {Q : PFunctor.{uA₂, uB₂}} :
     Lens.{max uA₁ uA₂, max uB₁ uB₂, uA₁, uB₁} (P * Q) P :=
-  Prod.fst ⇆ (fun _ => Sum.inl)
+  Prod.fst ⇆ fun _ => Sum.inl
 
 /-- Projection lens `snd : P * Q → Q` -/
 def snd {P : PFunctor.{uA₁, uB₁}} {Q : PFunctor.{uA₂, uB₂}} :
     Lens.{max uA₁ uA₂, max uB₁ uB₂, uA₂, uB₂} (P * Q) Q :=
-  Prod.snd ⇆ (fun _ => Sum.inr)
+  Prod.snd ⇆ fun _ => Sum.inr
 
 /-- Pairing of lenses `⟨l₁, l₂⟩ₗ : P → Q * R` -/
 def prodPair {P : PFunctor.{uA₁, uB₁}} {Q : PFunctor.{uA₂, uB₂}} {R : PFunctor.{uA₃, uB₃}}
@@ -221,8 +256,8 @@ def compMap {P : PFunctor.{uA₁, uB₁}} {Q : PFunctor.{uA₂, uB₂}} {R : PFu
 def tensorMap {P : PFunctor.{uA₁, uB₁}} {Q : PFunctor.{uA₂, uB₂}} {R : PFunctor.{uA₃, uB₃}}
     {W : PFunctor.{uA₄, uB₄}} (l₁ : Lens P R) (l₂ : Lens Q W) :
     Lens.{max uA₁ uA₂, max uB₁ uB₂, max uA₃ uA₄, max uB₃ uB₄} (P ⊗ Q) (R ⊗ W) :=
-  (fun ⟨pa, qa⟩ => (l₁.toFunA pa, l₂.toFunA qa)) ⇆
-    (fun ⟨_pa, qa⟩ ⟨rb, wb⟩ => (l₁.toFunB _pa rb, l₂.toFunB qa wb))
+  Prod.map l₁.toFunA l₂.toFunA ⇆
+    fun (pa, qa) => Prod.map (l₁.toFunB pa) (l₂.toFunB qa)
 
 /-- Lens to introduce `X` on the right: `P → P ◃ X` -/
 def tildeR {P : PFunctor.{uA, uB}} : Lens P (P ◃ X) :=
@@ -434,8 +469,8 @@ namespace Equiv
 /-- Commutativity of product -/
 def prodComm (P : PFunctor.{uA₁, uB₁}) (Q : PFunctor.{uA₂, uB₂}) :
     Lens.Equiv.{max uA₁ uA₂, max uB₁ uB₂, max uA₁ uA₂, max uB₁ uB₂} (P * Q) (Q * P) where
-  toLens := Prod.swap ⇆ (fun _ => Sum.elim Sum.inr Sum.inl)
-  invLens := Prod.swap ⇆ (fun _ => Sum.elim Sum.inr Sum.inl)
+  toLens := Prod.swap ⇆ fun _ => Sum.elim Sum.inr Sum.inl
+  invLens := Prod.swap ⇆ fun _ => Sum.elim Sum.inr Sum.inl
   left_inv := by
     ext _ b
     · rfl
@@ -454,9 +489,9 @@ variable {P : PFunctor.{uA₁, uB₁}} {Q : PFunctor.{uA₂, uB₂}} {R : PFunct
 def prodAssoc : Lens.Equiv.{max uA₁ uA₂ uA₃, max uB₁ uB₂ uB₃, max uA₁ uA₂ uA₃, max uB₁ uB₂ uB₃}
     ((P * Q) * R) (P * (Q * R)) where
   toLens := (_root_.Equiv.prodAssoc P.A Q.A R.A).toFun ⇆
-              (fun _ d => (_root_.Equiv.sumAssoc _ _ _).invFun d)
+              (fun _ => (_root_.Equiv.sumAssoc _ _ _).invFun)
   invLens := (_root_.Equiv.prodAssoc P.A Q.A R.A).invFun ⇆
-               (fun _ d => _root_.Equiv.sumAssoc _ _ _ d)
+               (fun _ => _root_.Equiv.sumAssoc _ _ _)
   left_inv := by
     ext _ b
     · rfl
@@ -473,8 +508,8 @@ def prodAssoc : Lens.Equiv.{max uA₁ uA₂ uA₃, max uB₁ uB₂ uB₃, max uA
 /-- Product with `1` is identity (right) -/
 def prodOne :
     Lens.Equiv.{max uA₁ uA₂, max uB₁ uB₂, uA₁, uB₁} (P * (1 : PFunctor.{uA₂, uB₂})) P where
-  toLens := Prod.fst ⇆ (fun _ => Sum.inl)
-  invLens := (fun p => (p, PUnit.unit)) ⇆ (fun _ => Sum.elim id PEmpty.elim)
+  toLens := Prod.fst ⇆ fun _ => Sum.inl
+  invLens := (·, PUnit.unit) ⇆ fun _ => Sum.elim id PEmpty.elim
   left_inv := by
     ext _ b
     · rfl
@@ -487,8 +522,8 @@ def prodOne :
 /-- Product with `1` is identity (left) -/
 def oneProd :
     Lens.Equiv.{max uA₁ uA₂, max uB₁ uB₂, uA₁, uB₁} ((1 : PFunctor.{uA₂, uB₂}) * P) P where
-  toLens := Prod.snd ⇆ (fun _ => Sum.inr)
-  invLens := (fun p => (PUnit.unit, p)) ⇆ (fun _ => Sum.elim PEmpty.elim id)
+  toLens := Prod.snd ⇆ fun _ => Sum.inr
+  invLens := (PUnit.unit, ·) ⇆ fun _ => Sum.elim PEmpty.elim id
   left_inv := by
     ext _ b
     · rfl
@@ -501,8 +536,8 @@ def oneProd :
 /-- Product with `0` is zero (right) -/
 def prodZero :
     Lens.Equiv.{max uA₁ uA₂, max uB₁ uB₂, uA₁, uB₁} (P * (0 : PFunctor.{uA₂, uB₂})) 0 where
-  toLens := (fun a => PEmpty.elim a.2) ⇆ (fun _ x => PEmpty.elim x)
-  invLens := PEmpty.elim ⇆ (fun pe _ => PEmpty.elim pe)
+  toLens := (fun a => PEmpty.elim a.2) ⇆ fun _ => PEmpty.elim
+  invLens := PEmpty.elim ⇆ fun pe => PEmpty.elim pe
   left_inv := by
     ext ⟨_, a⟩ _ <;> exact PEmpty.elim a
   right_inv := by
@@ -511,8 +546,8 @@ def prodZero :
 /-- Product with `0` is zero (left) -/
 def zeroProd :
     Lens.Equiv.{max uA₁ uA₂, max uB₁ uB₂, uA₁, uB₁} ((0 : PFunctor.{uA₂, uB₂}) * P) 0 where
-  toLens := (fun ⟨pa, _⟩ => PEmpty.elim pa) ⇆ (fun _ x => PEmpty.elim x)
-  invLens := PEmpty.elim ⇆ (fun pe _ => PEmpty.elim pe)
+  toLens := (fun (pa, _) => PEmpty.elim pa) ⇆ fun _ => PEmpty.elim
+  invLens := PEmpty.elim ⇆ fun pe => PEmpty.elim pe
   left_inv := by
     ext ⟨a, _⟩ <;> exact PEmpty.elim a
   right_inv := by
@@ -524,41 +559,23 @@ variable {R : PFunctor.{uA₃, uB₂}}
 def prodCoprodDistrib :
     Lens.Equiv.{max uA₁ uA₂ uA₃, max uB₁ uB₂, max uA₁ uA₂ uA₃, max uB₁ uB₂}
       (P * (Q + R)) ((P * Q) + (P * R)) where
-  toLens := (fun ⟨p, qr⟩ => match qr with
-              | Sum.inl q => Sum.inl (p, q)
-              | Sum.inr r => Sum.inr (p, r)) ⇆
-            (fun ⟨_, qr⟩ => match qr with
-              | Sum.inl _ => id -- P.B p ⊕ Q.B q
-              | Sum.inr _ => id) -- P.B p ⊕ R.B r
-  invLens := (Sum.elim
-              (fun ⟨p, q⟩ => (p, Sum.inl q))
-              (fun ⟨p, r⟩ => (p, Sum.inr r))) ⇆
-             (fun pq_pr => match pq_pr with
-              | Sum.inl _ => id -- P.B p ⊕ Q.B q
-              | Sum.inr _ => id) -- P.B p ⊕ R.B r
-  left_inv := by
-    ext a <;> rcases a with ⟨p, q | r⟩ <;> rfl
-  right_inv := by
-    ext a <;> rcases a with ⟨p, q⟩ | ⟨p, r⟩ <;> rfl
+  toLens := (fun (p, qr) => qr.map (p, ·) (p, ·)) ⇆
+    (fun | ⟨_, .inl _⟩ | ⟨_, .inr _⟩ => id)
+  invLens := Sum.elim (Prod.map id Sum.inl) (Prod.map id Sum.inr) ⇆
+    (fun | .inl _ | .inr _ => id)
+  left_inv := by ext ⟨_, qr⟩ <;> cases qr <;> rfl
+  right_inv := by ext pqpr <;> cases pqpr <;> rfl
 
 /-- Right distributive law for coproduct over product -/
 def sumProdDistrib :
     Lens.Equiv.{max uA₁ uA₂ uA₃, max uB₁ uB₂, max uA₁ uA₂ uA₃, max uB₁ uB₂}
       ((Q + R) * P) ((Q * P) + (R * P)) where
-  toLens := (fun ⟨qr, p⟩ => Sum.elim (fun q => Sum.inl (q, p)) (fun r => Sum.inr (r, p)) qr) ⇆
-            (fun ⟨qr, p⟩ => match qr with
-              | Sum.inl _ => id
-              | Sum.inr _ => id)
-  invLens := (fun qp_rp => match qp_rp with
-              | Sum.inl (q, p) => (Sum.inl q, p)
-              | Sum.inr (r, p) => (Sum.inr r, p)) ⇆
-             (fun qp_rp => match qp_rp with
-              | Sum.inl _ => id
-              | Sum.inr _ => id)
-  left_inv := by
-    ext a <;> rcases a with ⟨q | r, p⟩ <;> rfl
-  right_inv := by
-    ext a <;> rcases a with ⟨q, p⟩ | ⟨r, p⟩ <;> rfl
+  toLens := (fun (qr, p) => qr.map (·, p) (·, p)) ⇆
+    (fun | ⟨.inl _, _⟩ | ⟨.inr _, _⟩ => id)
+  invLens := Sum.elim (Prod.map Sum.inl id) (Prod.map Sum.inr id) ⇆
+    (fun | .inl _ | .inr _ => id)
+  left_inv := by ext ⟨qr, _⟩ <;> cases qr <;> rfl
+  right_inv := by ext qprp <;> cases qprp <;> rfl
 
 end Equiv
 
@@ -607,22 +624,16 @@ def XComp : X ◃ P ≃ₗ P where
 def sumCompDistrib {R : PFunctor.{uA₃, uB₂}} :
     Lens.Equiv.{max uA₁ uA₂ uA₃ uB₂, max uB₁ uB₂, max uA₁ uA₂ uA₃ uB₂, max uB₁ uB₂}
       ((Q + R : PFunctor.{max uA₂ uA₃, uB₂}) ◃ P) ((Q ◃ P) + (R ◃ P)) where
-  toLens := (fun a => match a with
-              | ⟨Sum.inl qa, pf⟩ => Sum.inl ⟨qa, pf⟩
-              | ⟨Sum.inr ra, pf⟩ => Sum.inr ⟨ra, pf⟩) ⇆
-            (fun ⟨qr, pf⟩ b => match qr with
-              | Sum.inl _ => b
-              | Sum.inr _ => b)
-  invLens := (fun a => match a with
-              | Sum.inl ⟨qa, pf⟩ => ⟨Sum.inl qa, pf⟩
-              | Sum.inr ⟨ra, pf⟩ => ⟨Sum.inr ra, pf⟩) ⇆
-            (fun qprp b => match qprp with
-              | Sum.inl _ => b
-              | Sum.inr _ => b)
-  left_inv := by
-    ext a <;> rcases a with ⟨_ | _, _⟩ <;> rfl
-  right_inv := by
-    ext a <;> cases a <;> rfl
+  toLens := (fun
+    | ⟨.inl qa, pf⟩ => .inl ⟨qa, pf⟩
+    | ⟨.inr ra, pf⟩ => .inr ⟨ra, pf⟩) ⇆
+      (fun | ⟨.inl _, _⟩ | ⟨.inr _, _⟩ => id)
+  invLens := (fun
+    | .inl ⟨qa, pf⟩ => ⟨.inl qa, pf⟩
+    | .inr ⟨ra, pf⟩ => ⟨.inr ra, pf⟩) ⇆
+      (fun | .inl _ | .inr _ => id)
+  left_inv := by ext ⟨qr, _⟩ <;> cases qr <;> rfl
+  right_inv := by ext qprp <;> cases qprp <;> rfl
 
 end Equiv
 
@@ -653,30 +664,30 @@ def tensorComm (P : PFunctor.{uA₁, uB₁}) (Q : PFunctor.{uA₂, uB₂}) : P �
 /-- Associativity of tensor product -/
 def tensorAssoc : (P ⊗ Q) ⊗ R ≃ₗ P ⊗ (Q ⊗ R) where
   toLens := (_root_.Equiv.prodAssoc _ _ _).toFun ⇆
-            (fun _ => (_root_.Equiv.prodAssoc _ _ _).invFun)
+    (fun _ => (_root_.Equiv.prodAssoc _ _ _).invFun)
   invLens := (_root_.Equiv.prodAssoc _ _ _).invFun ⇆
-            (fun _ => (_root_.Equiv.prodAssoc _ _ _).toFun)
+    (fun _ => (_root_.Equiv.prodAssoc _ _ _).toFun)
   left_inv := rfl
   right_inv := rfl
 
 /-- Tensor product with `X` is identity (right) -/
 def tensorX : P ⊗ X ≃ₗ P where
-  toLens := Prod.fst ⇆ (fun _ b => (b, PUnit.unit))
-  invLens := (fun p => (p, PUnit.unit)) ⇆ (fun _ bp => bp.1)
+  toLens := Prod.fst ⇆ fun _ => (·, PUnit.unit)
+  invLens := (·, PUnit.unit) ⇆ fun _ => Prod.fst
   left_inv := rfl
   right_inv := rfl
 
 /-- Tensor product with `X` is identity (left) -/
 def xTensor : X ⊗ P ≃ₗ P where
-  toLens := Prod.snd ⇆ (fun _ b => (PUnit.unit, b))
-  invLens := (fun p => (PUnit.unit, p)) ⇆ (fun _ bp => bp.2)
+  toLens := Prod.snd ⇆ fun _ => (PUnit.unit, ·)
+  invLens := (PUnit.unit, ·) ⇆ fun _ => Prod.snd
   left_inv := rfl
   right_inv := rfl
 
 /-- Tensor product with `0` is zero (left) -/
 def zeroTensor : 0 ⊗ P ≃ₗ 0 where
-  toLens := (fun a => PEmpty.elim a.1) ⇆ (fun _ b => PEmpty.elim b)
-  invLens := PEmpty.elim ⇆ (fun a _ => PEmpty.elim a)
+  toLens := (fun a => PEmpty.elim a.1) ⇆ fun _ => PEmpty.elim
+  invLens := PEmpty.elim ⇆ fun a => PEmpty.elim a
   left_inv := by
     ext ⟨a, _⟩ <;> exact PEmpty.elim a
   right_inv := by
@@ -684,8 +695,8 @@ def zeroTensor : 0 ⊗ P ≃ₗ 0 where
 
 /-- Tensor product with `0` is zero (right) -/
 def tensorZero : P ⊗ 0 ≃ₗ 0 where
-  toLens := (fun a => PEmpty.elim a.2) ⇆ (fun _ b => PEmpty.elim b)
-  invLens := PEmpty.elim ⇆ (fun a _ => PEmpty.elim a)
+  toLens := (fun a => PEmpty.elim a.2) ⇆ fun _ => PEmpty.elim
+  invLens := PEmpty.elim ⇆ fun a => PEmpty.elim a
   left_inv := by
     ext ⟨_, b⟩ <;> exact PEmpty.elim b
   right_inv := by
@@ -697,43 +708,23 @@ variable {R : PFunctor.{uA₃, uB₂}}
 def tensorCoprodDistrib :
     Lens.Equiv.{max uA₁ uA₂ uA₃, max uB₁ uB₂, max uA₁ uA₂ uA₃, max uB₁ uB₂}
       (P ⊗ (Q + R : PFunctor.{max uA₂ uA₃, uB₂})) ((P ⊗ Q) + (P ⊗ R)) where
-  toLens := (fun ⟨p, qr⟩ => match qr with
-              | Sum.inl q => Sum.inl (p, q)
-              | Sum.inr r => Sum.inr (p, r)) ⇆
-            (fun ⟨p, qr⟩ b => match qr with
-              | Sum.inl _ => b
-              | Sum.inr _ => b)
-  invLens := (fun pqpr => match pqpr with
-              | Sum.inl (p, q) => (p, Sum.inl q)
-              | Sum.inr (p, r) => (p, Sum.inr r)) ⇆
-             (fun pqpr b => match pqpr with
-              | Sum.inl _ => b
-              | Sum.inr _ => b)
-  left_inv := by
-    ext ⟨_, qr⟩ <;> cases qr <;> rfl
-  right_inv := by
-    ext pqpr <;> cases pqpr <;> rfl
+  toLens := (fun (p, qr) => qr.map (p, ·) (p, ·)) ⇆
+    (fun | ⟨_, .inl _⟩ | ⟨_, .inr _⟩ => id)
+  invLens := Sum.elim (Prod.map id Sum.inl) (Prod.map id Sum.inr) ⇆
+    (fun | .inl _ | .inr _ => id)
+  left_inv := by ext ⟨_, qr⟩ <;> cases qr <;> rfl
+  right_inv := by ext pqpr <;> cases pqpr <;> rfl
 
 /-- Right distributivity of tensor product over coproduct -/
 def sumTensorDistrib :
     (Q + R : PFunctor.{max uA₂ uA₃, uB₂}) ⊗ P
       ≃ₗ ((Q ⊗ P) + (R ⊗ P) : PFunctor.{max uA₁ uA₂ uA₃, max uB₁ uB₂}) where
-  toLens := (fun ⟨qr, p⟩ => match qr with
-              | Sum.inl q => Sum.inl (q, p)
-              | Sum.inr r => Sum.inr (r, p)) ⇆
-            (fun ⟨qr, _⟩ b => match qr with
-              | Sum.inl _ => b
-              | Sum.inr _ => b)
-  invLens := (fun qprp => match qprp with
-              | Sum.inl (q, p) => (Sum.inl q, p)
-              | Sum.inr (r, p) => (Sum.inr r, p)) ⇆
-             (fun qprp b => match qprp with
-              | Sum.inl _ => b
-              | Sum.inr _ => b)
-  left_inv := by
-    ext ⟨qr, _⟩ <;> cases qr <;> rfl
-  right_inv := by
-    ext qprp <;> cases qprp <;> rfl
+  toLens := (fun (qr, p) => qr.map (·, p) (·, p)) ⇆
+    (fun | ⟨.inl _, _⟩ | ⟨.inr _, _⟩ => id)
+  invLens := Sum.elim (Prod.map Sum.inl id) (Prod.map Sum.inr id) ⇆
+    (fun | .inl _ | .inr _ => id)
+  left_inv := by ext ⟨qr, _⟩ <;> cases qr <;> rfl
+  right_inv := by ext qprp <;> cases qprp <;> rfl
 
 end Equiv
 
@@ -859,8 +850,8 @@ def piZero [Inhabited I] {F : I → PFunctor.{uA, uB}} (F_zero : ∀ i, F i = 0)
     rw [F_zero (default : I)] at hf
     exact hf.elim
   refine
-    { toLens := isEmptyElim ⇆ (fun a _ => isEmptyElim a)
-      invLens := PEmpty.elim ⇆ (fun a => PEmpty.elim a)
+    { toLens := isEmptyElim ⇆ fun a => isEmptyElim a
+      invLens := PEmpty.elim ⇆ fun a => PEmpty.elim a
       left_inv := by
         ext a <;> exact isEmptyElim a
       right_inv := by
@@ -872,8 +863,8 @@ namespace Equiv
 
 /-- ULift equivalence for lenses -/
 def ulift {P : PFunctor.{uA, uB}} : P.ulift ≃ₗ P where
-  toLens := (fun a => ULift.down a) ⇆ (fun _ b => ULift.up b)
-  invLens := (fun a => ULift.up a) ⇆ (fun _ b => ULift.down b)
+  toLens := ULift.down ⇆ fun _ => ULift.up
+  invLens := ULift.up ⇆ fun _ => ULift.down
   left_inv := rfl
   right_inv := rfl
 

--- a/PolyFun/PFunctor/Lens/Cartesian.lean
+++ b/PolyFun/PFunctor/Lens/Cartesian.lean
@@ -132,7 +132,7 @@ is the identity on directions. This is the `Lens` whose corresponding
 /-- Lens injection `Lens (F j) (sigma F)` for a fixed index `j : I`. -/
 def sigmaInj {I : Type v} {F : I → PFunctor.{uA, uB}} (j : I) :
     Lens (F j) (sigma F) :=
-  (fun fa => ⟨j, fa⟩) ⇆ (fun _ d => d)
+  (fun fa => ⟨j, fa⟩) ⇆ fun _ => id
 
 namespace IsCartesian
 

--- a/PolyFun/PFunctor/Lens/Duoidal.lean
+++ b/PolyFun/PFunctor/Lens/Duoidal.lean
@@ -77,7 +77,7 @@ constant map returning `b`. On directions, a `p ◃ q`-direction over
 which maps back to the tensor-direction `(u, v) : p.B a × q.B b`. -/
 def orderingLens (p : PFunctor.{uA₁, uB₁}) (q : PFunctor.{uA₂, uB₂}) :
     Lens (p ⊗ q) (p ◃ q) :=
-  (fun ab => ⟨ab.1, fun _ => ab.2⟩) ⇆ (fun _ab uv => (uv.1, uv.2))
+  (fun (a, b) => ⟨a, fun _ => b⟩) ⇆ fun _ ⟨u, v⟩ => (u, v)
 
 /-- The ordering lens is cartesian: on every fiber the backward map
 `⟨u, v⟩ ↦ (u, v)` is the bijection between the (constant-family) dependent pair
@@ -157,10 +157,10 @@ def Equiv.tensorMiddleFour
     (p : PFunctor.{uA₁, uB₁}) (p' : PFunctor.{uA₂, uB₂})
     (q : PFunctor.{uA₃, uB₃}) (q' : PFunctor.{uA₄, uB₄}) :
     ((p ⊗ p') ⊗ (q ⊗ q')) ≃ₗ ((p ⊗ q) ⊗ (p' ⊗ q')) where
-  toLens := (fun x => ((x.1.1, x.2.1), (x.1.2, x.2.2))) ⇆
-    (fun _ d => ((d.1.1, d.2.1), (d.1.2, d.2.2)))
-  invLens := (fun x => ((x.1.1, x.2.1), (x.1.2, x.2.2))) ⇆
-    (fun _ d => ((d.1.1, d.2.1), (d.1.2, d.2.2)))
+  toLens := (fun ((a, b), (c, d)) => ((a, c), (b, d))) ⇆
+    (fun _ ((a, b), (c, d)) => ((a, c), (b, d)))
+  invLens := (fun ((a, b), (c, d)) => ((a, c), (b, d))) ⇆
+    (fun _ ((a, b), (c, d)) => ((a, c), (b, d)))
   left_inv := rfl
   right_inv := rfl
 
@@ -205,7 +205,7 @@ direction. The forward lens is `orderingLens (linear A) (linear B)`. -/
 def linearTensorLinear (A : Type u) (B : Type u) :
     (linear.{u, u} A ⊗ linear.{u, u} B) ≃ₗ (linear.{u, u} A ◃ linear.{u, u} B) where
   toLens := orderingLens (linear A) (linear B)
-  invLens := (fun af => (af.1, af.2 PUnit.unit)) ⇆ (fun _af uw => ⟨uw.1, uw.2⟩)
+  invLens := (fun ⟨a, f⟩ => (a, f PUnit.unit)) ⇆ fun _ (u, w) => ⟨u, w⟩
   left_inv := rfl
   right_inv := rfl
 
@@ -218,7 +218,7 @@ def purePowerTensorPurePower (A : Type u) (B : Type u) :
     (purePower.{u, u} A ⊗ purePower.{u, u} B) ≃ₗ
       (purePower.{u, u} A ◃ purePower.{u, u} B) where
   toLens := orderingLens (purePower A) (purePower B)
-  invLens := (fun uf => (uf.1, PUnit.unit)) ⇆ (fun _uf xy => ⟨xy.1, xy.2⟩)
+  invLens := (fun uf => (uf.1, PUnit.unit)) ⇆ fun _ (x, y) => ⟨x, y⟩
   left_inv := rfl
   right_inv := rfl
 
@@ -232,7 +232,7 @@ first and then continuing with `p`. The forward lens is
 def linearTensor (B : Type u) (p : PFunctor.{u, u}) :
     (linear.{u, u} B ⊗ p) ≃ₗ (linear.{u, u} B ◃ p) where
   toLens := orderingLens (linear B) p
-  invLens := (fun bf => (bf.1, bf.2 PUnit.unit)) ⇆ (fun _bf ud => ⟨ud.1, ud.2⟩)
+  invLens := (fun ⟨b, f⟩ => (b, f PUnit.unit)) ⇆ fun _ (u, d) => ⟨u, d⟩
   left_inv := rfl
   right_inv := rfl
 
@@ -245,7 +245,7 @@ paired with an `A`-direction is the same as a `p`-move followed by an
 def tensorPurePower (p : PFunctor.{u, u}) (A : Type u) :
     (p ⊗ purePower.{u, u} A) ≃ₗ (p ◃ purePower.{u, u} A) where
   toLens := orderingLens p (purePower A)
-  invLens := (fun pf => (pf.1, PUnit.unit)) ⇆ (fun _pf xy => ⟨xy.1, xy.2⟩)
+  invLens := (fun pf => (pf.1, PUnit.unit)) ⇆ fun _ (x, y) => ⟨x, y⟩
   left_inv := rfl
   right_inv := rfl
 

--- a/PolyFun/PFunctor/Lens/Factorization.lean
+++ b/PolyFun/PFunctor/Lens/Factorization.lean
@@ -113,12 +113,12 @@ def factorMid (l : Lens P Q) : PFunctor.{uA₁, uB₂} :=
 /-- The vertical leg `P ⇆ factorMid l`: identity on positions, `l.toFunB` on
 directions. -/
 def factorVert (l : Lens P Q) : Lens P (factorMid l) :=
-  (fun i => i) ⇆ l.toFunB
+  id ⇆ l.toFunB
 
 /-- The cartesian leg `factorMid l ⇆ Q`: `l.toFunA` on positions, identity on
 each direction fiber. -/
 def factorCart (l : Lens P Q) : Lens (factorMid l) Q :=
-  l.toFunA ⇆ (fun _ d => d)
+  l.toFunA ⇆ fun _ => id
 
 /-- The factorization recovers the original lens. -/
 @[simp]

--- a/PolyFunTest/PFunctor/Adjunctions.lean
+++ b/PolyFunTest/PFunctor/Adjunctions.lean
@@ -52,11 +52,11 @@ example (l : Lens qBool (1 : PFunctor.{0, 0})) : l = Lens.terminal := by
 /-! ## `homFromX`: a lens `y ⇆ p` is a position -/
 
 /-- The forward map reads off the chosen position. -/
-example : homFromX (p := qBool) ((fun _ => true) ⇆ (fun _ _ => PUnit.unit)) = true := rfl
+example : homFromX (p := qBool) (Lens.fromX true) = true := rfl
 
 /-- The inverse builds the constant-position lens. -/
 example :
-    (homFromX (p := qBool)).symm false = ((fun _ => false) ⇆ (fun _ _ => PUnit.unit)) := rfl
+    (homFromX (p := qBool)).symm false = Lens.fromX false := rfl
 
 /-- Round-trip through a position is the identity. -/
 example (a : qBool.A) : homFromX (p := qBool) ((homFromX (p := qBool)).symm a) = a := rfl
@@ -66,11 +66,11 @@ example (a : qBool.A) : homFromX (p := qBool) ((homFromX (p := qBool)).symm a) =
 /-- The forward map is exactly the position map `toFunA`, checked concretely
 on `Bool.toNat`. -/
 example :
-    homToConst ((Bool.toNat ⇆ (fun _ => PEmpty.elim)) : Lens qBool (C Nat)) = Bool.toNat := rfl
+    homToConst (Lens.toConst Bool.toNat : Lens qBool (C Nat)) = Bool.toNat := rfl
 
 /-- The forward map is exactly the position map `toFunA`, for an arbitrary map. -/
 example (f : qBool.A → Nat) :
-    homToConst ((f ⇆ (fun _ => PEmpty.elim)) : Lens qBool (C Nat)) = f := rfl
+    homToConst (Lens.toConst f : Lens qBool (C Nat)) = f := rfl
 
 /-- The inverse installs the empty backward map. -/
 example (f : Bool → Nat) : ((homToConst (p := qBool) (A := Nat)).symm f).toFunA = f := rfl
@@ -83,7 +83,7 @@ example (f : qBool.A → Nat) :
 
 /-- The forward map splits into the position map and the chosen section. -/
 example (f : qBool.A → Nat) (s : (a : qBool.A) → qBool.B a) :
-    homToLinear ((f ⇆ (fun a _ => s a)) : Lens qBool (linear Nat)) = (f, s) := rfl
+    homToLinear (Lens.toLinear f s : Lens qBool (linear Nat)) = (f, s) := rfl
 
 /-- The inverse reassembles the position map and section into a lens. -/
 example (f : Bool → Nat) (s : (a : qBool.A) → qBool.B a) :

--- a/PolyFunTest/PFunctor/Dynamical/Examples.lean
+++ b/PolyFunTest/PFunctor/Dynamical/Examples.lean
@@ -29,7 +29,7 @@ namespace DynSystem.Examples
 /-- A running-sum counter: state is the accumulated total, the output is the total
 itself, and each input is added to the state. -/
 def counter : MooreMachine ℕ ℕ ℕ :=
-  (fun n : ℕ => n) ⇆ fun (n : ℕ) (i : ℕ) => n + i
+  id ⇆ fun (n : ℕ) (i : ℕ) => n + i
 
 example : counter.run (0 : ℕ) [1, 2, 3] = (6 : ℕ) := rfl
 

--- a/PolyFunTest/PFunctor/Dynamical/GameExamples.lean
+++ b/PolyFunTest/PFunctor/Dynamical/GameExamples.lean
@@ -86,7 +86,7 @@ def countingResponder : Responder ℕ (monomial ℕ ℕ) :=
 /-- The doubling adversary over `ℕ X^ ℕ`: queries its state, stores double the
 answer it hears. -/
 def doublingAdversary : DynSystem ℕ (monomial ℕ ℕ) :=
-  (fun t => t) ⇆ fun _ (a : ℕ) => 2 * a
+  id ⇆ fun _ (a : ℕ) => 2 * a
 
 /-- Three closed-game steps, computed by `rfl`:
 `(0, 5) ↦ (1, 0) ↦ (2, 2) ↦ (3, 4)`. -/
@@ -135,11 +135,11 @@ def privKChallenger :
 
 /-- The commit-phase adversary: submits the fixed message pair `(false, true)`. -/
 def commitAdversary : DynSystem PUnit (monomial (Bool × Bool) Bool) :=
-  (fun _ => (false, true)) ⇆ fun _ _ => PUnit.unit
+  Lens.fromX (false, true)
 
 /-- The guess-phase adversary: guesses its own (fixed) state bit. -/
 def guessAdversary : DynSystem Bool (monomial Bool PUnit) :=
-  (fun t => t) ⇆ fun t _ => t
+  id ⇆ fun t _ => t
 
 /-- The full PrivK-shaped game: challenger against the ordered adversary pair. -/
 def privKGame : DynSystem (Bool × (PUnit × Bool)) (X.{0, 0} ◃ monomial Bool PUnit) :=

--- a/PolyFunTest/PFunctor/Dynamical/IOMachineExamples.lean
+++ b/PolyFunTest/PFunctor/Dynamical/IOMachineExamples.lean
@@ -69,7 +69,7 @@ example (M₁ : IOMachine p α mid) (M₂ : IOMachine p mid β) (s₁ : M₁.Sta
 /-- A machine that halts immediately with output `b`. -/
 def haltMachine (b : β) : IOMachine X.{u, u} α β where
   State := PUnit
-  toDynSystem := (fun _ => PUnit.unit) ⇆ fun _ _ => PUnit.unit
+  toDynSystem := Lens.fromX PUnit.unit
   init := fun _ => PUnit.unit
   output := fun _ => some b
 

--- a/PolyFunTest/PFunctor/Dynamical/OracleObsEqExample.lean
+++ b/PolyFunTest/PFunctor/Dynamical/OracleObsEqExample.lean
@@ -45,12 +45,12 @@ abbrev oraclePoly (A Q : Type u) : PFunctor.{u, u} := ⟨Option A, fun _ => Q⟩
 /-- The log-carrying oracle: state is `(lastAnswer, queryLog)`. On query `q` it
 answers `f q`, records the answer, and appends `q` to the log. -/
 def oracleLog : DynSystem (Option A × List Q) (oraclePoly A Q) :=
-  (fun s => s.1) ⇆ (fun s q => (some (f q), s.2 ++ [(q : Q)]))
+  Prod.fst ⇆ fun s q => (some (f q), s.2 ++ [(q : Q)])
 
 /-- The count-carrying oracle: state is `(lastAnswer, queryCount)`. On query `q`
 it answers `f q`, records the answer, and increments the counter. -/
 def oracleCount : DynSystem (Option A × Nat) (oraclePoly A Q) :=
-  (fun s => s.1) ⇆ (fun s q => (some (f q), s.2 + 1))
+  Prod.fst ⇆ fun s q => (some (f q), s.2 + 1)
 
 /-- The two carriers agree exactly on the observable part (the last answer);
 the log/count bookkeeping is unconstrained. -/

--- a/PolyFunTest/PFunctor/Dynamical/RunNExamples.lean
+++ b/PolyFunTest/PFunctor/Dynamical/RunNExamples.lean
@@ -57,7 +57,7 @@ example (φ : DynSystem S p) (state : S)
 (concrete universe so the `Bool` state set lives in the machine's state type). -/
 def delayMachine (b : Bool) : DynSystem.IOMachine X.{0, 0} PUnit Bool where
   State := Bool
-  toDynSystem := (fun _ => PUnit.unit) ⇆ (fun _ _ => true)
+  toDynSystem := (fun _ => PUnit.unit) ⇆ fun _ _ => true
   init := fun _ => false
   output := fun s => if s then some b else none
 


### PR DESCRIPTION
Stacked on #35.

## Overview

- Streamline lens and chart constructions with standard `Sum`/`Prod` combinators, constructor shorthand, section notation, eta reduction, partial application, and concise pattern functions.
- Apply the same presentation to distributivity equivalences, adjunctions, internal hom, duoidal and factorization helpers, dynamical constructions, and worked examples.
- Keep the refactor definition-preserving while adding small projection simp lemmas for the new constructors.

## New definitions

- `Lens.fromX`: construct a lens `X ⇆ P` from a selected position of `P`.
- `Lens.toConst`: construct a lens into `C A` from its position map.
- `Lens.toLinear`: construct a lens into `linear A` from a position map and a selected source direction.

## Validation

- `./scripts/validate.sh --lint --test`
- `lake exe lint-style`
- `git diff --check`