### PR TITLE
docs: update VCVio naming

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ interaction framework over a polynomial substrate. Built on Mathlib.
 
 PolyFun packages three layers of generic, domain-agnostic infrastructure
 that emerged from the cryptographic-protocols formalization in
-[`Verified-zkEVM/VCV-io`](https://github.com/Verified-zkEVM/VCV-io):
+[`Verified-zkEVM/VCVio`](https://github.com/Verified-zkEVM/VCVio):
 
 1. **Polynomial functors and lenses.** `PFunctor` cores (positions /
    directions), polynomial charts, lenses (Cartesian, state),
@@ -48,7 +48,7 @@ PolyFun is intentionally *not* the place for cryptographic content.
 Probabilistic semantics, evaluation distributions, oracle-simulation
 security definitions, scheme-specific algebra, and concrete-protocol
 runtime layers all live in
-[`Verified-zkEVM/VCV-io`](https://github.com/Verified-zkEVM/VCV-io)
+[`Verified-zkEVM/VCVio`](https://github.com/Verified-zkEVM/VCVio)
 and depend on this library.
 
 ## Repo Map
@@ -74,7 +74,7 @@ and depend on this library.
   - `UC/`: open-process / open-theory layer, structural composition
     (interfaces, par, wire, plug), corruption models, environment
     actions, leakage. *Generic only* — security-flavored UC layers
-    (computational equivalence, asymptotic security) live in VCV-io.
+    (computational equivalence, asymptotic security) live in VCVio.
 - `PolyFun/Control/`: monad and comonad infrastructure transitively
   required by the above (coalgebra, comonad, free / freecont monad
   algebra, monad iter / hom, lawful re-exports).
@@ -196,7 +196,7 @@ Structures use UpperCamelCase: `PFunctor`, `Spec`, `Decoration`,
    probability monads, evaluation distributions, security predicates,
    or concrete-scheme algebra. Parameterize over an abstract monad
    instead. Cryptographic content belongs in
-   [`Verified-zkEVM/VCV-io`](https://github.com/Verified-zkEVM/VCV-io).
+   [`Verified-zkEVM/VCVio`](https://github.com/Verified-zkEVM/VCVio).
 3. **`Spec.done` and `Spec.node` are `@[match_pattern, reducible]`**
    wrappers over `PFunctor.FreeM.{pure, liftBind}`. Pattern matching on
    them works transparently; `rfl` against the polynomial substrate

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ free / displayed-free / cofree structures, interaction trees, and the
 generic interaction framework over a polynomial substrate. PRs that
 introduce *cryptographic* content (probabilistic semantics, evaluation
 distributions, oracle-simulation security definitions, scheme-specific
-algebra) belong in [`Verified-zkEVM/VCV-io`](https://github.com/Verified-zkEVM/VCV-io)
+algebra) belong in [`Verified-zkEVM/VCVio`](https://github.com/Verified-zkEVM/VCVio)
 or downstream consumers, not here.
 
 If a PolyFun definition has a load-bearing dependency on a probability
@@ -79,7 +79,7 @@ Attribution policy:
    existing file or external source and substantial original
    structure / content remains, preserve any required upstream
    `Authors:` attribution. Files imported from
-   `Verified-zkEVM/VCV-io` during the initial bootstrap had their
+   `Verified-zkEVM/VCVio` during the initial bootstrap had their
    copyright line normalized to "PolyFun Contributors" but their
    `Authors:` line retained verbatim.
 5. **AI assistance**: do not add a separate AI-attribution line. Use

--- a/PolyFun/Interaction/UC/EnvAction.lean
+++ b/PolyFun/Interaction/UC/EnvAction.lean
@@ -74,7 +74,7 @@ the consumer needs (deterministic via `Id`, probabilistic via a
 probability monad, oracle-using via a free interaction monad, etc.).
 Deterministic events use `pure ∘ update` and pay no extra cost.
 
-Crypto-flavored consumers (e.g. VCV-io) instantiate `m := ProbComp`
+Crypto-flavored consumers (e.g. VCVio) instantiate `m := ProbComp`
 to recover the original probabilistic-corruption interface; this
 file itself depends only on `Pure` / `Monad` from `Mathlib.Init`.
 

--- a/PolyFun/PFunctor/Adjunctions.lean
+++ b/PolyFun/PFunctor/Adjunctions.lean
@@ -42,7 +42,7 @@ types, matching the observation of the reading notes (§5.1) that none of these
 hom-isos needs category-theory packaging to be useful.
 
 These hom-isomorphisms are reference API: book-completeness formalizations of
-the §5.1 trivial-interface adjunctions, staged for downstream (VCV-io)
+the §5.1 trivial-interface adjunctions, staged for downstream (VCVio)
 consumers and exercised in `PolyFunTest/PFunctor/Adjunctions.lean`.
 
 Both directions of `homFromX` and `homToLinear` hold definitionally

--- a/PolyFunTest/PFunctor/Dynamical/OracleObsEqExample.lean
+++ b/PolyFunTest/PFunctor/Dynamical/OracleObsEqExample.lean
@@ -12,7 +12,7 @@ public import PolyFun.PFunctor.Dynamical.Bisimulation
 
 A deterministic "lookup oracle" with a fixed underlying answer function
 `f : Q → A` (a crypto-free, structural stand-in for a random oracle: sampling
-lives downstream in VCV-io). We model the *same* observable oracle two ways,
+lives downstream in VCVio). We model the *same* observable oracle two ways,
 differing only in the internal bookkeeping state:
 
 * `oracleLog` keeps the full query **log** as a `List Q`;

--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ PolyFun is a ready, buildable Lean 4 library. The repository builds without
 current module layout and scope.
 
 PolyFun originated as a wholesale extraction from
-[`Verified-zkEVM/VCV-io`](https://github.com/Verified-zkEVM/VCV-io).
+[`Verified-zkEVM/VCVio`](https://github.com/Verified-zkEVM/VCVio).
 
 ## Scope
 
 `PolyFun` collects three layers of generic, domain-agnostic infrastructure
-that emerged from the cryptographic-protocols formalization in `VCV-io`:
+that emerged from the cryptographic-protocols formalization in `VCVio`:
 
 1. **Polynomial functors and lenses.** `PFunctor` cores (positions /
    directions), polynomial charts, lenses, equivalences, free monad
@@ -32,7 +32,7 @@ that emerged from the cryptographic-protocols formalization in `VCV-io`:
 
 Cryptographic content (probabilistic semantics, evaluation distributions,
 oracle simulation, security definitions) lives in
-[`Verified-zkEVM/VCV-io`](https://github.com/Verified-zkEVM/VCV-io)
+[`Verified-zkEVM/VCVio`](https://github.com/Verified-zkEVM/VCVio)
 and depends on this library.
 
 ## Build

--- a/docs/wiki/gotchas.md
+++ b/docs/wiki/gotchas.md
@@ -28,7 +28,7 @@ typeclasses, security predicates, or concrete cryptographic algebra
 (specific groups, fields, hash functions). Parameterize over an abstract
 monad `m : Type v → Type w` with `[Pure m]` / `[Monad m]` / `[LawfulMonad m]`
 instead. Cryptographic content belongs in
-[`Verified-zkEVM/VCV-io`](https://github.com/Verified-zkEVM/VCV-io)
+[`Verified-zkEVM/VCVio`](https://github.com/Verified-zkEVM/VCVio)
 downstream.
 
 When in doubt, ask: *can I state this against an arbitrary monad with no

--- a/docs/wiki/interaction.md
+++ b/docs/wiki/interaction.md
@@ -5,7 +5,7 @@ roles, multiparty local views, and concurrent process semantics. PolyFun's
 [`PolyFun/Interaction/`](../../PolyFun/Interaction/) is intentionally
 *generic*. It carries no probability, no security predicates, and no
 concrete cryptographic algebra. Cryptographic content of any kind belongs
-in [`Verified-zkEVM/VCV-io`](https://github.com/Verified-zkEVM/VCV-io)
+in [`Verified-zkEVM/VCVio`](https://github.com/Verified-zkEVM/VCVio)
 downstream.
 
 This page is descriptive. The Lean source under
@@ -41,7 +41,7 @@ The framework is organized around a few stable principles:
   operations (`map`, `par`, `wire`, `plug`). Computational equivalence,
   asymptotic security, and other security-flavored UC layers are *not*
   part of PolyFun: those live in
-  [`Verified-zkEVM/VCV-io`](https://github.com/Verified-zkEVM/VCV-io).
+  [`Verified-zkEVM/VCVio`](https://github.com/Verified-zkEVM/VCVio).
 
 ## Quick orientation
 
@@ -502,7 +502,7 @@ PolyFun deliberately stops here: anything that requires a probability
 monad (e.g. `processSemanticsProbComp`), an oracle simulation
 (`processSemanticsOracle`), or a UC security predicate
 (`UCSecure`, `CompEmulates`) lives downstream in
-[`Verified-zkEVM/VCV-io`](https://github.com/Verified-zkEVM/VCV-io). The
+[`Verified-zkEVM/VCVio`](https://github.com/Verified-zkEVM/VCVio). The
 relevant runtime / async / security files live there, not here.
 
 ## Import guide
@@ -628,10 +628,10 @@ import PolyFun.Interaction.UC.OpenProcessModel
 | `MomentaryCorruption.lean` | momentary corruption surface, parametric over `m` |
 | `Leakage.lean` | leakage-oriented UC observation helpers |
 
-UC files that depended on a probability monad in VCV-io (`Computational.lean`,
+UC files that depended on a probability monad in VCVio (`Computational.lean`,
 `Runtime.lean`, `AsyncRuntime.lean`, `AsyncSecurity.lean`, `Standard.lean`,
 `StdDoBridge.lean`) deliberately do **not** appear in PolyFun. They live in
-[`Verified-zkEVM/VCV-io`](https://github.com/Verified-zkEVM/VCV-io) and
+[`Verified-zkEVM/VCVio`](https://github.com/Verified-zkEVM/VCVio) and
 re-import the generic primitives from PolyFun.
 
 ## In-tree examples
@@ -648,4 +648,4 @@ re-import the generic primitives from PolyFun.
 
 End-to-end UC examples that involve probability monads or concrete
 cryptographic content (one-time pad, oracle protocols, etc.) live in
-VCV-io rather than PolyFun, by design.
+VCVio rather than PolyFun, by design.

--- a/docs/wiki/ipfunctor.md
+++ b/docs/wiki/ipfunctor.md
@@ -268,5 +268,5 @@ so the deterministic elaborator's head check on `FreeM.liftBind` continues to fi
 `IPFunctor` is generic substrate, like `PFunctor`. Downstream usage that
 benefits from state-gated interaction (multi-phase oracle protocols, session
 types) should sit on top, not inline these constructors. Cryptographic
-content remains in [`Verified-zkEVM/VCV-io`](https://github.com/Verified-zkEVM/VCV-io)
+content remains in [`Verified-zkEVM/VCVio`](https://github.com/Verified-zkEVM/VCVio)
 per the project policy in [`CLAUDE.md`](../../CLAUDE.md).

--- a/docs/wiki/pfunctor.md
+++ b/docs/wiki/pfunctor.md
@@ -92,7 +92,7 @@ McBride 2010 / Dagand-McBride 2014 (displayed algebras / ornaments).
 ### Free monad `FreeM`
 
 `PFunctor.FreeM` is **re-exported from upstream cslib**
-(`Cslib.Foundations.Data.PFunctor.Free`, originally ported from VCV-io). cslib
+(`Cslib.Foundations.Data.PFunctor.Free`, originally ported from VCVio). cslib
 supplies the inductive type (constructors `pure` / `liftBind`), the `bind` / `map`
 / `Monad` / `LawfulMonad` / `MonadLift` instances, the `@[induction_eliminator]
 induction` principle (non-pure case `lift_bind`), the shape lift `lift : P.A →

--- a/docs/wiki/repo-map.md
+++ b/docs/wiki/repo-map.md
@@ -111,14 +111,14 @@ PolyFun is intentionally *not* the place for cryptographic content.
 Probabilistic semantics, evaluation distributions, oracle-simulation
 security definitions, scheme-specific algebra, and concrete-protocol
 runtime layers all live in
-[`Verified-zkEVM/VCV-io`](https://github.com/Verified-zkEVM/VCV-io) and
+[`Verified-zkEVM/VCVio`](https://github.com/Verified-zkEVM/VCVio) and
 depend on this library.
 
 When in doubt, ask: *can this definition be stated against an arbitrary
 monad `m` with `[Monad m]` and friends, with no probability, no security
 predicate, and no concrete cryptographic algebra?* If the answer is yes,
 it belongs in PolyFun. If the answer is no, it belongs downstream in
-VCV-io or a more specialized repo.
+VCVio or a more specialized repo.
 
 ## Navigation Notes
 


### PR DESCRIPTION
## Summary

- replace the former `VCV-io` spelling with `VCVio` across PolyFun documentation and docstrings
- update repository links to the canonical `Verified-zkEVM/VCVio` location
- preserve the existing explanation that PolyFun originated as an extraction from VCVio

## Impact

This is a naming-only documentation change. It does not alter declarations, imports, or runtime behavior.

## Validation

- `git diff --check`
- `./scripts/validate.sh`
  - `lake build --wfail`
  - umbrella-import check
  - documentation-integrity check
- verified that no tracked first-party occurrence of `VCV-io` remains
