### PR TITLE
Generalize ITree core universes

### DIFF
--- a/PolyFun/ITree/Basic.lean
+++ b/PolyFun/ITree/Basic.lean
@@ -24,10 +24,12 @@ CoInductive itree (E : Type → Type) (R : Type) :=
 ```
 
 In Lean we model the event signature as a *polynomial functor*
-`F : PFunctor.{u, u}` (shapes are event names, positions are answer types) so
-that the resulting tree lives at a single universe `u`. ITrees themselves are
-the M-type (final coalgebra) of the one-step polynomial functor `Poly F α`
-whose shapes are pure leaves, silent steps, or visible queries.
+`F : PFunctor.{uA, uB}`: its positions are event names and its directions are
+answer types. The event-name, answer, and return universes are independent.
+For `α : Type uα`, the resulting tree lives in `Type (max uA uB uα)`.
+ITrees themselves are the M-type (final coalgebra) of the one-step polynomial
+functor `Poly F α` whose shapes are pure leaves, silent steps, or visible
+queries.
 
 ## Naming conventions
 
@@ -70,7 +72,7 @@ the project's `ITreePilot.lean` (no longer needed once this file is in place).
 
 @[expose] public section
 
-universe u v
+universe uA uB uα uβ
 
 namespace ITree
 
@@ -78,7 +80,7 @@ namespace ITree
 
 /-- One-step view of an ITree node: a pure leaf, a silent step, or a visible
 query. Mirrors Coq's `itreeF` (`Core/ITreeDefinition.v`). -/
-inductive Shape (F : PFunctor.{u, u}) (α : Type u) : Type u where
+inductive Shape (F : PFunctor.{uA, uB}) (α : Type uα) : Type (max uA uα) where
   /-- A leaf carrying a result of type `α`. (Coq `RetF`.) -/
   | pure (r : α) : Shape F α
   /-- A silent (`τ`) step. (Coq `TauF`.) -/
@@ -96,26 +98,29 @@ inductive Shape (F : PFunctor.{u, u}) (α : Type u) : Type u where
   - `.step` has exactly one child (`PUnit`).
   - `.query a` has children indexed by the answer type `F.B a`. -/
 @[reducible]
-def Poly (F : PFunctor.{u, u}) (α : Type u) : PFunctor.{u, u} where
+def Poly (F : PFunctor.{uA, uB}) (α : Type uα) : PFunctor.{max uA uα, uB} where
   A := Shape F α
   B
-    | .pure _r => PEmpty.{u + 1}
-    | .step    => PUnit.{u + 1}
+    | .pure _r => PEmpty.{uB + 1}
+    | .step    => PUnit.{uB + 1}
     | .query a => F.B a
 
 end ITree
 
-/-- Interaction trees over events `F : PFunctor.{u, u}` with leaves of type
-`α : Type u`, defined as the final coalgebra (M-type) of `ITree.Poly F α`.
+/-- Interaction trees over events `F : PFunctor.{uA, uB}` with leaves of type
+`α : Type uα`, defined as the final coalgebra (M-type) of `ITree.Poly F α`.
+
+Event names, event answers, and returned values may live in independent
+universes. The resulting tree lives in `Type (max uA uB uα)`.
 
 This is the Lean / Mathlib analogue of Coq's `itree E R`
 (`InteractionTrees/theories/Core/ITreeDefinition.v`). -/
-def ITree (F : PFunctor.{u, u}) (α : Type u) : Type u :=
+def ITree (F : PFunctor.{uA, uB}) (α : Type uα) : Type (max uA uB uα) :=
   PFunctor.M (ITree.Poly F α)
 
 namespace ITree
 
-variable {F : PFunctor.{u, u}} {α β γ : Type u}
+variable {F : PFunctor.{uA, uB}} {α : Type uα} {β : Type uβ}
 
 /-! ### Smart constructors -/
 

--- a/PolyFun/ITree/Construct.lean
+++ b/PolyFun/ITree/Construct.lean
@@ -25,26 +25,29 @@ The list of definitions and their Coq counterparts:
 | `ITree.ignore`  | `ITree.ignore`    |
 | `burn n t`      | `ITree.take`      |
 
-The `Functor` and `Applicative` instances on `ITree F` are derived from the
-`Monad` instance in `PolyFun.ITree.Basic`; we record the corresponding `simp`
-lemma `Functor.map = ITree.map` so that `simp` can normalise occurrences of
-`(· <$> ·)` to `ITree.map`.
+The named `map`, `cat`, and `forever` operations allow their source and target
+types to live in different universes. The `Functor` and `Applicative` instances
+on `ITree F` are derived from the `Monad` instance in `PolyFun.ITree.Basic` and
+therefore use one value universe at a time. We record the corresponding `simp`
+lemma `Functor.map = ITree.map` on that homogeneous fragment so that `simp` can
+normalise occurrences of `(· <$> ·)` to `ITree.map`.
 -/
 
 @[expose] public section
 
-universe u
+universe u uA uB uα uβ uγ uUnit
 
 namespace ITree
 
-variable {F : PFunctor.{u, u}} {α β γ : Type u}
+variable {F : PFunctor.{uA, uB}} {α : Type uα} {β : Type uβ} {γ : Type uγ}
 
 /-! ### Diverging tree -/
 
 /-- The diverging interaction tree, an infinite sequence of silent (`step`)
 nodes. (Coq `spin`.) -/
 def diverge : ITree F α :=
-  PFunctor.M.corec (F := Poly F α) (fun (_ : PUnit.{u + 1}) => ⟨.step, fun _ => PUnit.unit⟩)
+  PFunctor.M.corec (F := Poly F α)
+    (fun (_ : PUnit.{uB + 1}) => ⟨.step, fun _ => PUnit.unit⟩)
     PUnit.unit
 
 @[simp] theorem shape'_diverge :
@@ -73,8 +76,9 @@ def cat (f : α → ITree F β) (g : β → ITree F γ) : α → ITree F γ :=
 
 /-! ### Ignoring the result -/
 
-/-- Run `t`, discarding its leaf value. (Coq `ITree.ignore`.) -/
-def ignore (t : ITree F α) : ITree F PUnit.{u + 1} :=
+/-- Run `t`, discarding its leaf value. The unit result may live in any
+universe. (Coq `ITree.ignore`.) -/
+def ignore (t : ITree F α) : ITree F PUnit.{uUnit + 1} :=
   map (fun _ => PUnit.unit) t
 
 /-! ### Forever -/
@@ -82,7 +86,7 @@ def ignore (t : ITree F α) : ITree F PUnit.{u + 1} :=
 /-- Run `t` forever, discarding each leaf value. The result type `β` is
 arbitrary because `forever t` never produces a leaf. (Coq `forever`.) -/
 def forever (t : ITree F α) : ITree F β :=
-  iter (fun _ : PUnit.{u + 1} => bind t (fun _ => pure (Sum.inl PUnit.unit))) PUnit.unit
+  iter (fun _ : PUnit.{uB + 1} => bind t (fun _ => pure (Sum.inl PUnit.unit))) PUnit.unit
 
 /-! ### Bounded execution -/
 
@@ -130,7 +134,7 @@ in `PolyFun.ITree.Basic`) and computes `Functor.map f t` as
 a `simp` lemma so that ordinary `(· <$> ·)` notation is normalised to
 `ITree.map`. -/
 
-@[simp] theorem map_eq_functor_map (f : α → β) (t : ITree F α) :
+@[simp] theorem map_eq_functor_map {α β : Type u} (f : α → β) (t : ITree F α) :
     f <$> t = ITree.map f t := rfl
 
 end ITree

--- a/PolyFun/ITree/Unfold.lean
+++ b/PolyFun/ITree/Unfold.lean
@@ -24,33 +24,35 @@ no silent steps — every node is a `query` at the exposed position.
 
 @[expose] public section
 
-universe u v
+universe uA uB uR uS
 
 namespace PFunctor
 
 /-- Embed a `p`-behavior tree as an interaction tree over event signature `p`:
 every node becomes a visible `query` at its position, with the same children.
-The result never returns (`PEmpty` leaves) and takes no silent steps. -/
-def M.toITree {p : PFunctor.{u, u}} : M p → ITree p PEmpty.{u + 1} :=
+The result never returns (`PEmpty` leaves) and takes no silent steps. The empty
+return type may live in a universe independent of both universes of `p`. -/
+def M.toITree {p : PFunctor.{uA, uB}} : M p → ITree p PEmpty.{uR + 1} :=
   M.corec fun t => ⟨.query (M.dest t).1, (M.dest t).2⟩
 
 namespace DynSystem
 
 /-- The ITree unfolding of a dynamical system from a state: query the exposed
 position forever, transitioning along each answer. -/
-def toITree {S : Type v} {p : PFunctor.{u, u}} (s : DynSystem S p) :
-    S → ITree p PEmpty.{u + 1} :=
+def toITree {S : Type uS} {p : PFunctor.{uA, uB}} (s : DynSystem S p) :
+    S → ITree p PEmpty.{uR + 1} :=
   M.corec fun st => ⟨.query (s.expose st), fun d => s.update st d⟩
 
-@[simp] theorem dest_toITree {S : Type v} {p : PFunctor.{u, u}} (s : DynSystem S p) (st : S) :
+@[simp] theorem dest_toITree {S : Type uS} {p : PFunctor.{uA, uB}}
+    (s : DynSystem S p) (st : S) :
     M.dest (s.toITree st)
       = ⟨.query (s.expose st), fun d => s.toITree (s.update st d)⟩ := by
   simp only [toITree, M.dest_corec_apply]
 
 /-- Unfolding a system into an ITree is the query-embedding of its behavior
 tree: the two coinductive semantics agree. -/
-theorem toITree_eq_toITree_behavior {S : Type v} {p : PFunctor.{u, u}} (s : DynSystem S p)
-    (st : S) : s.toITree st = M.toITree (s.behavior st) := by
+theorem toITree_eq_toITree_behavior {S : Type uS} {p : PFunctor.{uA, uB}}
+    (s : DynSystem S p) (st : S) : s.toITree st = M.toITree (s.behavior st) := by
   refine congrFun (Eq.symm (M.corec_unique _ (fun st => M.toITree (s.behavior st)) ?_)) st
   intro st
   simp only [M.toITree, M.dest_corec_apply]

--- a/PolyFunTest/ITree/UniverseExamples.lean
+++ b/PolyFunTest/ITree/UniverseExamples.lean
@@ -1,0 +1,87 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+module
+
+public import PolyFun.ITree.Construct
+public import PolyFun.ITree.Unfold
+
+/-!
+# Universe-polymorphic interaction-tree examples
+
+These examples are compile-time canaries for the public universe contract of
+`ITree`. Event positions, event directions, returned values, and coalgebra
+states may inhabit independent universes.
+-/
+
+@[expose] public section
+
+universe u uA uB uR uS uT uState
+
+namespace ITree.UniverseExamples
+
+variable {F : PFunctor.{uA, uB}} {R : Type uR} {S : Type uS}
+  {State : Type uState}
+
+/-- The one-step shape joins only the event-position and return universes. -/
+example : Type (max uA uR) := ITree.Shape F R
+
+/-- Directions of the one-step polynomial remain in the event-direction
+universe. -/
+example : PFunctor.{max uA uR, uB} := ITree.Poly F R
+
+/-- The final coalgebra joins the two signature universes with the return
+universe. -/
+example : Type (max uA uB uR) := ITree F R
+
+/-- A visible query can return a value from a universe unrelated to either
+universe of the event signature. -/
+def queryAndReturn (a : F.A) (k : F.B a → R) : ITree F R :=
+  ITree.query a (fun answer => ITree.pure (k answer))
+
+example (a : F.A) (k : F.B a → R) :
+    ITree.shape (queryAndReturn a k) = .query a := by
+  simp [queryAndReturn]
+
+/-- Named bind supports a universe change in the return type. -/
+def mixedBind (tree : ITree F R) (next : R → ITree F S) : ITree F S :=
+  ITree.bind tree next
+
+/-- Named map supports a universe change in the return type. -/
+def mixedMap (f : R → S) (tree : ITree F R) : ITree F S :=
+  ITree.map f tree
+
+/-- Kleisli composition inherits the mixed-universe behavior of bind. -/
+def mixedCat {T : Type uT} (first : R → ITree F S) (second : S → ITree F T) :
+    R → ITree F T :=
+  ITree.cat first second
+
+/-- A non-returning loop may be assigned a result in any universe. -/
+def mixedForever (tree : ITree F R) : ITree F S :=
+  ITree.forever tree
+
+/-- Discarding a result does not force the unit type into the source-result
+universe. -/
+def mixedIgnore (tree : ITree F R) : ITree F PUnit.{uT + 1} :=
+  ITree.ignore tree
+
+/-- Lean's `Monad` interface is necessarily homogeneous in the value universe;
+the named operations above provide the heterogeneous API. -/
+def homogeneousDo {A B : Type u} (tree : ITree F A) (next : A → ITree F B) :
+    ITree F B := do
+  next (← tree)
+
+/-- Embedding an M-type behavior permits an independently universe-lifted
+empty return type. -/
+def behaviorToITree (tree : PFunctor.M F) : ITree F PEmpty.{uR + 1} :=
+  PFunctor.M.toITree tree
+
+/-- Dynamical-system states are also independent of the signature and empty
+return universes. -/
+def systemToITree (system : PFunctor.DynSystem State F) (state : State) :
+    ITree F PEmpty.{uR + 1} :=
+  system.toITree state
+
+end ITree.UniverseExamples

--- a/docs/wiki/itree.md
+++ b/docs/wiki/itree.md
@@ -18,10 +18,22 @@ CoInductive itree (E : Type → Type) (R : Type) :=
 ```
 
 In Lean we model the event signature as a *polynomial functor*
-`F : PFunctor.{u, u}` (shapes are event names, positions are answer types)
-so the resulting tree lives at a single universe `u`. ITrees themselves
-are the M-type (final coalgebra) of the one-step polynomial functor
-`Poly F α` whose shapes are pure leaves, silent steps, or visible queries.
+`F : PFunctor.{uA, uB}`: its positions are event names and its directions are
+answer types. The event-position, event-direction, and return universes are
+independent. ITrees themselves are the M-type (final coalgebra) of the one-step
+polynomial functor `Poly F α` whose positions are pure leaves, silent steps, or
+visible queries.
+
+For `α : Type uR`, the public universe contract is:
+
+```lean
+ITree.Shape F α : Type (max uA uR)
+ITree.Poly F α  : PFunctor.{max uA uR, uB}
+ITree F α       : Type (max uA uB uR)
+```
+
+The empty direction type of a pure leaf and the unit direction type of a silent
+step are lifted to `uB`; a visible query retains its original direction type.
 
 | Coq | Lean |
 |---|---|
@@ -37,8 +49,8 @@ are the M-type (final coalgebra) of the one-step polynomial functor
 
 | File | Purpose |
 |------|---------|
-| [`PolyFun/ITree/Basic.lean`](../../PolyFun/ITree/Basic.lean) | `ITree F α` defined as `PFunctor.M (Poly F α)`, `Shape` (one-step view), smart constructors `pure` / `step` / `query`, `bind`, `iter`, `Monad` instance. |
-| [`PolyFun/ITree/Construct.lean`](../../PolyFun/ITree/Construct.lean) | Standard combinators: `diverge` (Coq `spin`), `forever`, `map`, `cat`, `ignore`, `burn`. Pure consequences of `bind` / `iter` / `M.corec`. |
+| [`PolyFun/ITree/Basic.lean`](../../PolyFun/ITree/Basic.lean) | `ITree F α` defined as `PFunctor.M (Poly F α)`, `Shape` (one-step view), smart constructors `pure` / `step` / `query`, mixed-universe named `bind`, `iter`, and the homogeneous `Monad` instance. |
+| [`PolyFun/ITree/Construct.lean`](../../PolyFun/ITree/Construct.lean) | Standard combinators: `diverge` (Coq `spin`), `forever`, mixed-universe `map` / `cat`, `ignore`, `burn`. Pure consequences of `bind` / `iter` / `M.corec`. |
 | [`PolyFun/ITree/Handler.lean`](../../PolyFun/ITree/Handler.lean) | `Handler E F`: choice of `F`-program for every `E`-event. Source data of the simulation operator. |
 | [`PolyFun/ITree/Sim/Defs.lean`](../../PolyFun/ITree/Sim/Defs.lean) | `ITree.simulate` (interprets every event via a handler), `ITree.mapSpec` (pure event-renaming via a `PFunctor.Lens`). Coq `interp` analogue. |
 | [`PolyFun/ITree/Sim/Facts.lean`](../../PolyFun/ITree/Sim/Facts.lean) | Algebraic facts about simulation. |


### PR DESCRIPTION
## Summary

- generalize `ITree.Shape`, `ITree.Poly`, and `ITree` across independent event-position, event-direction, and return universes
- preserve mixed-universe named operations in `Basic` and `Construct`, while documenting the homogeneous `Monad`/`Functor` typeclass fragment
- generalize M-type and dynamical-system unfolding to independent signature, state, and empty-return universes
- add producer-level compile canaries for the exact universe contract and update the ITree wiki

## Motivation

The core previously imposed `F : PFunctor.{u, u}` and `R : Type u`, coupling three mathematically independent components. This blocked ordinary signatures whose event names, answers, and returned values inhabit different universes.

The resulting core contract is:

```lean
ITree.Shape F R : Type (max uA uR)
ITree.Poly F R  : PFunctor.{max uA uR, uB}
ITree F R       : Type (max uA uB uR)
```

This is the I1/core slice of #33. Later Handler/Sim/Bisim/event-theory work can build on it independently; all current downstream ITree modules remain source-compatible and compile unchanged.

## Validation

- `lake build` — 8,805 jobs
- `lake test`
- `./scripts/validate.sh --lint --test`
- `lake exe lint-style`
- `git diff --check`
