### PR TITLE
Generalize ITree handlers and simulation

### DIFF
--- a/PolyFun/ITree/Bisim/Bind.lean
+++ b/PolyFun/ITree/Bisim/Bind.lean
@@ -10,13 +10,18 @@ public import PolyFun.ITree.Bisim.Equiv
 /-! # Algebraic laws for `bind` and `iter`
 
 The classical equational theory of interaction trees, lifted to Lean. All
-laws are stated either as strong bisimulations (`Bisim`, i.e. definitional
+laws are stated either as strong bisimulations (`Bisim`, i.e. Lean
 equality of M-types) or weak bisimulations (`WeakBisim`).
+
+The event-position and event-direction universes and every result type used by
+the named `bind`/`iter` laws are independent. `bind_weakBisimRel` exposes the
+fully relational theorem; `bind_weakBisim_cont` is its equality-specialized,
+one-sided corollary.
 
 ## Main statements
 
 * `bind_pure_left`, `bind_pure_right`, `bind_assoc` — monad laws on
-  `ITree.bind`, as strong bisimulations (i.e. definitional equalities on
+  `ITree.bind`, as strong bisimulations (i.e. exact equalities on
   `PFunctor.M`).
 * `bind_step`, `bind_query` — `bind` distributes over a leading silent
   step / visible query.
@@ -25,16 +30,21 @@ equality of M-types) or weak bisimulations (`WeakBisim`).
 * `iter_bind` — left-distributive interaction between `iter` and `bind`.
 * `step_weakBisim` — silent steps are absorbed by weak bisimulation
   (`step t ≈ t`); the defining feature of `eutt`.
-* `bind_weakBisim_cont` — weak bind-congruence on the continuation.
+* `bind_weakBisimRel` — two-sided relational bind congruence for different
+  source and target result types and universes.
+* `map_weakBisimRel` — relational congruence of `ITree.map`.
+* `bind_weakBisim_cont` — equality-specialized weak bind-congruence on the
+  continuation.
 -/
 
 @[expose] public section
 
-universe u
+universe uFA uFB uα uβ uγ uδ
 
 namespace ITree
 
-variable {F : PFunctor.{u, u}} {α β γ : Type u}
+variable {F : PFunctor.{uFA, uFB}} {α : Type uα} {β : Type uβ}
+  {γ : Type uγ} {δ : Type uδ}
 
 /-! ### Monad laws -/
 
@@ -248,7 +258,7 @@ theorem iter_unfold (body : β → ITree F (β ⊕ α)) (init : β) :
                     ⟨.pure (.inl j), PEmpty.elim⟩ from PFunctor.M.dest_mk _]
               rfl
             · rw [bind_pure_left]
-              show PFunctor.M.dest (kk (.inl j)) = ⟨.step, fun _ => iter body j⟩
+              change PFunctor.M.dest (kk (.inl j)) = ⟨.step, fun _ => iter body j⟩
               rw [hkk]
               exact shape'_step _
         | inr r =>
@@ -268,7 +278,7 @@ theorem iter_unfold (body : β → ITree F (β ⊕ α)) (init : β) :
               funext z
               exact z.elim
             · rw [bind_pure_left]
-              show PFunctor.M.dest (kk (.inr r)) = ⟨.pure r, PEmpty.elim⟩
+              change PFunctor.M.dest (kk (.inr r)) = ⟨.pure r, PEmpty.elim⟩
               rw [hkk]
               exact shape'_pure r
     | step =>
@@ -538,7 +548,83 @@ theorem step_weakBisim (t : ITree F α) : WeakBisim (step t) t :=
   WeakBisim.absorb_tauSteps_left
     (TauSteps.one (fun _ => t) (shape'_step t)) (WeakBisim.refl t)
 
-/-! ### Weak bind-congruence on the continuation
+/-! ### Relational bind and map congruence -/
+
+namespace TauSteps
+
+/-- Binding a continuation preserves finite silent-step stripping. -/
+theorem bind {t t' : ITree F α} (h : TauSteps t t')
+    (k : α → ITree F β) : TauSteps (ITree.bind t k) (ITree.bind t' k) := by
+  induction h with
+  | refl _ => exact .refl _
+  | step c ht _ ih =>
+      exact .step (fun _ => ITree.bind (c PUnit.unit) k)
+        (dest_bind_step k _ c ht) ih
+
+end TauSteps
+
+/-- Two-sided relational congruence for `bind`.
+
+The source trees may return different types related by `RR`; their
+continuations may return two further different types related by `SS`. All
+four result universes are independent of each other and of the event
+signature. -/
+theorem bind_weakBisimRel {RR : α → β → Prop} {SS : γ → δ → Prop}
+    {u : ITree F α} {v : ITree F β}
+    {f : α → ITree F γ} {g : β → ITree F δ}
+    (huv : WeakBisimRel RR u v)
+    (hfg : ∀ a b, RR a b → WeakBisimRel SS (f a) (g b)) :
+    WeakBisimRel SS (bind u f) (bind v g) := by
+  refine WeakBisimRel.coinduct SS
+    (fun x y =>
+      (∃ u v, WeakBisimRel RR u v ∧ x = bind u f ∧ y = bind v g) ∨
+      WeakBisimRel SS x y) ?_ (Or.inl ⟨u, v, huv, rfl, rfl⟩)
+  rintro x y (⟨u, v, huv, rfl, rfl⟩ | hxy)
+  · obtain ⟨u', v', hu, hv, M⟩ := huv.dest
+    cases M with
+    | pure r s hrs hu' hv' =>
+        have hut : u' = pure r := by
+          apply PFunctor.M.eq_of_dest_eq
+          change shape' u' = shape' (pure r)
+          exact hu'.trans (shape'_pure r).symm
+        have hvt : v' = pure s := by
+          apply PFunctor.M.eq_of_dest_eq
+          change shape' v' = shape' (pure s)
+          exact hv'.trans (shape'_pure s).symm
+        subst hut
+        subst hvt
+        obtain ⟨x', y', hx, hy, Mxy⟩ := (hfg r s hrs).dest
+        refine ⟨x', y', ?_, ?_, Mxy.mono (fun _ _ h => Or.inr h)⟩
+        · have huf : TauSteps (bind u f) (f r) := by
+            simpa only [bind_pure_left] using hu.bind f
+          exact huf.trans hx
+        · have hvg : TauSteps (bind v g) (g s) := by
+            simpa only [bind_pure_left] using hv.bind g
+          exact hvg.trans hy
+    | query a c c' hu' hv' hcc =>
+        refine ⟨bind u' f, bind v' g, hu.bind f, hv.bind g, ?_⟩
+        refine MatchRel.query a (fun b => bind (c b) f) (fun b => bind (c' b) g)
+          (dest_bind_query f u' a c hu') (dest_bind_query g v' a c' hv') ?_
+        intro b
+        exact Or.inl ⟨c b, c' b, hcc b, rfl, rfl⟩
+    | tau cu cv hu' hv' hcc =>
+        refine ⟨bind u' f, bind v' g, hu.bind f, hv.bind g, ?_⟩
+        refine MatchRel.tau (fun _ => bind (cu PUnit.unit) f)
+          (fun _ => bind (cv PUnit.unit) g)
+          (dest_bind_step f u' cu hu') (dest_bind_step g v' cv hv') ?_
+        exact Or.inl ⟨cu PUnit.unit, cv PUnit.unit, hcc, rfl, rfl⟩
+  · obtain ⟨x', y', hx, hy, M⟩ := hxy.dest
+    exact ⟨x', y', hx, hy, M.mono (fun _ _ h => Or.inr h)⟩
+
+/-- Relational congruence of `ITree.map`. -/
+theorem map_weakBisimRel {RR : α → β → Prop} {SS : γ → δ → Prop}
+    (f : α → γ) (g : β → δ) {u : ITree F α} {v : ITree F β}
+    (huv : WeakBisimRel RR u v) (hfg : ∀ a b, RR a b → SS (f a) (g b)) :
+    WeakBisimRel SS (map f u) (map g v) := by
+  unfold map
+  exact bind_weakBisimRel huv (fun a b hab => WeakBisimRel.pure (hfg a b hab))
+
+/-! ### Equality-specialized bind congruence
 
 Pointwise-weak-bisimilar continuations yield weakly-bisimilar `bind`s. This
 is the `eutt` congruence lemma for `bind` on its second argument; the
@@ -547,35 +633,7 @@ standard tool for replacing a continuation up to weak equivalence. -/
 /-- If `f a ≈ g a` for every `a`, then `bind u f ≈ bind u g`. -/
 theorem bind_weakBisim_cont {u : ITree F α} {f g : α → ITree F β}
     (hfg : ∀ a, WeakBisim (f a) (g a)) :
-    WeakBisim (bind u f) (bind u g) := by
-  refine WeakBisim.coinduct
-    (fun x y => (∃ u : ITree F α, x = bind u f ∧ y = bind u g) ∨ WeakBisim x y)
-    ?_ (Or.inl ⟨u, rfl, rfl⟩)
-  rintro a b (⟨u, rfl, rfl⟩ | hab)
-  · rcases hu : PFunctor.M.dest u with ⟨sh, c⟩
-    cases sh with
-    | pure r =>
-        have hu_eq : u = pure r := by
-          apply PFunctor.M.eq_of_dest_eq; rw [hu]
-          change (⟨.pure r, c⟩ : (Poly F α).Obj _) = ⟨.pure r, PEmpty.elim⟩
-          congr 1; funext z; exact z.elim
-        subst hu_eq
-        rw [bind_pure_left, bind_pure_left]
-        obtain ⟨x', y', hx, hy, M⟩ := (hfg r).dest
-        exact ⟨x', y', hx, hy, M.mono (fun _ _ hxy => Or.inr hxy)⟩
-    | step =>
-        refine ⟨bind u f, bind u g, .refl _, .refl _, ?_⟩
-        refine Match.tau (fun _ => bind (c PUnit.unit) f)
-          (fun _ => bind (c PUnit.unit) g) (dest_bind_step f u c hu)
-          (dest_bind_step g u c hu) ?_
-        exact Or.inl ⟨c PUnit.unit, rfl, rfl⟩
-    | query a =>
-        refine ⟨bind u f, bind u g, .refl _, .refl _, ?_⟩
-        refine Match.query a (fun b => bind (c b) f) (fun b => bind (c b) g)
-          (dest_bind_query f u a c hu) (dest_bind_query g u a c hu) ?_
-        intro b
-        exact Or.inl ⟨c b, rfl, rfl⟩
-  · obtain ⟨x', y', hx, hy, M⟩ := hab.dest
-    exact ⟨x', y', hx, hy, M.mono (fun _ _ hxy => Or.inr hxy)⟩
+    WeakBisim (bind u f) (bind u g) :=
+  bind_weakBisimRel (WeakBisim.refl u) (fun a _ hab => hab ▸ hfg a)
 
 end ITree

--- a/PolyFun/ITree/Bisim/Defs.lean
+++ b/PolyFun/ITree/Bisim/Defs.lean
@@ -15,10 +15,15 @@ algebraic theory:
 * `ITree.Bisim t s` — *strong* (a.k.a. structural) bisimulation. Two ITrees
   are strongly bisimilar iff their one-step shapes match and the
   continuations are pointwise bisimilar. By the universal property of
-  `PFunctor.M`, strong bisimulation coincides with definitional equality;
+  `PFunctor.M`, strong bisimulation coincides with Lean equality;
   for that reason we set `Bisim = (· = ·)`.
 
-* `ITree.WeakBisim t s` — *weak* bisimulation (Coq `eutt`). Two ITrees are
+* `ITree.WeakBisimRel RR t s` — relational weak bisimulation (Coq `euttR`).
+  The trees share an event signature, but their return types and universes are
+  independent; pure leaves are compared by `RR`.
+
+* `ITree.WeakBisim t s` — the equality-specialized weak bisimulation (Coq
+  `eutt`). Two ITrees are
   weakly bisimilar iff, after stripping any *finitely many* leading `step`
   nodes from each side, their observable heads agree (pure leaves, visible
   queries, or paired silent steps) and continuations are pointwise weakly
@@ -37,30 +42,34 @@ and let each coinductive "step" of `WeakBisim` consist of stripping
 finitely many τ's from each side and then matching observable heads via
 the `Match` functor.
 
-We define `WeakBisim` as the Tarski greatest fixed point of the
-one-step functor packaged by `TauSteps` + `Match`, i.e. as the largest
+We define `WeakBisimRel` as the Tarski greatest fixed point of the
+one-step functor packaged by `TauSteps` + `MatchRel`, i.e. as the largest
 relation `R` that is closed under the functor. This `∃ R, …` form is
-used because Lean 4.29's `coinductive` keyword requires syntactic
+used because Lean's `coinductive` keyword requires syntactic
 monotonicity, which does not see through the separately-declared
-`Match` inductive.
+`MatchRel` inductive.
 
 ## Implementation notes
 
-Lean 4.29 supports `coinductive` *predicates*, but the monotonicity
+Lean supports `coinductive` *predicates*, but the monotonicity
 checker is syntactic. We therefore use the explicit Tarski formulation
 `∃ R, R t s ∧ closure`. The coinduction principle is then the
-constructor itself (`WeakBisim.coinduct`), and the standard algebraic
-laws (reflexivity, symmetry, transitivity) are recovered by exhibiting
-an appropriate witness relation `R` in each case.
+constructor itself (`WeakBisimRel.coinduct`), and the standard algebraic
+laws for the equality specialization are recovered by exhibiting an
+appropriate witness relation `R` in each case.
+
+All event-position, event-direction, and result universes are independent.
+The two trees in `WeakBisimRel` deliberately share one event signature;
+relating different signatures is the separate relational-simulation layer.
 -/
 
 @[expose] public section
 
-universe u
+universe uFA uFB uα uβ
 
 namespace ITree
 
-variable {F : PFunctor.{u, u}} {α : Type u}
+variable {F : PFunctor.{uFA, uFB}} {α : Type uα} {β : Type uβ}
 
 /-! ### Strong bisimulation -/
 
@@ -102,7 +111,7 @@ inductive TauSteps : ITree F α → ITree F α → Prop where
   /-- Strip zero steps: `t` is reachable from itself. -/
   | refl (t : ITree F α) : TauSteps t t
   /-- Strip one step from a step-headed tree and continue stripping. -/
-  | step {t t' : ITree F α} (c : PUnit.{u + 1} → ITree F α)
+  | step {t t' : ITree F α} (c : PUnit.{uFB + 1} → ITree F α)
       (ht : shape' t = ⟨.step, c⟩) (hr : TauSteps (c PUnit.unit) t') :
       TauSteps t t'
 
@@ -116,12 +125,12 @@ theorem trans {t s u : ITree F α} (h₁ : TauSteps t s) (h₂ : TauSteps s u) :
   | step c ht _ ih => exact .step c ht (ih h₂)
 
 /-- Stripping one step is available when the head is a step. -/
-theorem one {t : ITree F α} (c : PUnit.{u + 1} → ITree F α)
+theorem one {t : ITree F α} (c : PUnit.{uFB + 1} → ITree F α)
     (ht : shape' t = ⟨.step, c⟩) : TauSteps t (c PUnit.unit) :=
   TauSteps.step (t' := c PUnit.unit) c ht (TauSteps.refl _)
 
 /-- The `.step` relation is deterministic on step-headed trees. -/
-theorem cont_eq {t : ITree F α} {c c' : PUnit.{u + 1} → ITree F α}
+theorem cont_eq {t : ITree F α} {c c' : PUnit.{uFB + 1} → ITree F α}
     (h : shape' t = ⟨.step, c⟩) (h' : shape' t = ⟨.step, c'⟩) : c = c' := by
   have hmk := h.symm.trans h'
   exact eq_of_heq (Sigma.mk.inj hmk).2
@@ -143,7 +152,72 @@ theorem linear {t a b : ITree F α}
 
 end TauSteps
 
-/-! ### Head match relation
+/-! ### Relational head matching
+
+`MatchRel RR R t s` pins two trees whose observable heads agree. Pure
+leaves are compared by `RR`; visible queries share an event and compare
+their continuations pointwise by `R`; paired silent steps also continue
+through `R`. There is no τ-stripping here: stripping happens separately
+via `TauSteps` before invoking `MatchRel`. -/
+
+/-- One-step observable head match for trees with potentially different
+return types. -/
+inductive MatchRel (RR : α → β → Prop)
+    (R : ITree F α → ITree F β → Prop) :
+    ITree F α → ITree F β → Prop where
+  /-- Both heads are pure leaves carrying `RR`-related values. -/
+  | pure {t : ITree F α} {s : ITree F β} (r : α) (r' : β) (hrr : RR r r')
+      (ht : shape' t = ⟨.pure r, PEmpty.elim⟩)
+      (hs : shape' s = ⟨.pure r', PEmpty.elim⟩) :
+      MatchRel RR R t s
+  /-- Both heads are visible queries on the same event. -/
+  | query {t : ITree F α} {s : ITree F β} (a : F.A)
+      (c : F.B a → ITree F α) (c' : F.B a → ITree F β)
+      (ht : shape' t = ⟨.query a, c⟩) (hs : shape' s = ⟨.query a, c'⟩)
+      (h : ∀ b, R (c b) (c' b)) :
+      MatchRel RR R t s
+  /-- Both heads are silent steps, with continuations related by `R`. -/
+  | tau {t : ITree F α} {s : ITree F β}
+      (ct : PUnit.{uFB + 1} → ITree F α)
+      (cs : PUnit.{uFB + 1} → ITree F β)
+      (ht : shape' t = ⟨.step, ct⟩) (hs : shape' s = ⟨.step, cs⟩)
+      (h : R (ct PUnit.unit) (cs PUnit.unit)) :
+      MatchRel RR R t s
+
+namespace MatchRel
+
+/-- Monotonicity in the continuation relation. -/
+theorem mono {RR : α → β → Prop}
+    {R R' : ITree F α → ITree F β → Prop}
+    (h : ∀ a b, R a b → R' a b) {t : ITree F α} {s : ITree F β}
+    (hM : MatchRel RR R t s) : MatchRel RR R' t s := by
+  cases hM with
+  | pure r r' hrr ht hs => exact .pure r r' hrr ht hs
+  | query a c c' ht hs hcc => exact .query a c c' ht hs (fun b => h _ _ (hcc b))
+  | tau ct cs ht hs hr => exact .tau ct cs ht hs (h _ _ hr)
+
+/-- Monotonicity in the return-value relation. -/
+theorem mono_result {RR RR' : α → β → Prop}
+    (h : ∀ a b, RR a b → RR' a b)
+    {R : ITree F α → ITree F β → Prop} {t : ITree F α} {s : ITree F β}
+    (hM : MatchRel RR R t s) : MatchRel RR' R t s := by
+  cases hM with
+  | pure r r' hrr ht hs => exact .pure r r' (h _ _ hrr) ht hs
+  | query a c c' ht hs hcc => exact .query a c c' ht hs hcc
+  | tau ct cs ht hs hr => exact .tau ct cs ht hs hr
+
+/-- Swap the two trees and both component relations. -/
+theorem swap {RR : α → β → Prop} {R : ITree F α → ITree F β → Prop}
+    {t : ITree F α} {s : ITree F β} (hM : MatchRel RR R t s) :
+    MatchRel (fun b a => RR a b) (fun y x => R x y) s t := by
+  cases hM with
+  | pure r r' hrr ht hs => exact .pure r' r hrr hs ht
+  | query a c c' ht hs hcc => exact .query a c' c hs ht (fun b => hcc b)
+  | tau ct cs ht hs hr => exact .tau cs ct hs ht hr
+
+end MatchRel
+
+/-! ### Equality-specialized head match compatibility view
 
 `Match R t s` pins two trees whose observable heads agree. There is no
 τ-stripping here: stripping happens separately via `TauSteps` before
@@ -166,7 +240,7 @@ inductive Match (R : ITree F α → ITree F α → Prop) :
       (h : ∀ b, R (c b) (c' b)) :
       Match R t s
   /-- Both heads are silent steps, with continuations related by `R`. -/
-  | tau {t s : ITree F α} (ct cs : PUnit.{u + 1} → ITree F α)
+  | tau {t s : ITree F α} (ct cs : PUnit.{uFB + 1} → ITree F α)
       (ht : shape' t = ⟨.step, ct⟩) (hs : shape' s = ⟨.step, cs⟩)
       (h : R (ct PUnit.unit) (cs PUnit.unit)) :
       Match R t s
@@ -192,7 +266,104 @@ theorem swap {R : ITree F α → ITree F α → Prop} {t s : ITree F α}
 
 end Match
 
-/-! ### Weak bisimulation -/
+/-- Embed the equality-specialized compatibility view into `MatchRel`. -/
+theorem Match.toMatchRel {R : ITree F α → ITree F α → Prop}
+    {t s : ITree F α} (hM : Match R t s) : MatchRel Eq R t s := by
+  cases hM with
+  | pure r ht hs => exact .pure r r rfl ht hs
+  | query a c c' ht hs hcc => exact .query a c c' ht hs hcc
+  | tau ct cs ht hs hr => exact .tau ct cs ht hs hr
+
+/-- Recover the compatibility `Match` view from an equality-specialized
+relational head match. -/
+theorem MatchRel.toMatch {R : ITree F α → ITree F α → Prop}
+    {t s : ITree F α} (hM : MatchRel Eq R t s) : Match R t s := by
+  cases hM with
+  | pure r r' hrr ht hs =>
+      subst r'
+      exact .pure r ht hs
+  | query a c c' ht hs hcc => exact .query a c c' ht hs hcc
+  | tau ct cs ht hs hr => exact .tau ct cs ht hs hr
+
+/-! ### Relational weak bisimulation -/
+
+/-- One-step unfolding functor for relational weak bisimulation. -/
+def WeakBisimRelF (RR : α → β → Prop)
+    (R : ITree F α → ITree F β → Prop)
+    (t : ITree F α) (s : ITree F β) : Prop :=
+  ∃ t' : ITree F α, ∃ s' : ITree F β,
+    TauSteps t t' ∧ TauSteps s s' ∧ MatchRel RR R t' s'
+
+namespace WeakBisimRelF
+
+/-- Monotonicity in the continuation relation. -/
+theorem mono {RR : α → β → Prop}
+    {R R' : ITree F α → ITree F β → Prop}
+    (h : ∀ a b, R a b → R' a b) {t : ITree F α} {s : ITree F β}
+    (hF : WeakBisimRelF RR R t s) : WeakBisimRelF RR R' t s := by
+  obtain ⟨t', s', ht, hs, hm⟩ := hF
+  exact ⟨t', s', ht, hs, hm.mono h⟩
+
+/-- Monotonicity in the return-value relation. -/
+theorem mono_result {RR RR' : α → β → Prop}
+    (h : ∀ a b, RR a b → RR' a b)
+    {R : ITree F α → ITree F β → Prop} {t : ITree F α} {s : ITree F β}
+    (hF : WeakBisimRelF RR R t s) : WeakBisimRelF RR' R t s := by
+  obtain ⟨t', s', ht, hs, hm⟩ := hF
+  exact ⟨t', s', ht, hs, hm.mono_result h⟩
+
+end WeakBisimRelF
+
+/-- Relational weak bisimulation (`euttR`). The trees share an event
+signature but may have return types in different universes. -/
+def WeakBisimRel (RR : α → β → Prop) (t : ITree F α) (s : ITree F β) : Prop :=
+  ∃ R : ITree F α → ITree F β → Prop,
+    (∀ a b, R a b → WeakBisimRelF RR R a b) ∧ R t s
+
+@[inherit_doc] scoped notation:50 t " ≈[" RR "] " s => ITree.WeakBisimRel RR t s
+
+namespace WeakBisimRel
+
+/-- Coinduction principle for relational weak bisimulation. -/
+theorem coinduct (RR : α → β → Prop) (R : ITree F α → ITree F β → Prop)
+    (h : ∀ a b, R a b → WeakBisimRelF RR R a b)
+    {a : ITree F α} {b : ITree F β} (hab : R a b) : WeakBisimRel RR a b :=
+  ⟨R, h, hab⟩
+
+/-- Relational weak bisimulation is closed under its one-step functor. -/
+theorem unfold {RR : α → β → Prop} {t : ITree F α} {s : ITree F β}
+    (h : WeakBisimRel RR t s) : WeakBisimRelF RR (WeakBisimRel RR) t s := by
+  obtain ⟨R, hcl, hR⟩ := h
+  obtain ⟨t', s', ht, hs, hm⟩ := hcl _ _ hR
+  exact ⟨t', s', ht, hs, hm.mono (fun x y hxy => ⟨R, hcl, hxy⟩)⟩
+
+/-- Extract the stripped-heads relational match witness. -/
+theorem dest {RR : α → β → Prop} {t : ITree F α} {s : ITree F β}
+    (h : WeakBisimRel RR t s) :
+    ∃ t' : ITree F α, ∃ s' : ITree F β,
+      TauSteps t t' ∧ TauSteps s s' ∧ MatchRel RR (WeakBisimRel RR) t' s' :=
+  unfold h
+
+/-- Folding rule for relational weak bisimulation. -/
+theorem fold {RR : α → β → Prop} {t : ITree F α} {s : ITree F β}
+    (h : WeakBisimRelF RR (WeakBisimRel RR) t s) : WeakBisimRel RR t s := by
+  obtain ⟨t', s', ht, hs, hm⟩ := h
+  refine coinduct RR (fun a b => WeakBisimRel RR a b ∨ (a = t ∧ b = s))
+    ?_ (Or.inr ⟨rfl, rfl⟩)
+  rintro a b (hab | ⟨rfl, rfl⟩)
+  · exact (unfold hab).mono (fun x y hxy => Or.inl hxy)
+  · exact ⟨t', s', ht, hs, hm.mono (fun x y hxy => Or.inl hxy)⟩
+
+/-- Monotonicity in the relation used to compare pure leaves. -/
+theorem mono_result {RR RR' : α → β → Prop}
+    (hRR : ∀ a b, RR a b → RR' a b) {t : ITree F α} {s : ITree F β}
+    (h : WeakBisimRel RR t s) : WeakBisimRel RR' t s := by
+  obtain ⟨R, hcl, hR⟩ := h
+  exact ⟨R, fun a b hab => (hcl a b hab).mono_result hRR, hR⟩
+
+end WeakBisimRel
+
+/-! ### Equality-specialized weak bisimulation -/
 
 /-- One-step unfolding functor for weak bisimulation: strip finitely many
 τ's from each side (via `TauSteps`) and then match observable heads (via
@@ -207,13 +378,25 @@ theorem WeakBisimF.mono {R R' : ITree F α → ITree F α → Prop}
   obtain ⟨t', s', ht, hs, hm⟩ := hF
   exact ⟨t', s', ht, hs, hm.mono h⟩
 
+/-- Convert the compatibility one-step view to the relational functor. -/
+theorem WeakBisimF.toWeakBisimRelF {R : ITree F α → ITree F α → Prop}
+    {t s : ITree F α} (hF : WeakBisimF R t s) : WeakBisimRelF Eq R t s := by
+  obtain ⟨t', s', ht, hs, hm⟩ := hF
+  exact ⟨t', s', ht, hs, hm.toMatchRel⟩
+
+/-- Convert the equality-specialized relational functor to its compatibility
+view. -/
+theorem WeakBisimRelF.toWeakBisimF {R : ITree F α → ITree F α → Prop}
+    {t s : ITree F α} (hF : WeakBisimRelF Eq R t s) : WeakBisimF R t s := by
+  obtain ⟨t', s', ht, hs, hm⟩ := hF
+  exact ⟨t', s', ht, hs, hm.toMatch⟩
+
 /-- Weak bisimulation (Coq `eutt`). Two trees are weakly bisimilar iff
 there exists a relation `R` containing the pair that is closed under
 one-step unfolding into `WeakBisimF`. Equivalently, `WeakBisim` is the
 largest such relation (Tarski greatest fixed point). -/
-def WeakBisim (t s : ITree F α) : Prop :=
-  ∃ R : ITree F α → ITree F α → Prop,
-    (∀ a b, R a b → WeakBisimF R a b) ∧ R t s
+abbrev WeakBisim (t s : ITree F α) : Prop :=
+  WeakBisimRel Eq t s
 
 @[inherit_doc] scoped infix:50 " ≈ " => ITree.WeakBisim
 
@@ -225,13 +408,11 @@ characterization. -/
 theorem coinduct (R : ITree F α → ITree F α → Prop)
     (h : ∀ a b, R a b → WeakBisimF R a b)
     {a b : ITree F α} (hab : R a b) : a ≈ b :=
-  ⟨R, h, hab⟩
+  WeakBisimRel.coinduct Eq R (fun a b hR => (h a b hR).toWeakBisimRelF) hab
 
 /-- `WeakBisim` is closed under `WeakBisimF`. -/
 theorem unfold {t s : ITree F α} (h : t ≈ s) : WeakBisimF WeakBisim t s := by
-  obtain ⟨R, hcl, hR⟩ := h
-  obtain ⟨t', s', ht, hs, hm⟩ := hcl _ _ hR
-  exact ⟨t', s', ht, hs, hm.mono (fun x y hxy => ⟨R, hcl, hxy⟩)⟩
+  exact (WeakBisimRel.unfold h).toWeakBisimF
 
 /-- Extract the stripped-heads match witness. -/
 theorem dest {t s : ITree F α} (h : t ≈ s) :

--- a/PolyFun/ITree/Bisim/Equiv.lean
+++ b/PolyFun/ITree/Bisim/Equiv.lean
@@ -50,11 +50,11 @@ absence of full transitivity.
 
 @[expose] public section
 
-universe u
+universe uFA uFB uα uβ uγ
 
 namespace ITree
 
-variable {F : PFunctor.{u, u}} {α : Type u}
+variable {F : PFunctor.{uFA, uFB}} {α : Type uα} {β : Type uβ}
 
 /-! ### `Bisim` is an equivalence -/
 
@@ -84,7 +84,7 @@ theorem rigid_of_query {t t' : ITree F α} (a : F.A) (c : F.B a → ITree F α)
 /-- Determinism of τ-stripping on a step-headed tree: a stripping from
 a step-headed tree either does nothing or proceeds through the unique
 step continuation. -/
-theorem step_cases {t t' : ITree F α} (c : PUnit.{u + 1} → ITree F α)
+theorem step_cases {t t' : ITree F α} (c : PUnit.{uFB + 1} → ITree F α)
     (ht : shape' t = ⟨.step, c⟩) (h : TauSteps t t') :
     t' = t ∨ TauSteps (c PUnit.unit) t' := by
   cases h with
@@ -94,11 +94,484 @@ theorem step_cases {t t' : ITree F α} (c : PUnit.{u + 1} → ITree F α)
       subst hcc
       exact Or.inr hr
 
+private theorem diverge_target_eq_aux {source t : ITree F α}
+    (hsource : source = diverge) (h : TauSteps source t) :
+    t = diverge := by
+  exact TauSteps.rec
+    (motive := fun initial target _ =>
+      initial = diverge → target = diverge)
+    (fun _ hs => hs)
+    (fun {t t'} c hstep (_ : TauSteps (c PUnit.unit) t') ih hs => by
+      subst t
+      have hc : c = fun _ => diverge :=
+        TauSteps.cont_eq hstep shape'_diverge
+      subst c
+      exact ih rfl)
+    h hsource
+
+/-- Every finite silent stripping of `diverge` still ends at `diverge`. -/
+theorem diverge_target_eq {t : ITree F α}
+    (h : TauSteps (diverge (F := F) (α := α)) t) :
+    t = diverge :=
+  diverge_target_eq_aux rfl h
+
 end TauSteps
+
+/-! ### Basic relational laws -/
+
+namespace WeakBisimRel
+
+/-- Pure trees are relationally weakly bisimilar exactly when their return
+values are related. -/
+theorem pure {RR : α → β → Prop} {r : α} {s : β} (h : RR r s) :
+    WeakBisimRel RR (pure (F := F) r) (pure (F := F) s) := by
+  refine fold ⟨ITree.pure r, ITree.pure s, .refl _, .refl _, ?_⟩
+  exact MatchRel.pure r s h (shape'_pure r) (shape'_pure s)
+
+/-- Relational reflexivity, assuming the return relation is reflexive. -/
+theorem refl {RR : α → α → Prop} (hRR : ∀ r, RR r r) (t : ITree F α) :
+    WeakBisimRel RR t t := by
+  refine coinduct RR Eq ?_ rfl
+  rintro a b rfl
+  rcases hsh : shape' a with ⟨sh, c⟩
+  refine ⟨a, a, .refl _, .refl _, ?_⟩
+  cases sh with
+  | pure r =>
+      refine MatchRel.pure r r (hRR r) ?_ ?_
+      · rw [hsh]; congr 1; funext z; exact z.elim
+      · rw [hsh]; congr 1; funext z; exact z.elim
+  | step => exact MatchRel.tau c c hsh hsh rfl
+  | query a => exact MatchRel.query a c c hsh hsh (fun _ => rfl)
+
+/-- Swap a relational weak bisimulation and reverse its return relation. -/
+theorem symm {RR : α → β → Prop} {t : ITree F α} {s : ITree F β}
+    (h : WeakBisimRel RR t s) :
+    WeakBisimRel (fun b a => RR a b) s t := by
+  obtain ⟨R, hcl, hR⟩ := h
+  refine coinduct (fun b a => RR a b) (fun a b => R b a) ?_ hR
+  intro a b hab
+  obtain ⟨b', a', hb, ha, hm⟩ := hcl _ _ hab
+  exact ⟨a', b', ha, hb, MatchRel.swap hm⟩
+
+/-- Prepending finitely many silent steps on the left preserves relational
+weak bisimulation. -/
+theorem absorb_tauSteps_left {RR : α → β → Prop}
+    {t t' : ITree F α} {s : ITree F β}
+    (h : TauSteps t t') (hw : WeakBisimRel RR t' s) : WeakBisimRel RR t s := by
+  refine coinduct RR
+    (fun x y => ∃ x', TauSteps x x' ∧ WeakBisimRel RR x' y) ?_ ⟨t', h, hw⟩
+  rintro a b ⟨a', haa', hab⟩
+  obtain ⟨a'', b', ha'a'', hbb', M⟩ := hab.dest
+  refine ⟨a'', b', haa'.trans ha'a'', hbb', M.mono ?_⟩
+  intro x y hxy
+  exact ⟨x, .refl _, hxy⟩
+
+/-- Appending finitely many silent steps before the right endpoint preserves
+relational weak bisimulation. -/
+theorem of_tauSteps_right {RR : α → β → Prop}
+    {t : ITree F α} {s s' : ITree F β}
+    (h : WeakBisimRel RR t s') (hstrip : TauSteps s s') :
+    WeakBisimRel RR t s := by
+  refine coinduct RR
+    (fun x y => ∃ y', TauSteps y y' ∧ WeakBisimRel RR x y') ?_ ⟨s', hstrip, h⟩
+  rintro a b ⟨b', hbb', hab'⟩
+  obtain ⟨a', b'', ha, hb, M⟩ := hab'.dest
+  exact ⟨a', b'', ha, hbb'.trans hb,
+    M.mono (fun _ y hxy => ⟨y, .refl _, hxy⟩)⟩
+
+/-- A leading silent step on the left is observationally irrelevant. -/
+theorem step_left {RR : α → β → Prop} {t : ITree F α} {s : ITree F β}
+    (h : WeakBisimRel RR t s) : WeakBisimRel RR (step t) s :=
+  absorb_tauSteps_left (TauSteps.one (fun _ => t) (shape'_step t)) h
+
+/-- A leading silent step on the right is observationally irrelevant. -/
+theorem step_right {RR : α → β → Prop} {t : ITree F α} {s : ITree F β}
+    (h : WeakBisimRel RR t s) : WeakBisimRel RR t (step s) :=
+  of_tauSteps_right h (TauSteps.one (fun _ => s) (shape'_step s))
+
+/-- Paired leading silent steps preserve relational weak bisimulation. -/
+theorem step {RR : α → β → Prop} {t : ITree F α} {s : ITree F β}
+    (h : WeakBisimRel RR t s) : WeakBisimRel RR (ITree.step t) (ITree.step s) :=
+  (step_left h).step_right
+
+/-- Strip one silent step from the right endpoint of a relational weak
+bisimulation. This is the direction not supplied directly by the post-fixed
+point constructors and is the key to relational composition. -/
+theorem step_absorb_right {RR : α → β → Prop}
+    {t : ITree F α} {s : ITree F β}
+    (c : PUnit.{uFB + 1} → ITree F β) (h : WeakBisimRel RR t s)
+    (hstep : shape' s = ⟨.step, c⟩) :
+    WeakBisimRel RR t (c PUnit.unit) := by
+  refine coinduct RR
+    (fun x z => WeakBisimRel RR x z ∨
+      ∃ (s' : ITree F β) (c' : PUnit.{uFB + 1} → ITree F β),
+        WeakBisimRel RR x s' ∧ shape' s' = ⟨.step, c'⟩ ∧ z = c' PUnit.unit)
+    ?_ (Or.inr ⟨s, c, h, hstep, rfl⟩)
+  intro a b hab
+  rcases hab with hab | ⟨s', c', hab, hstep', rfl⟩
+  · obtain ⟨a', b', ha, hb, M⟩ := hab.dest
+    exact ⟨a', b', ha, hb, M.mono (fun _ _ hxy => Or.inl hxy)⟩
+  · obtain ⟨a', s₁, ha, hs, M⟩ := hab.dest
+    rcases TauSteps.step_cases c' hstep' hs with hs_eq | hs_strict
+    · subst hs_eq
+      cases M with
+      | pure _ _ _ _ hs_bad => exfalso; rw [hstep'] at hs_bad; cases hs_bad
+      | query _ _ _ _ hs_bad _ => exfalso; rw [hstep'] at hs_bad; cases hs_bad
+      | tau ct cs ht_a hs_a hr =>
+          have hcc : cs = c' := TauSteps.cont_eq hs_a hstep'
+          subst hcc
+          rcases hsh : shape' (cs PUnit.unit) with ⟨sh, cc⟩
+          cases sh with
+          | pure r =>
+              have hsh' : shape' (cs PUnit.unit) =
+                  ⟨Shape.pure r, PEmpty.elim⟩ := by
+                rw [hsh]
+                congr 1
+                funext z
+                exact z.elim
+              obtain ⟨X, Y, hX, hY, MXY⟩ := hr.dest
+              have hYeq : Y = cs PUnit.unit :=
+                TauSteps.rigid_of_pure r hsh' hY
+              subst hYeq
+              cases MXY with
+              | pure x y hxy hX' hY' =>
+                  have heq : (⟨Shape.pure y, PEmpty.elim⟩ :
+                      (Poly F β).Obj (ITree F β)) =
+                      ⟨Shape.pure r, PEmpty.elim⟩ := hY'.symm.trans hsh'
+                  have hyr : y = r := Shape.pure.inj (Sigma.mk.inj heq).1
+                  subst y
+                  refine ⟨X, cs PUnit.unit,
+                    ha.trans ((TauSteps.one ct ht_a).trans hX), .refl _, ?_⟩
+                  exact MatchRel.pure x r hxy hX' hsh'
+              | query _ _ _ _ hY' _ =>
+                  exfalso; rw [hY'] at hsh'; cases hsh'
+              | tau _ _ _ hY' _ =>
+                  exfalso; rw [hY'] at hsh'; cases hsh'
+          | step =>
+              refine ⟨a', cs PUnit.unit, ha, .refl _, ?_⟩
+              refine MatchRel.tau ct cc ht_a hsh ?_
+              exact Or.inr ⟨cs PUnit.unit, cc, hr, hsh, rfl⟩
+          | query q =>
+              obtain ⟨X, Y, hX, hY, MXY⟩ := hr.dest
+              have hYeq : Y = cs PUnit.unit :=
+                TauSteps.rigid_of_query q cc hsh hY
+              subst hYeq
+              cases MXY with
+              | pure _ _ _ _ hY' =>
+                  exfalso; rw [hY'] at hsh; cases hsh
+              | query q' cX cY hX' hY' hcont =>
+                  have heq : (⟨Shape.query q', cY⟩ :
+                      (Poly F β).Obj (ITree F β)) =
+                      ⟨Shape.query q, cc⟩ := hY'.symm.trans hsh
+                  have hqq : q' = q := Shape.query.inj (Sigma.mk.inj heq).1
+                  subst hqq
+                  have hcc : cY = cc := eq_of_heq (Sigma.mk.inj heq).2
+                  subst hcc
+                  refine ⟨X, cs PUnit.unit,
+                    ha.trans ((TauSteps.one ct ht_a).trans hX), .refl _, ?_⟩
+                  exact MatchRel.query q' cX cY hX' hsh
+                    (fun reply => Or.inl (hcont reply))
+              | tau _ _ _ hY' _ =>
+                  exfalso; rw [hY'] at hsh; cases hsh
+    · exact ⟨a', s₁, ha, hs_strict,
+        M.mono (fun _ _ hxy => Or.inl hxy)⟩
+
+/-- Strip finitely many silent steps from the right endpoint. -/
+theorem absorb_tauSteps_right {RR : α → β → Prop}
+    {t : ITree F α} {s s' : ITree F β}
+    (h : WeakBisimRel RR t s) (hstrip : TauSteps s s') :
+    WeakBisimRel RR t s' := by
+  induction hstrip generalizing t with
+  | refl _ => exact h
+  | @step _ _ c ht hr ih => exact ih (step_absorb_right c h ht)
+
+/-- Strip finitely many silent steps from the left endpoint. -/
+theorem tauSteps_left {RR : α → β → Prop}
+    {t t' : ITree F α} {s : ITree F β}
+    (h : WeakBisimRel RR t s) (hstrip : TauSteps t t') :
+    WeakBisimRel RR t' s := by
+  have hs := absorb_tauSteps_right (RR := fun y x => RR x y) h.symm hstrip
+  exact hs.symm
+
+end WeakBisimRel
+
+/-! ### Relational head alignment -/
+
+namespace MatchRel
+
+/-- Advance the right endpoint of a relational head match through silent
+steps, absorbing those steps into its continuation relation. -/
+theorem advance_right {RR : α → β → Prop}
+    {x : ITree F α} {z₁ z₂ : ITree F β}
+    (headMatch : MatchRel RR (WeakBisimRel RR) x z₁)
+    (steps : TauSteps z₁ z₂) :
+    ∃ x' z', TauSteps x x' ∧ TauSteps z₂ z' ∧
+      MatchRel RR (WeakBisimRel RR) x' z' := by
+  induction steps generalizing x with
+  | refl z => exact ⟨x, z, .refl _, .refl _, headMatch⟩
+  | @step _ z₂' c hz hr _ =>
+      cases headMatch with
+      | pure _ _ _ _ hp => exfalso; rw [hp] at hz; cases hz
+      | query _ _ _ _ hq _ => exfalso; rw [hq] at hz; cases hz
+      | tau ct cs hx hz' hrel =>
+          have hcc : cs = c := TauSteps.cont_eq hz' hz
+          subst hcc
+          have hrel' : WeakBisimRel RR (ct PUnit.unit) z₂' :=
+            WeakBisimRel.absorb_tauSteps_right hrel hr
+          obtain ⟨X, Z, hX, hZ, matched⟩ := hrel'.dest
+          refine ⟨X, Z, ?_, hZ, matched⟩
+          exact (TauSteps.one ct hx).trans hX
+
+/-- Advance the left endpoint of a relational head match through silent
+steps, absorbing those steps into its continuation relation. -/
+theorem advance_left {RR : α → β → Prop}
+    {x₁ x₂ : ITree F α} {z : ITree F β}
+    (headMatch : MatchRel RR (WeakBisimRel RR) x₁ z)
+    (steps : TauSteps x₁ x₂) :
+    ∃ x' z', TauSteps x₂ x' ∧ TauSteps z z' ∧
+      MatchRel RR (WeakBisimRel RR) x' z' := by
+  induction steps generalizing z with
+  | refl x => exact ⟨x, z, .refl _, .refl _, headMatch⟩
+  | @step _ x₂' c hx hr _ =>
+      cases headMatch with
+      | pure _ _ _ hp _ => exfalso; rw [hp] at hx; cases hx
+      | query _ _ _ hp _ _ => exfalso; rw [hp] at hx; cases hx
+      | tau ct cs hx' hz hrel =>
+          have hcc : c = ct := TauSteps.cont_eq hx hx'
+          subst hcc
+          have hrel' : WeakBisimRel RR x₂' (cs PUnit.unit) :=
+            WeakBisimRel.tauSteps_left hrel hr
+          obtain ⟨X, Z, hX, hZ, matched⟩ := hrel'.dest
+          refine ⟨X, Z, hX, ?_, matched⟩
+          exact (TauSteps.one cs hz).trans hZ
+
+/-- Compose two head matches aligned at the same middle tree. The intermediate
+return value remains explicit in `Relation.Comp`. -/
+theorem comp_aligned {γ : Type uγ} {RR : α → β → Prop} {SS : β → γ → Prop}
+    {left : ITree F α} {middle : ITree F β} {right : ITree F γ}
+    (first : MatchRel RR (WeakBisimRel RR) left middle)
+    (second : MatchRel SS (WeakBisimRel SS) middle right) :
+    MatchRel (Relation.Comp RR SS)
+      (fun x z => ∃ y, WeakBisimRel RR x y ∧ WeakBisimRel SS y z)
+      left right := by
+  cases first with
+  | pure x y hxy hleft hmiddle =>
+      cases second with
+      | pure y' z hyz hmiddle' hright =>
+          have heq : (⟨Shape.pure y, PEmpty.elim⟩ :
+              (Poly F β).Obj (ITree F β)) =
+              ⟨Shape.pure y', PEmpty.elim⟩ := hmiddle.symm.trans hmiddle'
+          have hyy : y = y' := Shape.pure.inj (Sigma.mk.inj heq).1
+          subst y'
+          exact .pure x z ⟨y, hxy, hyz⟩ hleft hright
+      | query _ _ _ hbad _ _ => exfalso; rw [hmiddle] at hbad; cases hbad
+      | tau _ _ hbad _ _ => exfalso; rw [hmiddle] at hbad; cases hbad
+  | query event cLeft cMiddle hleft hmiddle hcont =>
+      cases second with
+      | pure _ _ _ hbad _ => exfalso; rw [hmiddle] at hbad; cases hbad
+      | query event' cMiddle' cRight hmiddle' hright hcont' =>
+          have heq : (⟨Shape.query event, cMiddle⟩ :
+              (Poly F β).Obj (ITree F β)) =
+              ⟨Shape.query event', cMiddle'⟩ := hmiddle.symm.trans hmiddle'
+          have hevent : event = event' := Shape.query.inj (Sigma.mk.inj heq).1
+          subst event'
+          have hc : cMiddle = cMiddle' := eq_of_heq (Sigma.mk.inj heq).2
+          subst cMiddle'
+          exact .query event cLeft cRight hleft hright
+            (fun reply => ⟨cMiddle reply, hcont reply, hcont' reply⟩)
+      | tau _ _ hbad _ _ => exfalso; rw [hmiddle] at hbad; cases hbad
+  | tau cLeft cMiddle hleft hmiddle hcont =>
+      cases second with
+      | pure _ _ _ hbad _ => exfalso; rw [hmiddle] at hbad; cases hbad
+      | query _ _ _ hbad _ _ => exfalso; rw [hmiddle] at hbad; cases hbad
+      | tau cMiddle' cRight hmiddle' hright hcont' =>
+          have hc : cMiddle' = cMiddle := TauSteps.cont_eq hmiddle' hmiddle
+          exact .tau cLeft cRight hleft hright
+            ⟨cMiddle PUnit.unit, hcont, hc ▸ hcont'⟩
+
+end MatchRel
+
+namespace WeakBisimRel
+
+/-- Relational weak bisimulations compose through an explicit intermediate
+return value. This is the heterogeneous form of `WeakBisim.trans`. -/
+protected theorem comp {γ : Type uγ} {RR : α → β → Prop}
+    {SS : β → γ → Prop}
+    {left : ITree F α} {middle : ITree F β} {right : ITree F γ}
+    (first : WeakBisimRel RR left middle)
+    (second : WeakBisimRel SS middle right) :
+    WeakBisimRel (Relation.Comp RR SS) left right := by
+  let R : ITree F α → ITree F γ → Prop := fun x z =>
+    ∃ y, WeakBisimRel RR x y ∧ WeakBisimRel SS y z
+  refine coinduct (Relation.Comp RR SS) R ?_ ⟨middle, first, second⟩
+  rintro a d ⟨b, hab, hbd⟩
+  obtain ⟨a', b₁, ha, hb₁, Ma⟩ := hab.dest
+  obtain ⟨b₂, d', hb₂, hd, Mb⟩ := hbd.dest
+  cases TauSteps.linear hb₁ hb₂ with
+  | inl hlin =>
+      obtain ⟨a'', b', ha', hb', Ma'⟩ := MatchRel.advance_right Ma hlin
+      obtain ⟨b'', d'', hb'', hd', Mb'⟩ := MatchRel.advance_left Mb hb'
+      cases Ma' with
+      | pure x y hxy Ha Hb =>
+          have hEq : b'' = b' := TauSteps.rigid_of_pure y Hb hb''
+          subst hEq
+          exact ⟨a'', d'', ha.trans ha', hd.trans hd',
+            (MatchRel.pure x y hxy Ha Hb).comp_aligned Mb'⟩
+      | query event ca cb Ha Hb hcont =>
+          have hEq : b'' = b' := TauSteps.rigid_of_query event cb Hb hb''
+          subst hEq
+          exact ⟨a'', d'', ha.trans ha', hd.trans hd',
+            (MatchRel.query event ca cb Ha Hb hcont).comp_aligned Mb'⟩
+      | tau ca cb Ha Hb hAB =>
+          rcases TauSteps.step_cases cb Hb hb'' with hEq | hrest
+          · subst hEq
+            exact ⟨a'', d'', ha.trans ha', hd.trans hd',
+              (MatchRel.tau ca cb Ha Hb hAB).comp_aligned Mb'⟩
+          · cases Mb' with
+            | pure y z hyz Hb'' Hd'' =>
+                have hAC : WeakBisimRel RR (ca PUnit.unit) b'' :=
+                  absorb_tauSteps_right hAB hrest
+                obtain ⟨X, Y, hX, hY, MXY⟩ := hAC.dest
+                have hYeq : Y = b'' := TauSteps.rigid_of_pure y Hb'' hY
+                subst hYeq
+                cases MXY with
+                | pure x y' hxy HX HY =>
+                    have heq : (⟨Shape.pure y', PEmpty.elim⟩ :
+                        (Poly F β).Obj (ITree F β)) =
+                        ⟨Shape.pure y, PEmpty.elim⟩ := HY.symm.trans Hb''
+                    have hyy : y' = y := Shape.pure.inj (Sigma.mk.inj heq).1
+                    subst y'
+                    refine ⟨X, d'',
+                      ha.trans (ha'.trans ((TauSteps.one ca Ha).trans hX)),
+                      hd.trans hd', ?_⟩
+                    exact MatchRel.pure x z ⟨y, hxy, hyz⟩ HX Hd''
+                | query _ _ _ _ HY _ => exfalso; rw [HY] at Hb''; cases Hb''
+                | tau _ _ _ HY _ => exfalso; rw [HY] at Hb''; cases Hb''
+            | query event cMiddle cRight Hb'' Hd'' hBD =>
+                have hAC : WeakBisimRel RR (ca PUnit.unit) b'' :=
+                  absorb_tauSteps_right hAB hrest
+                obtain ⟨X, Y, hX, hY, MXY⟩ := hAC.dest
+                have hYeq : Y = b'' :=
+                  TauSteps.rigid_of_query event cMiddle Hb'' hY
+                subst hYeq
+                cases MXY with
+                | pure _ _ _ _ HY => exfalso; rw [HY] at Hb''; cases Hb''
+                | query event' cLeft cMiddle' HX HY hAC' =>
+                    have heq : (⟨Shape.query event', cMiddle'⟩ :
+                        (Poly F β).Obj (ITree F β)) =
+                        ⟨Shape.query event, cMiddle⟩ := HY.symm.trans Hb''
+                    have hevent : event' = event :=
+                      Shape.query.inj (Sigma.mk.inj heq).1
+                    subst event'
+                    have hc : cMiddle' = cMiddle := eq_of_heq (Sigma.mk.inj heq).2
+                    subst cMiddle'
+                    refine ⟨X, d'',
+                      ha.trans (ha'.trans ((TauSteps.one ca Ha).trans hX)),
+                      hd.trans hd', ?_⟩
+                    exact MatchRel.query event cLeft cRight HX Hd''
+                      (fun reply => ⟨cMiddle reply, hAC' reply, hBD reply⟩)
+                | tau _ _ _ HY _ => exfalso; rw [HY] at Hb''; cases Hb''
+            | tau cMiddle cRight Hb'' Hd'' hBD =>
+                refine ⟨a'', d'', ha.trans ha', hd.trans hd', ?_⟩
+                refine MatchRel.tau ca cRight Ha Hd'' ?_
+                refine ⟨cMiddle PUnit.unit, ?_, hBD⟩
+                exact absorb_tauSteps_right hAB
+                  (hrest.trans (TauSteps.one cMiddle Hb''))
+  | inr hlin =>
+      obtain ⟨b', d'', hb', hd', Mb'⟩ := MatchRel.advance_left Mb hlin
+      obtain ⟨a'', b'', ha', hb'', Ma'⟩ := MatchRel.advance_right Ma hb'
+      cases Mb' with
+      | pure y z hyz Hb Hd =>
+          have hEq : b'' = b' := TauSteps.rigid_of_pure y Hb hb''
+          subst hEq
+          exact ⟨a'', d'', ha.trans ha', hd.trans hd',
+            Ma'.comp_aligned (MatchRel.pure y z hyz Hb Hd)⟩
+      | query event cb cd Hb Hd hcont =>
+          have hEq : b'' = b' := TauSteps.rigid_of_query event cb Hb hb''
+          subst hEq
+          exact ⟨a'', d'', ha.trans ha', hd.trans hd',
+            Ma'.comp_aligned (MatchRel.query event cb cd Hb Hd hcont)⟩
+      | tau cb cd Hb Hd hBD =>
+          rcases TauSteps.step_cases cb Hb hb'' with hEq | hrest
+          · subst hEq
+            exact ⟨a'', d'', ha.trans ha', hd.trans hd',
+              Ma'.comp_aligned (MatchRel.tau cb cd Hb Hd hBD)⟩
+          · cases Ma' with
+            | pure x y hxy Ha Hb'' =>
+                have hBD' : WeakBisimRel SS b'' (cd PUnit.unit) :=
+                  tauSteps_left hBD hrest
+                obtain ⟨X, Y, hX, hY, MXY⟩ := hBD'.dest
+                have hXeq : X = b'' := TauSteps.rigid_of_pure y Hb'' hX
+                subst hXeq
+                cases MXY with
+                | pure y' z hyz HX HY =>
+                    have heq : (⟨Shape.pure y', PEmpty.elim⟩ :
+                        (Poly F β).Obj (ITree F β)) =
+                        ⟨Shape.pure y, PEmpty.elim⟩ := HX.symm.trans Hb''
+                    have hyy : y' = y := Shape.pure.inj (Sigma.mk.inj heq).1
+                    subst y'
+                    refine ⟨a'', Y, ha.trans ha',
+                      hd.trans (hd'.trans ((TauSteps.one cd Hd).trans hY)), ?_⟩
+                    exact MatchRel.pure x z ⟨y, hxy, hyz⟩ Ha HY
+                | query _ _ _ HX _ _ => exfalso; rw [HX] at Hb''; cases Hb''
+                | tau _ _ HX _ _ => exfalso; rw [HX] at Hb''; cases Hb''
+            | query event cLeft cMiddle Ha Hb'' hAB =>
+                have hBD' : WeakBisimRel SS b'' (cd PUnit.unit) :=
+                  tauSteps_left hBD hrest
+                obtain ⟨X, Y, hX, hY, MXY⟩ := hBD'.dest
+                have hXeq : X = b'' :=
+                  TauSteps.rigid_of_query event cMiddle Hb'' hX
+                subst hXeq
+                cases MXY with
+                | pure _ _ _ HX _ => exfalso; rw [HX] at Hb''; cases Hb''
+                | query event' cMiddle' cRight HX HY hBD' =>
+                    have heq : (⟨Shape.query event', cMiddle'⟩ :
+                        (Poly F β).Obj (ITree F β)) =
+                        ⟨Shape.query event, cMiddle⟩ := HX.symm.trans Hb''
+                    have hevent : event' = event :=
+                      Shape.query.inj (Sigma.mk.inj heq).1
+                    subst event'
+                    have hc : cMiddle' = cMiddle := eq_of_heq (Sigma.mk.inj heq).2
+                    subst cMiddle'
+                    refine ⟨a'', Y, ha.trans ha',
+                      hd.trans (hd'.trans ((TauSteps.one cd Hd).trans hY)), ?_⟩
+                    exact MatchRel.query event cLeft cRight Ha HY
+                      (fun reply => ⟨cMiddle reply, hAB reply, hBD' reply⟩)
+                | tau _ _ HX _ _ => exfalso; rw [HX] at Hb''; cases Hb''
+            | tau cLeft cMiddle Ha Hb'' hAB =>
+                refine ⟨a'', d'', ha.trans ha', hd.trans hd', ?_⟩
+                refine MatchRel.tau cLeft cd Ha Hd ?_
+                refine ⟨cMiddle PUnit.unit, hAB, ?_⟩
+                exact tauSteps_left hBD
+                  (hrest.trans (TauSteps.one cMiddle Hb''))
+
+end WeakBisimRel
 
 /-! ### `WeakBisim` is an equivalence -/
 
 namespace WeakBisim
+
+/-- A terminating return is not weakly bisimilar to silent divergence.
+This is the central finite-τ safety property of the definition. -/
+theorem pure_not_diverge (r : α) :
+    ¬ WeakBisim (pure (F := F) r) (diverge (F := F) (α := α)) := by
+  intro h
+  obtain ⟨left, right, hleft, hright, matched⟩ := h.dest
+  have hleft_eq : left = pure (F := F) r :=
+    TauSteps.rigid_of_pure r (shape'_pure r) hleft
+  have hright_eq : right = diverge := TauSteps.diverge_target_eq hright
+  subst left
+  subst right
+  cases matched with
+  | pure _ _ hdiverge =>
+      rw [shape'_diverge] at hdiverge
+      cases hdiverge
+  | query _ _ _ hpure _ _ =>
+      rw [shape'_pure] at hpure
+      cases hpure
+  | tau _ _ hpure _ _ =>
+      rw [shape'_pure] at hpure
+      cases hpure
 
 /-- Reflexivity: every tree is weakly bisimilar to itself. -/
 @[refl] theorem refl (t : ITree F α) : t ≈ t := by
@@ -116,11 +589,7 @@ namespace WeakBisim
 
 /-- Symmetry: weak bisimilarity is symmetric. -/
 @[symm] theorem symm {t s : ITree F α} (h : t ≈ s) : s ≈ t := by
-  obtain ⟨R, hcl, hR⟩ := h
-  refine coinduct (fun a b => R b a) ?_ hR
-  intro a b hab
-  obtain ⟨b', a', hb, ha, hm⟩ := hcl _ _ hab
-  exact ⟨a', b', ha, hb, hm.swap⟩
+  exact (WeakBisimRel.symm h).mono_result (fun _ _ hEq => hEq.symm)
 
 /-! ### τ-absorption lemmas
 
@@ -144,12 +613,12 @@ given `t ≈ s` and `s` step-headed with continuation `c`, conclude
 `t ≈ (c .unit)`. The proof unfolds the bisim once and case-analyzes on
 the head of `(c .unit)`, in the worst case unfolding the inner
 `WeakBisim (ct .unit) (cs .unit)` one more level to reach a head match. -/
-theorem step_absorb_right {t s : ITree F α} (c : PUnit.{u + 1} → ITree F α)
+theorem step_absorb_right {t s : ITree F α} (c : PUnit.{uFB + 1} → ITree F α)
     (h : t ≈ s) (hstep : shape' s = ⟨.step, c⟩) :
     t ≈ (c PUnit.unit) := by
   refine coinduct
     (fun x z => x ≈ z ∨
-      ∃ (s' : ITree F α) (c' : PUnit.{u + 1} → ITree F α),
+      ∃ (s' : ITree F α) (c' : PUnit.{uFB + 1} → ITree F α),
         x ≈ s' ∧ shape' s' = ⟨.step, c'⟩ ∧ z = (c' PUnit.unit))
     ?_ (Or.inr ⟨s, c, h, hstep, rfl⟩)
   intro a b hab

--- a/PolyFun/ITree/Handler.lean
+++ b/PolyFun/ITree/Handler.lean
@@ -16,6 +16,10 @@ choice of `F`-program for every `E`-event. Handlers are the data of the
 fundamental ITree simulation operator `ITree.simulate` (see
 `PolyFun.ITree.Sim.Defs`).
 
+The position and direction universes of `E` and `F` are all independent:
+for `E : PFunctor.{uEA, uEB}` and `F : PFunctor.{uFA, uFB}`, handlers live in
+`Type (max uEA uEB uFA uFB)`.
+
 For pure event renaming (no extra silent steps and no extra queries),
 `ITree.mapSpec` consumes a `PFunctor.Lens`. A `Lens E F` carries a forward
 shape map `E.A → F.A` together with a backward arity map
@@ -29,12 +33,13 @@ each `query` node of an interaction tree along an event-spec morphism.
 | `E ~> itree F`     | `ITree.Handler E F`               |
 | `E ~> F`           | `PFunctor.Lens E F`               |
 | `handler E := ...` | `Handler.id`                      |
-| `case_ E F`        | (TODO; coproduct routing on top of `PFunctor.sum`) |
+| `case_ E F`        | `Handler.case_`                   |
+| handler composition | `Handler.comp` (in `Sim.Defs`)  |
 -/
 
 @[expose] public section
 
-universe u
+universe uEA uEB uFA uFB uGA uGB
 
 namespace ITree
 
@@ -45,16 +50,18 @@ Concretely, for each event name `a : E.A` we choose an interaction tree of
 type `ITree F (E.B a)` returning the answer expected by the source signature.
 
 This is the Lean version of Coq's `Handler E F := E ~> itree F`. -/
-def Handler (E F : PFunctor.{u, u}) : Type u :=
+def Handler (E : PFunctor.{uEA, uEB}) (F : PFunctor.{uFA, uFB}) :
+    Type (max uEA uEB uFA uFB) :=
   ∀ a : E.A, ITree F (E.B a)
 
 namespace Handler
 
-variable {E F : PFunctor.{u, u}}
+variable {E : PFunctor.{uEA, uEB}} {F : PFunctor.{uFA, uFB}}
+  {G : PFunctor.{uGA, uGB}}
 
 /-- The trivial handler that interprets each `E`-event as itself, i.e. the
 single-step `lift` from `PolyFun.ITree.Basic`. -/
-def id (E : PFunctor.{u, u}) : Handler E E :=
+def id (E : PFunctor.{uEA, uEB}) : Handler E E :=
   fun a => lift a
 
 /-- Promote a polynomial-functor lens to a handler that performs a pure
@@ -66,6 +73,44 @@ There are no extra silent steps and no extra queries: this is the canonical
 "event-renaming" handler. -/
 def ofLens (φ : PFunctor.Lens E F) : Handler E F :=
   fun a => query (φ.toFunA a) (fun b => pure (φ.toFunB a b))
+
+@[simp] theorem ofLens_id (E : PFunctor.{uEA, uEB}) :
+    ofLens (PFunctor.Lens.id E) = id E := by
+  funext a
+  rfl
+
+/-! ### Coproduct routing -/
+
+/-- Route events from a coproduct signature through one of two handlers.
+
+The source signatures share a direction universe because `PFunctor.sum`
+currently requires it; their position universes and both universes of the
+target signature remain independent. -/
+def case_ {E : PFunctor.{uEA, uEB}} {F : PFunctor.{uFA, uEB}}
+    (left : Handler.{uEA, uEB, uGA, uGB} E G)
+    (right : Handler.{uFA, uEB, uGA, uGB} F G) :
+    Handler.{max uEA uFA, uEB, uGA, uGB} (E + F) G
+  | .inl a => left a
+  | .inr a => right a
+
+@[simp] theorem case_inl {E : PFunctor.{uEA, uEB}} {F : PFunctor.{uFA, uEB}}
+    (left : Handler.{uEA, uEB, uGA, uGB} E G)
+    (right : Handler.{uFA, uEB, uGA, uGB} F G) (a : E.A) :
+    case_ left right (.inl a) = left a := rfl
+
+@[simp] theorem case_inr {E : PFunctor.{uEA, uEB}} {F : PFunctor.{uFA, uEB}}
+    (left : Handler.{uEA, uEB, uGA, uGB} E G)
+    (right : Handler.{uFA, uEB, uGA, uGB} F G) (a : F.A) :
+    case_ left right (.inr a) = right a := rfl
+
+/-- Copairing pure-renaming handlers agrees with copairing their underlying
+lenses. -/
+theorem case_ofLens {E : PFunctor.{uEA, uEB}} {F : PFunctor.{uFA, uEB}}
+    (left : PFunctor.Lens E G) (right : PFunctor.Lens F G) :
+    case_ (ofLens left) (ofLens right) =
+      ofLens (PFunctor.Lens.sumPair left right) := by
+  funext a
+  cases a <;> rfl
 
 end Handler
 

--- a/PolyFun/ITree/Sim/Defs.lean
+++ b/PolyFun/ITree/Sim/Defs.lean
@@ -15,6 +15,11 @@ to produce an interaction tree over the target spec. `ITree.mapSpec`
 specialises this to event-renaming via a `PFunctor.Lens`, performing a pure
 relabelling without inserting any extra silent steps or queries.
 
+Both operators permit the source positions, source directions, target
+positions, target directions, and return values to inhabit independent
+universes. `Handler.comp` composes two handlers by simulating the output of
+the first through the second.
+
 The shape of `simulate` mirrors Coq's `interp` (`Core/Subevent.v`): we run
 the source ITree, replacing every `query a c` with `bind (h a) c`, every
 `step c` with `step (... continue ...)`, and every `pure r` with `pure r`.
@@ -26,11 +31,12 @@ long stretch in `query` nodes).
 
 @[expose] public section
 
-universe u
+universe uEA uEB uFA uFB uGA uGB uHA uHB uα
 
 namespace ITree
 
-variable {E F : PFunctor.{u, u}} {α : Type u}
+variable {E : PFunctor.{uEA, uEB}} {F : PFunctor.{uFA, uFB}}
+  {G : PFunctor.{uGA, uGB}} {α : Type uα}
 
 /-! ### Generic simulation -/
 
@@ -47,6 +53,34 @@ def simulate (h : Handler E F) (t : ITree E α) : ITree F α :=
       | ⟨.step, c⟩ => pure (.inl (c PUnit.unit))
       | ⟨.query a, c⟩ => bind (h a) (fun b => pure (.inl (c b))))
     t
+
+/-! ### Handler composition -/
+
+namespace Handler
+
+/-- Compose event handlers by simulating the output of the first handler with
+the second. Thus `second.comp first` interprets `E`-events as `F`-programs and
+then interprets those `F`-programs over `G`.
+
+Composition is maximally universe-polymorphic. Its pointwise weak identity and
+pure-renaming laws are stated in `PolyFun.ITree.Sim.Facts`.
+-/
+def comp (second : Handler F G) (first : Handler E F) : Handler E G :=
+  fun a => simulate second (first a)
+
+@[simp] theorem comp_apply (second : Handler F G) (first : Handler E F) (a : E.A) :
+    second.comp first a = simulate second (first a) := rfl
+
+/-- Handler composition distributes definitionally over coproduct routing. -/
+theorem comp_case {E : PFunctor.{uEA, uEB}} {F : PFunctor.{uFA, uEB}}
+    {G : PFunctor.{uGA, uGB}} {H : PFunctor.{uHA, uHB}}
+    (outer : Handler G H) (left : Handler E G) (right : Handler F G) :
+    outer.comp (Handler.case_ left right) =
+      Handler.case_ (outer.comp left) (outer.comp right) := by
+  funext a
+  cases a <;> rfl
+
+end Handler
 
 /-! ### Event renaming -/
 

--- a/PolyFun/ITree/Sim/Facts.lean
+++ b/PolyFun/ITree/Sim/Facts.lean
@@ -14,11 +14,16 @@ The standard equational theory for the simulation operators:
 
 * `simulate_pure`, `simulate_step`, `simulate_query` — one-step unfoldings
   recording the action of `simulate` on each `Shape` constructor.
+* `simulate_weakBisimRel` — relational weak bisimulation is a congruence for
+  interpretation through a common handler.
 * `simulate_bind` — `simulate` distributes over `bind`.
 * `simulate_id` — interpreting via the trivial handler is (weakly) the
   identity.
 * `Handler.id_comp_apply`, `Handler.comp_id_apply` — the trivial handler is
   a pointwise weak identity for handler composition.
+* `simulate_comp`, `Handler.comp_assoc_apply` — sequential interpretation
+  agrees with composite interpretation and handler composition is pointwise
+  associative, both up to weak bisimulation.
 * `mapSpec_pure`, `mapSpec_step`, `mapSpec_query` — one-step unfoldings of
   `mapSpec`.
 * `mapSpec_id`, `mapSpec_comp` — functoriality of `mapSpec` over the lens
@@ -39,23 +44,19 @@ one-step `M.corec` unfoldings with the bisimulation laws of
 `PolyFun.ITree.Bisim.Bind` (notably `bind_weakBisim_cont` and the bind
 unfoldings), so the resulting equations hold up to weak bisimulation.
 
-The executable Handler/Sim layer is fully universe-polymorphic. The primitive
-strong equations listed above retain the universe separation of the
-definitions. Laws that depend on the shared bind/iteration theory—including
-`simulate_query_eq_bind`, `mapSpec_bind`, `mapSpec_iter`, `mapSpec_map`, and
-`mapSpec_cat`—remain in the homogeneous fragment in this slice. The next two
-stack slices generalize that algebra and then these consumer laws. Theorems
-that mention `WeakBisim` likewise remain homogeneous until the relational
-bisimulation layer.
+The Handler/Sim layer and its weak simulation laws are fully
+universe-polymorphic: event-position, event-answer, and result universes are
+independent. In particular, `simulate_weakBisimRel` permits two independent
+result types, while the composition laws span three or four independently
+universe-polymorphic signatures. The strong equations retain the same
+universe separation as the definitions.
 -/
 
 @[expose] public section
 
-universe u uEA uEB uFA uFB uGA uGB uα
+universe u uEA uEB uFA uFB uGA uGB uHA uHB uα uβ uγ
 
 namespace ITree
-
-variable {E F G : PFunctor.{u, u}} {α β : Type u}
 
 /-! ### One-step unfoldings of `simulate` -/
 
@@ -152,7 +153,8 @@ theorem simulate_step_eq {E : PFunctor.{uEA, uEB}} {F : PFunctor.{uFA, uFB}}
       from shape'_step _]
   rfl
 
-theorem simulate_step (h : Handler E F) (t : ITree E α) :
+theorem simulate_step {E : PFunctor.{uEA, uEB}} {F : PFunctor.{uFA, uFB}}
+    {α : Type uα} (h : Handler E F) (t : ITree E α) :
     WeakBisim (simulate h (step t)) (simulate h t) := by
   rw [simulate_step_eq]
   exact step_weakBisim _
@@ -163,7 +165,9 @@ the `simulate` iteration collapses to `bind u` over the step-guarded
 
 This is the coinductive core of `simulate_query_eq_bind`, generalised over
 `u` so that the `PFunctor.M.bisim` is closed under continuation subtrees. -/
-private theorem corec_iter_simulateStep_bind_pureInl {γ : Type u}
+private theorem corec_iter_simulateStep_bind_pureInl
+    {E : PFunctor.{uEA, uEB}} {F : PFunctor.{uFA, uFB}}
+    {α : Type uα} {γ : Type uγ}
     (h : Handler E F) (k : γ → ITree E α) (u : ITree F γ) :
     PFunctor.M.corec (iterStep (simulateStep h))
         (bind u (fun b : γ => (pure (.inl (k b)) : ITree F (ITree E α ⊕ α)))) =
@@ -221,21 +225,171 @@ through a `query a k` is the same as binding over `h a` and then resuming
 
 This is the strong-bisimulation version of `simulate_query` and the key
 lemma for rewriting `simulate` on event-headed trees. -/
-theorem simulate_query_eq_bind (h : Handler E F) (a : E.A) (k : E.B a → ITree E α) :
+theorem simulate_query_eq_bind {E : PFunctor.{uEA, uEB}}
+    {F : PFunctor.{uFA, uFB}} {α : Type uα}
+    (h : Handler E F) (a : E.A) (k : E.B a → ITree E α) :
     simulate h (query a k) = bind (h a) (fun b => step (simulate h (k b))) := by
   change PFunctor.M.corec (iterStep (simulateStep h)) (simulateStep h (query a k)) = _
   rw [simulateStep_query]
   exact corec_iter_simulateStep_bind_pureInl h k (h a)
 
-theorem simulate_query (h : Handler E F) (a : E.A) (k : E.B a → ITree E α) :
+theorem simulate_query {E : PFunctor.{uEA, uEB}} {F : PFunctor.{uFA, uFB}}
+    {α : Type uα} (h : Handler E F) (a : E.A) (k : E.B a → ITree E α) :
     WeakBisim (simulate h (query a k))
       (bind (h a) (fun b => simulate h (k b))) := by
   rw [simulate_query_eq_bind]
   exact bind_weakBisim_cont (fun b => step_weakBisim _)
 
+/-! ### Relational congruence of simulation -/
+
+/-- Simulation preserves finite silent-step stripping. -/
+theorem TauSteps.simulate {E : PFunctor.{uEA, uEB}}
+    {F : PFunctor.{uFA, uFB}} {α : Type uα} {t t' : ITree E α}
+    (ht : TauSteps t t') (h : Handler E F) :
+    TauSteps (ITree.simulate h t) (ITree.simulate h t') := by
+  induction ht with
+  | refl _ => exact .refl _
+  | @step t _ c ht _ ih =>
+      have ht_eq : t = ITree.step (c PUnit.unit) := by
+        apply PFunctor.M.eq_of_dest_eq
+        change shape' t = shape' (ITree.step (c PUnit.unit))
+        rw [ht, shape'_step]
+      subst t
+      rw [simulate_step_eq]
+      exact TauSteps.step (fun _ => ITree.simulate h (c PUnit.unit))
+        (shape'_step _) ih
+
+/-- Interpreting both sides through the same handler preserves relational
+weak bisimulation. The return relation and both return universes are
+unchanged; the source and target event universes are independent. -/
+theorem simulate_weakBisimRel {E : PFunctor.{uEA, uEB}}
+    {F : PFunctor.{uFA, uFB}} {α : Type uα} {β : Type uβ}
+    {RR : α → β → Prop} (h : Handler E F) {t : ITree E α} {s : ITree E β}
+    (hts : WeakBisimRel RR t s) :
+    WeakBisimRel RR (simulate h t) (simulate h s) := by
+  refine WeakBisimRel.coinduct RR
+    (fun x y =>
+      (∃ t s, WeakBisimRel RR t s ∧ x = simulate h t ∧ y = simulate h s) ∨
+      (∃ (γ : Type uEB) (u : ITree F γ)
+          (k : γ → ITree E α) (k' : γ → ITree E β),
+        (∀ b, WeakBisimRel RR (k b) (k' b)) ∧
+        x = bind u (fun b => step (simulate h (k b))) ∧
+        y = bind u (fun b => step (simulate h (k' b)))))
+    ?_ (Or.inl ⟨t, s, hts, rfl, rfl⟩)
+  rintro x y (⟨t, s, hts, rfl, rfl⟩ | ⟨γ, u, k, k', hkk', rfl, rfl⟩)
+  · obtain ⟨t', s', ht, hs, M⟩ := hts.dest
+    cases M with
+    | pure r r' hrr ht' hs' =>
+        have ht_eq : t' = pure r := by
+          apply PFunctor.M.eq_of_dest_eq
+          change shape' t' = shape' (pure r)
+          exact ht'.trans (shape'_pure r).symm
+        have hs_eq : s' = pure r' := by
+          apply PFunctor.M.eq_of_dest_eq
+          change shape' s' = shape' (pure r')
+          exact hs'.trans (shape'_pure r').symm
+        subst ht_eq
+        subst hs_eq
+        refine ⟨pure r, pure r', ?_, ?_,
+          MatchRel.pure r r' hrr (shape'_pure r) (shape'_pure r')⟩
+        · simpa only [simulate_pure] using ht.simulate h
+        · simpa only [simulate_pure] using hs.simulate h
+    | tau ct cs ht' hs' hcont =>
+        have ht_eq : t' = step (ct PUnit.unit) := by
+          apply PFunctor.M.eq_of_dest_eq
+          change shape' t' = shape' (step (ct PUnit.unit))
+          rw [ht', shape'_step]
+        have hs_eq : s' = step (cs PUnit.unit) := by
+          apply PFunctor.M.eq_of_dest_eq
+          change shape' s' = shape' (step (cs PUnit.unit))
+          rw [hs', shape'_step]
+        subst ht_eq
+        subst hs_eq
+        refine ⟨step (simulate h (ct PUnit.unit)),
+          step (simulate h (cs PUnit.unit)), ?_, ?_, ?_⟩
+        · simpa only [simulate_step_eq] using ht.simulate h
+        · simpa only [simulate_step_eq] using hs.simulate h
+        · exact MatchRel.tau _ _ (shape'_step _) (shape'_step _)
+            (Or.inl ⟨ct PUnit.unit, cs PUnit.unit, hcont, rfl, rfl⟩)
+    | query a c c' ht' hs' hcont =>
+        have ht_eq : t' = query a c := by
+          apply PFunctor.M.eq_of_dest_eq
+          change shape' t' = shape' (query a c)
+          exact ht'.trans (shape'_query a c).symm
+        have hs_eq : s' = query a c' := by
+          apply PFunctor.M.eq_of_dest_eq
+          change shape' s' = shape' (query a c')
+          exact hs'.trans (shape'_query a c').symm
+        subst ht_eq
+        subst hs_eq
+        have ht_sim := ht.simulate h
+        have hs_sim := hs.simulate h
+        rw [simulate_query_eq_bind] at ht_sim hs_sim
+        rcases hu : PFunctor.M.dest (h a) with ⟨sh, cu⟩
+        cases sh with
+        | pure b =>
+            have hu_eq : h a = pure b := by
+              apply PFunctor.M.eq_of_dest_eq
+              rw [hu]
+              change (⟨.pure b, cu⟩ : (Poly F (E.B a)).Obj _) =
+                ⟨.pure b, PEmpty.elim⟩
+              congr 1
+              funext z
+              exact z.elim
+            rw [hu_eq, bind_pure_left] at ht_sim hs_sim
+            refine ⟨step (simulate h (c b)), step (simulate h (c' b)),
+              ht_sim, hs_sim, ?_⟩
+            exact MatchRel.tau _ _ (shape'_step _) (shape'_step _)
+              (Or.inl ⟨c b, c' b, hcont b, rfl, rfl⟩)
+        | step =>
+            refine ⟨bind (h a) (fun b => step (simulate h (c b))),
+              bind (h a) (fun b => step (simulate h (c' b))),
+              ht_sim, hs_sim, ?_⟩
+            exact MatchRel.tau _ _
+              (dest_bind_step _ (h a) cu hu) (dest_bind_step _ (h a) cu hu)
+              (Or.inr ⟨E.B a, cu PUnit.unit, c, c', hcont, rfl, rfl⟩)
+        | query q =>
+            refine ⟨bind (h a) (fun b => step (simulate h (c b))),
+              bind (h a) (fun b => step (simulate h (c' b))),
+              ht_sim, hs_sim, ?_⟩
+            refine MatchRel.query q _ _ (dest_bind_query _ (h a) q cu hu)
+              (dest_bind_query _ (h a) q cu hu) ?_
+            intro b
+            exact Or.inr ⟨E.B a, cu b, c, c', hcont, rfl, rfl⟩
+  · rcases hu : PFunctor.M.dest u with ⟨sh, c⟩
+    cases sh with
+    | pure r =>
+        have hu_eq : u = pure r := by
+          apply PFunctor.M.eq_of_dest_eq
+          rw [hu]
+          change (⟨.pure r, c⟩ : (Poly F γ).Obj _) =
+            ⟨.pure r, PEmpty.elim⟩
+          congr 1
+          funext z
+          exact z.elim
+        subst hu_eq
+        rw [bind_pure_left, bind_pure_left]
+        refine ⟨step (simulate h (k r)), step (simulate h (k' r)),
+          .refl _, .refl _, ?_⟩
+        exact MatchRel.tau _ _ (shape'_step _) (shape'_step _)
+          (Or.inl ⟨k r, k' r, hkk' r, rfl, rfl⟩)
+    | step =>
+        refine ⟨bind u (fun b => step (simulate h (k b))),
+          bind u (fun b => step (simulate h (k' b))), .refl _, .refl _, ?_⟩
+        exact MatchRel.tau _ _ (dest_bind_step _ u c hu) (dest_bind_step _ u c hu)
+          (Or.inr ⟨γ, c PUnit.unit, k, k', hkk', rfl, rfl⟩)
+    | query a =>
+        refine ⟨bind u (fun b => step (simulate h (k b))),
+          bind u (fun b => step (simulate h (k' b))), .refl _, .refl _, ?_⟩
+        refine MatchRel.query a _ _ (dest_bind_query _ u a c hu)
+          (dest_bind_query _ u a c hu) ?_
+        intro b
+        exact Or.inr ⟨γ, c b, k, k', hkk', rfl, rfl⟩
+
 /-! ### `simulate` is monadic and identity-preserving -/
 
-theorem simulate_id (t : ITree E α) :
+theorem simulate_id {E : PFunctor.{uEA, uEB}} {α : Type uα}
+    (t : ITree E α) :
     WeakBisim (simulate (Handler.id E) t) t := by
   refine WeakBisim.coinduct
     (fun x y => x = simulate (Handler.id E) y ∨
@@ -283,13 +437,15 @@ theorem simulate_id (t : ITree E α) :
 
 /-- Postcomposing a handler with the trivial handler is pointwise weakly
 equivalent to the original handler. -/
-theorem Handler.id_comp_apply (h : Handler E F) (a : E.A) :
+theorem Handler.id_comp_apply {E : PFunctor.{uEA, uEB}}
+    {F : PFunctor.{uFA, uFB}} (h : Handler E F) (a : E.A) :
     WeakBisim ((Handler.id F).comp h a) (h a) :=
   simulate_id (h a)
 
 /-- Precomposing a handler with the trivial handler is pointwise weakly
 equivalent to the original handler. -/
-theorem Handler.comp_id_apply (h : Handler E F) (a : E.A) :
+theorem Handler.comp_id_apply {E : PFunctor.{uEA, uEB}}
+    {F : PFunctor.{uFA, uFB}} (h : Handler E F) (a : E.A) :
     WeakBisim (h.comp (Handler.id E) a) (h a) := by
   change WeakBisim (simulate h (lift a)) (h a)
   simpa only [lift, simulate_pure, bind_pure_right] using
@@ -306,7 +462,9 @@ The witness is a three-disjunct coinductive relation:
   at a source-side `query a ...` node. This is what lets the coinductive
   step close when the source tree is query-headed and `simulate`'s
   productivity-forced silent step is emitted on the handler-output side. -/
-theorem simulate_bind (h : Handler E F) (t : ITree E α) (k : α → ITree E β) :
+theorem simulate_bind {E : PFunctor.{uEA, uEB}} {F : PFunctor.{uFA, uFB}}
+    {α : Type uα} {β : Type uβ}
+    (h : Handler E F) (t : ITree E α) (k : α → ITree E β) :
     WeakBisim (simulate h (bind t k))
       (bind (simulate h t) (fun a => simulate h (k a))) := by
   refine WeakBisim.coinduct
@@ -314,7 +472,7 @@ theorem simulate_bind (h : Handler E F) (t : ITree E α) (k : α → ITree E β)
       (∃ t : ITree E α,
         x = simulate h (bind t k) ∧
         y = bind (simulate h t) (fun a => simulate h (k a))) ∨
-      (∃ (γ : Type u) (u : ITree F γ) (f : γ → ITree E α),
+      (∃ (γ : Type uEB) (u : ITree F γ) (f : γ → ITree E α),
         x = bind u (fun b => step (simulate h (bind (f b) k))) ∧
         y = bind u (fun b => step
           (bind (simulate h (f b)) (fun a => simulate h (k a))))))
@@ -450,6 +608,288 @@ theorem simulate_bind (h : Handler E F) (t : ITree E α) (k : α → ITree E β)
         intro b'
         exact Or.inr (Or.inr ⟨γ, c b', f, rfl, rfl⟩)
 
+/-! ### Composition of simulation -/
+
+/-- Sequential simulation agrees with simulation through the composite
+handler, up to weak bisimulation.
+
+The proof uses three coinductive phases: source-tree traversal, traversal
+inside the first handler's output, and traversal inside the second handler's
+output. The latter two phases make the productivity-forced silent steps
+explicit instead of relying on an unproved up-to-bind principle. -/
+theorem simulate_comp {E : PFunctor.{uEA, uEB}} {F : PFunctor.{uFA, uFB}}
+    {G : PFunctor.{uGA, uGB}} {α : Type uα}
+    (outer : Handler F G) (inner : Handler E F) (t : ITree E α) :
+    WeakBisim (simulate outer (simulate inner t))
+      (simulate (outer.comp inner) t) := by
+  refine WeakBisim.coinduct
+    (fun x y =>
+      (∃ t : ITree E α,
+        x = simulate outer (simulate inner t) ∧
+        y = simulate (outer.comp inner) t) ∨
+      (∃ (γ : Type uEB) (u : ITree F γ) (k : γ → ITree E α),
+        x = simulate outer
+          (bind u (fun b => step (simulate inner (k b)))) ∧
+        y = bind (simulate outer u)
+          (fun b => step (simulate (outer.comp inner) (k b)))) ∨
+      (∃ (γ : Type uEB) (δ : Type uFB) (w : ITree G δ)
+          (q : δ → ITree F γ) (k : γ → ITree E α),
+        x = bind w (fun z => step (simulate outer
+          (bind (q z) (fun b => step (simulate inner (k b)))))) ∧
+        y = bind w (fun z => step
+          (bind (simulate outer (q z))
+            (fun b => step (simulate (outer.comp inner) (k b)))))))
+    ?_ (Or.inl ⟨t, rfl, rfl⟩)
+  rintro x y (⟨t, rfl, rfl⟩ | ⟨γ, u, k, rfl, rfl⟩ |
+    ⟨γ, δ, w, q, k, rfl, rfl⟩)
+  · rcases ht : PFunctor.M.dest t with ⟨sh, c⟩
+    cases sh with
+    | pure r =>
+        have ht_eq : t = pure r := by
+          apply PFunctor.M.eq_of_dest_eq
+          rw [ht]
+          change (⟨.pure r, c⟩ : (Poly E α).Obj _) =
+            ⟨.pure r, PEmpty.elim⟩
+          congr 1
+          funext z
+          exact z.elim
+        subst ht_eq
+        rw [simulate_pure, simulate_pure, simulate_pure]
+        exact ⟨pure r, pure r, .refl _, .refl _,
+          Match.pure r (shape'_pure r) (shape'_pure r)⟩
+    | step =>
+        have ht_eq : t = step (c PUnit.unit) := by
+          apply PFunctor.M.eq_of_dest_eq
+          rw [ht]
+          rfl
+        subst ht_eq
+        rw [simulate_step_eq, simulate_step_eq, simulate_step_eq]
+        refine ⟨step (simulate outer (simulate inner (c PUnit.unit))),
+          step (simulate (outer.comp inner) (c PUnit.unit)),
+          .refl _, .refl _, ?_⟩
+        exact Match.tau _ _ (shape'_step _) (shape'_step _)
+          (Or.inl ⟨c PUnit.unit, rfl, rfl⟩)
+    | query a =>
+        have ht_eq : t = query a c := by
+          apply PFunctor.M.eq_of_dest_eq
+          rw [ht]
+          rfl
+        subst ht_eq
+        rw [simulate_query_eq_bind inner, simulate_query_eq_bind (outer.comp inner),
+          Handler.comp_apply]
+        rcases hu : PFunctor.M.dest (inner a) with ⟨sh, cu⟩
+        cases sh with
+        | pure r =>
+            have hu_eq : inner a = pure r := by
+              apply PFunctor.M.eq_of_dest_eq
+              rw [hu]
+              change (⟨.pure r, cu⟩ : (Poly F (E.B a)).Obj _) =
+                ⟨.pure r, PEmpty.elim⟩
+              congr 1
+              funext z
+              exact z.elim
+            rw [hu_eq, bind_pure_left, simulate_step_eq, simulate_pure,
+              bind_pure_left]
+            refine ⟨step (simulate outer (simulate inner (c r))),
+              step (simulate (outer.comp inner) (c r)), .refl _, .refl _, ?_⟩
+            exact Match.tau _ _ (shape'_step _) (shape'_step _)
+              (Or.inl ⟨c r, rfl, rfl⟩)
+        | step =>
+            have hu_eq : inner a = step (cu PUnit.unit) := by
+              apply PFunctor.M.eq_of_dest_eq
+              rw [hu]
+              rfl
+            rw [hu_eq, bind_step, simulate_step_eq, simulate_step_eq, bind_step]
+            refine ⟨step (simulate outer
+                (bind (cu PUnit.unit)
+                  (fun b => step (simulate inner (c b))))),
+              step (bind (simulate outer (cu PUnit.unit))
+                (fun b => step (simulate (outer.comp inner) (c b)))),
+              .refl _, .refl _, ?_⟩
+            exact Match.tau _ _ (shape'_step _) (shape'_step _)
+              (Or.inr (Or.inl ⟨E.B a, cu PUnit.unit, c, rfl, rfl⟩))
+        | query a_F =>
+            have hu_eq : inner a = query a_F cu := by
+              apply PFunctor.M.eq_of_dest_eq
+              rw [hu]
+              rfl
+            rw [hu_eq, bind_query, simulate_query_eq_bind,
+              simulate_query_eq_bind, bind_assoc]
+            simp only [bind_step]
+            rcases hw : PFunctor.M.dest (outer a_F) with ⟨sh, cw⟩
+            cases sh with
+            | pure z =>
+                have hw_eq : outer a_F = pure z := by
+                  apply PFunctor.M.eq_of_dest_eq
+                  rw [hw]
+                  change (⟨.pure z, cw⟩ : (Poly G (F.B a_F)).Obj _) =
+                    ⟨.pure z, PEmpty.elim⟩
+                  congr 1
+                  funext e
+                  exact e.elim
+                rw [hw_eq, bind_pure_left, bind_pure_left]
+                refine ⟨step (simulate outer
+                    (bind (cu z) (fun b => step (simulate inner (c b))))),
+                  step (bind (simulate outer (cu z))
+                    (fun b => step (simulate (outer.comp inner) (c b)))),
+                  .refl _, .refl _, ?_⟩
+                exact Match.tau _ _ (shape'_step _) (shape'_step _)
+                  (Or.inr (Or.inl ⟨E.B a, cu z, c, rfl, rfl⟩))
+            | step =>
+                refine ⟨bind (outer a_F) (fun z => step (simulate outer
+                    (bind (cu z) (fun b => step (simulate inner (c b)))))),
+                  bind (outer a_F) (fun z => step
+                    (bind (simulate outer (cu z))
+                      (fun b => step (simulate (outer.comp inner) (c b))))),
+                  .refl _, .refl _, ?_⟩
+                exact Match.tau _ _ (dest_bind_step _ (outer a_F) cw hw)
+                  (dest_bind_step _ (outer a_F) cw hw)
+                  (Or.inr (Or.inr
+                    ⟨E.B a, F.B a_F, cw PUnit.unit, cu, c, rfl, rfl⟩))
+            | query q' =>
+                refine ⟨bind (outer a_F) (fun z => step (simulate outer
+                    (bind (cu z) (fun b => step (simulate inner (c b)))))),
+                  bind (outer a_F) (fun z => step
+                    (bind (simulate outer (cu z))
+                      (fun b => step (simulate (outer.comp inner) (c b))))),
+                  .refl _, .refl _, ?_⟩
+                refine Match.query q' _ _
+                  (dest_bind_query _ (outer a_F) q' cw hw)
+                  (dest_bind_query _ (outer a_F) q' cw hw) ?_
+                intro z
+                exact Or.inr (Or.inr
+                  ⟨E.B a, F.B a_F, cw z, cu, c, rfl, rfl⟩)
+  · rcases hu : PFunctor.M.dest u with ⟨sh, c⟩
+    cases sh with
+    | pure r =>
+        have hu_eq : u = pure r := by
+          apply PFunctor.M.eq_of_dest_eq
+          rw [hu]
+          change (⟨.pure r, c⟩ : (Poly F γ).Obj _) =
+            ⟨.pure r, PEmpty.elim⟩
+          congr 1
+          funext z
+          exact z.elim
+        subst hu_eq
+        rw [bind_pure_left, simulate_step_eq, simulate_pure, bind_pure_left]
+        refine ⟨step (simulate outer (simulate inner (k r))),
+          step (simulate (outer.comp inner) (k r)), .refl _, .refl _, ?_⟩
+        exact Match.tau _ _ (shape'_step _) (shape'_step _)
+          (Or.inl ⟨k r, rfl, rfl⟩)
+    | step =>
+        have hu_eq : u = step (c PUnit.unit) := by
+          apply PFunctor.M.eq_of_dest_eq
+          rw [hu]
+          rfl
+        subst hu_eq
+        rw [bind_step, simulate_step_eq, simulate_step_eq, bind_step]
+        refine ⟨step (simulate outer
+            (bind (c PUnit.unit) (fun b => step (simulate inner (k b))))),
+          step (bind (simulate outer (c PUnit.unit))
+            (fun b => step (simulate (outer.comp inner) (k b)))),
+          .refl _, .refl _, ?_⟩
+        exact Match.tau _ _ (shape'_step _) (shape'_step _)
+          (Or.inr (Or.inl ⟨γ, c PUnit.unit, k, rfl, rfl⟩))
+    | query a =>
+        have hu_eq : u = query a c := by
+          apply PFunctor.M.eq_of_dest_eq
+          rw [hu]
+          rfl
+        subst hu_eq
+        rw [bind_query, simulate_query_eq_bind, simulate_query_eq_bind,
+          bind_assoc]
+        simp only [bind_step]
+        rcases hw : PFunctor.M.dest (outer a) with ⟨sh, cw⟩
+        cases sh with
+        | pure z =>
+            have hw_eq : outer a = pure z := by
+              apply PFunctor.M.eq_of_dest_eq
+              rw [hw]
+              change (⟨.pure z, cw⟩ : (Poly G (F.B a)).Obj _) =
+                ⟨.pure z, PEmpty.elim⟩
+              congr 1
+              funext e
+              exact e.elim
+            rw [hw_eq, bind_pure_left, bind_pure_left]
+            refine ⟨step (simulate outer
+                (bind (c z) (fun b => step (simulate inner (k b))))),
+              step (bind (simulate outer (c z))
+                (fun b => step (simulate (outer.comp inner) (k b)))),
+              .refl _, .refl _, ?_⟩
+            exact Match.tau _ _ (shape'_step _) (shape'_step _)
+              (Or.inr (Or.inl ⟨γ, c z, k, rfl, rfl⟩))
+        | step =>
+            refine ⟨bind (outer a) (fun z => step (simulate outer
+                (bind (c z) (fun b => step (simulate inner (k b)))))),
+              bind (outer a) (fun z => step
+                (bind (simulate outer (c z))
+                  (fun b => step (simulate (outer.comp inner) (k b))))),
+              .refl _, .refl _, ?_⟩
+            exact Match.tau _ _ (dest_bind_step _ (outer a) cw hw)
+              (dest_bind_step _ (outer a) cw hw)
+              (Or.inr (Or.inr ⟨γ, F.B a, cw PUnit.unit, c, k, rfl, rfl⟩))
+        | query q' =>
+            refine ⟨bind (outer a) (fun z => step (simulate outer
+                (bind (c z) (fun b => step (simulate inner (k b)))))),
+              bind (outer a) (fun z => step
+                (bind (simulate outer (c z))
+                  (fun b => step (simulate (outer.comp inner) (k b))))),
+              .refl _, .refl _, ?_⟩
+            refine Match.query q' _ _ (dest_bind_query _ (outer a) q' cw hw)
+              (dest_bind_query _ (outer a) q' cw hw) ?_
+            intro z
+            exact Or.inr (Or.inr ⟨γ, F.B a, cw z, c, k, rfl, rfl⟩)
+  · rcases hw : PFunctor.M.dest w with ⟨sh, c⟩
+    cases sh with
+    | pure z =>
+        have hw_eq : w = pure z := by
+          apply PFunctor.M.eq_of_dest_eq
+          rw [hw]
+          change (⟨.pure z, c⟩ : (Poly G δ).Obj _) =
+            ⟨.pure z, PEmpty.elim⟩
+          congr 1
+          funext e
+          exact e.elim
+        subst hw_eq
+        rw [bind_pure_left, bind_pure_left]
+        refine ⟨step (simulate outer
+            (bind (q z) (fun b => step (simulate inner (k b))))),
+          step (bind (simulate outer (q z))
+            (fun b => step (simulate (outer.comp inner) (k b)))),
+          .refl _, .refl _, ?_⟩
+        exact Match.tau _ _ (shape'_step _) (shape'_step _)
+          (Or.inr (Or.inl ⟨γ, q z, k, rfl, rfl⟩))
+    | step =>
+        refine ⟨bind w (fun z => step (simulate outer
+            (bind (q z) (fun b => step (simulate inner (k b)))))),
+          bind w (fun z => step
+            (bind (simulate outer (q z))
+              (fun b => step (simulate (outer.comp inner) (k b))))),
+          .refl _, .refl _, ?_⟩
+        exact Match.tau _ _ (dest_bind_step _ w c hw) (dest_bind_step _ w c hw)
+          (Or.inr (Or.inr ⟨γ, δ, c PUnit.unit, q, k, rfl, rfl⟩))
+    | query a =>
+        refine ⟨bind w (fun z => step (simulate outer
+            (bind (q z) (fun b => step (simulate inner (k b)))))),
+          bind w (fun z => step
+            (bind (simulate outer (q z))
+              (fun b => step (simulate (outer.comp inner) (k b))))),
+          .refl _, .refl _, ?_⟩
+        refine Match.query a _ _ (dest_bind_query _ w a c hw)
+          (dest_bind_query _ w a c hw) ?_
+        intro z
+        exact Or.inr (Or.inr ⟨γ, δ, c z, q, k, rfl, rfl⟩)
+
+/-- Handler composition is associative pointwise up to weak bisimulation. -/
+theorem Handler.comp_assoc_apply {E : PFunctor.{uEA, uEB}}
+    {F : PFunctor.{uFA, uFB}} {G : PFunctor.{uGA, uGB}}
+    {H : PFunctor.{uHA, uHB}}
+    (third : Handler G H) (second : Handler F G) (first : Handler E F)
+    (a : E.A) :
+    WeakBisim (third.comp (second.comp first) a)
+      ((third.comp second).comp first a) := by
+  simpa only [Handler.comp_apply] using simulate_comp third second (first a)
+
 /-! ### One-step unfoldings of `mapSpec`
 
 These are direct `M.corec` unfoldings using `dest_corec_eq` and the fact
@@ -576,7 +1016,9 @@ which only matches `mapSpec` up to weak bisim. The proofs are by
 `PFunctor.M.bisim` with a relation that encodes the *defining equation*
 (left-hand side ↔ right-hand side) plus the trivial diagonal closure. -/
 
-theorem mapSpec_bind (φ : PFunctor.Lens E F)
+theorem mapSpec_bind {E : PFunctor.{uEA, uEB}}
+    {F : PFunctor.{uFA, uFB}} {α : Type uα} {β : Type uβ}
+    (φ : PFunctor.Lens E F)
     (t : ITree E α) (k : α → ITree E β) :
     mapSpec φ (bind t k) = bind (mapSpec φ t) (fun a => mapSpec φ (k a)) := by
   refine PFunctor.M.bisim
@@ -627,6 +1069,7 @@ Used by `mapSpec_iter` below. They factor the case analysis on `shape' t`
 out of the bisimulation proof. -/
 
 private theorem dest_corec_iterStep_pure_inl
+    {E : PFunctor.{uEA, uEB}} {α : Type uα} {β : Type uβ}
     (body : β → ITree E (β ⊕ α)) (t : ITree E (β ⊕ α)) (j : β)
     (cIn : (Poly E (β ⊕ α)).B (.pure (.inl j)) → (Poly E (β ⊕ α)).M)
     (h : PFunctor.M.dest t = ⟨.pure (.inl j), cIn⟩) :
@@ -635,6 +1078,7 @@ private theorem dest_corec_iterStep_pure_inl
   rw [PFunctor.M.dest_corec_apply, iterStep, h]
 
 private theorem dest_corec_iterStep_pure_inr
+    {E : PFunctor.{uEA, uEB}} {α : Type uα} {β : Type uβ}
     (body : β → ITree E (β ⊕ α)) (t : ITree E (β ⊕ α)) (r : α)
     (cIn : (Poly E (β ⊕ α)).B (.pure (.inr r)) → (Poly E (β ⊕ α)).M)
     (h : PFunctor.M.dest t = ⟨.pure (.inr r), cIn⟩) :
@@ -646,14 +1090,16 @@ private theorem dest_corec_iterStep_pure_inr
   exact z.elim
 
 private theorem dest_corec_iterStep_step
+    {E : PFunctor.{uEA, uEB}} {α : Type uα} {β : Type uβ}
     (body : β → ITree E (β ⊕ α)) (t : ITree E (β ⊕ α))
-    (c : PUnit → ITree E (β ⊕ α))
+    (c : PUnit.{uEB + 1} → ITree E (β ⊕ α))
     (h : PFunctor.M.dest t = ⟨.step, c⟩) :
     PFunctor.M.dest (PFunctor.M.corec (iterStep body) t) =
       ⟨.step, fun u => PFunctor.M.corec (iterStep body) (c u)⟩ := by
   rw [PFunctor.M.dest_corec_apply, iterStep, h]
 
 private theorem dest_corec_iterStep_query
+    {E : PFunctor.{uEA, uEB}} {α : Type uα} {β : Type uβ}
     (body : β → ITree E (β ⊕ α)) (t : ITree E (β ⊕ α)) (a : E.A)
     (c : E.B a → ITree E (β ⊕ α))
     (h : PFunctor.M.dest t = ⟨.query a, c⟩) :
@@ -661,7 +1107,9 @@ private theorem dest_corec_iterStep_query
       ⟨.query a, fun b => PFunctor.M.corec (iterStep body) (c b)⟩ := by
   rw [PFunctor.M.dest_corec_apply, iterStep, h]
 
-theorem mapSpec_iter (φ : PFunctor.Lens E F)
+theorem mapSpec_iter {E : PFunctor.{uEA, uEB}}
+    {F : PFunctor.{uFA, uFB}} {α : Type uα} {β : Type uβ}
+    (φ : PFunctor.Lens E F)
     (body : β → ITree E (β ⊕ α)) (init : β) :
     mapSpec φ (iter body init) = iter (fun j => mapSpec φ (body j)) init := by
   refine PFunctor.M.bisim
@@ -797,15 +1245,21 @@ theorem mapSpec_iter (φ : PFunctor.Lens E F)
 
 These follow directly from `mapSpec_bind` + `mapSpec_pure`. -/
 
-@[simp] theorem mapSpec_map (φ : PFunctor.Lens E F) (f : α → β) (t : ITree E α) :
+@[simp] theorem mapSpec_map {E : PFunctor.{uEA, uEB}}
+    {F : PFunctor.{uFA, uFB}} {α : Type uα} {β : Type uβ}
+    (φ : PFunctor.Lens E F) (f : α → β) (t : ITree E α) :
     mapSpec φ (ITree.map f t) = ITree.map f (mapSpec φ t) := by
   simp only [ITree.map, mapSpec_bind, mapSpec_pure]
 
-theorem mapSpec_functorMap (φ : PFunctor.Lens E F) (f : α → β)
+theorem mapSpec_functorMap {E : PFunctor.{uEA, uEB}}
+    {F : PFunctor.{uFA, uFB}} {α β : Type u}
+    (φ : PFunctor.Lens E F) (f : α → β)
     (t : ITree E α) : mapSpec φ (f <$> t) = f <$> mapSpec φ t := by
   simp only [map_eq_functor_map, mapSpec_map]
 
-@[simp] theorem mapSpec_cat {γ : Type u} (φ : PFunctor.Lens E F)
+@[simp] theorem mapSpec_cat {E : PFunctor.{uEA, uEB}}
+    {F : PFunctor.{uFA, uFB}} {α : Type uα} {β : Type uβ}
+    {γ : Type uγ} (φ : PFunctor.Lens E F)
     (f : α → ITree E β) (g : β → ITree E γ) (a : α) :
     mapSpec φ (ITree.cat f g a) =
       ITree.cat (mapSpec φ ∘ f) (mapSpec φ ∘ g) a := by
@@ -817,7 +1271,9 @@ theorem mapSpec_functorMap (φ : PFunctor.Lens E F) (f : α → β)
 /-- `mapSpec` distributes over `Seq.seq`, i.e. it is an Applicative
 morphism. Falls out of `mapSpec_bind` + `mapSpec_functorMap` after unfolding
 the default `seq` of `Monad (ITree F)` to `bind`. -/
-@[simp] theorem mapSpec_seq (φ : PFunctor.Lens E F) (mf : ITree E (α → β))
+@[simp] theorem mapSpec_seq {E : PFunctor.{uEA, uEB}}
+    {F : PFunctor.{uFA, uFB}} {α β : Type u}
+    (φ : PFunctor.Lens E F) (mf : ITree E (α → β))
     (mx : ITree E α) :
     mapSpec φ (mf <*> mx) = mapSpec φ mf <*> mapSpec φ mx := by
   change mapSpec φ (bind mf (fun f => f <$> mx)) =
@@ -827,7 +1283,9 @@ the default `seq` of `Monad (ITree F)` to `bind`. -/
 
 /-! ### Relating `simulate` and `mapSpec` -/
 
-theorem simulate_ofLens (φ : PFunctor.Lens E F) (t : ITree E α) :
+theorem simulate_ofLens {E : PFunctor.{uEA, uEB}}
+    {F : PFunctor.{uFA, uFB}} {α : Type uα}
+    (φ : PFunctor.Lens E F) (t : ITree E α) :
     WeakBisim (simulate (Handler.ofLens φ) t) (mapSpec φ t) := by
   refine WeakBisim.coinduct
     (fun x y => (∃ t : ITree E α,
@@ -883,7 +1341,9 @@ theorem simulate_ofLens (φ : PFunctor.Lens E F) (t : ITree E α) :
 
 /-- Composition of pure-renaming handlers agrees pointwise, up to weak
 bisimilarity, with composition of their underlying lenses. -/
-theorem Handler.ofLens_comp_apply (φ : PFunctor.Lens E F)
+theorem Handler.ofLens_comp_apply {E : PFunctor.{uEA, uEB}}
+    {F : PFunctor.{uFA, uFB}} {G : PFunctor.{uGA, uGB}}
+    (φ : PFunctor.Lens E F)
     (ψ : PFunctor.Lens F G) (a : E.A) :
     WeakBisim ((Handler.ofLens ψ).comp (Handler.ofLens φ) a)
       (Handler.ofLens (ψ ∘ₗ φ) a) := by

--- a/PolyFun/ITree/Sim/Facts.lean
+++ b/PolyFun/ITree/Sim/Facts.lean
@@ -17,6 +17,8 @@ The standard equational theory for the simulation operators:
 * `simulate_bind` — `simulate` distributes over `bind`.
 * `simulate_id` — interpreting via the trivial handler is (weakly) the
   identity.
+* `Handler.id_comp_apply`, `Handler.comp_id_apply` — the trivial handler is
+  a pointwise weak identity for handler composition.
 * `mapSpec_pure`, `mapSpec_step`, `mapSpec_query` — one-step unfoldings of
   `mapSpec`.
 * `mapSpec_id`, `mapSpec_comp` — functoriality of `mapSpec` over the lens
@@ -29,16 +31,27 @@ The standard equational theory for the simulation operators:
   step of `M.corec (iterStep body)` in each of the four cases for the head of
   the input ITree.
 * `simulate_ofLens` — relating `simulate` and `mapSpec` on a renaming.
+* `Handler.ofLens_comp_apply` — pure-renaming handler composition agrees
+  pointwise with lens composition.
 
 Each proof is built by coinduction on the shared `ITree` shape and combines
 one-step `M.corec` unfoldings with the bisimulation laws of
 `PolyFun.ITree.Bisim.Bind` (notably `bind_weakBisim_cont` and the bind
 unfoldings), so the resulting equations hold up to weak bisimulation.
+
+The executable Handler/Sim layer is fully universe-polymorphic. The primitive
+strong equations listed above retain the universe separation of the
+definitions. Laws that depend on the shared bind/iteration theory—including
+`simulate_query_eq_bind`, `mapSpec_bind`, `mapSpec_iter`, `mapSpec_map`, and
+`mapSpec_cat`—remain in the homogeneous fragment in this slice. The next two
+stack slices generalize that algebra and then these consumer laws. Theorems
+that mention `WeakBisim` likewise remain homogeneous until the relational
+bisimulation layer.
 -/
 
 @[expose] public section
 
-universe u
+universe u uEA uEB uFA uFB uGA uGB uα
 
 namespace ITree
 
@@ -47,17 +60,22 @@ variable {E F G : PFunctor.{u, u}} {α β : Type u}
 /-! ### One-step unfoldings of `simulate` -/
 
 /-- Step transformer used internally by `simulate`. -/
-private def simulateStep (h : Handler E F) :
+private def simulateStep {E : PFunctor.{uEA, uEB}} {F : PFunctor.{uFA, uFB}}
+    {α : Type uα} (h : Handler E F) :
     ITree E α → ITree F (ITree E α ⊕ α) := fun t =>
   match shape' t with
   | ⟨.pure r, _⟩ => pure (.inr r)
   | ⟨.step, c⟩ => pure (.inl (c PUnit.unit))
   | ⟨.query a, c⟩ => bind (h a) (fun b => pure (.inl (c b)))
 
-private theorem simulate_eq_iter (h : Handler E F) (t : ITree E α) :
+private theorem simulate_eq_iter {E : PFunctor.{uEA, uEB}}
+    {F : PFunctor.{uFA, uFB}} {α : Type uα}
+    (h : Handler E F) (t : ITree E α) :
     simulate h t = iter (simulateStep h) t := rfl
 
-private theorem simulateStep_pure (h : Handler E F) (r : α) :
+private theorem simulateStep_pure {E : PFunctor.{uEA, uEB}}
+    {F : PFunctor.{uFA, uFB}} {α : Type uα}
+    (h : Handler E F) (r : α) :
     simulateStep h (pure (F := E) r) = (pure (.inr r) : ITree F (ITree E α ⊕ α)) := by
   change (match shape' (pure (F := E) r) with
       | ⟨.pure r, _⟩ => (pure (.inr r) : ITree F (ITree E α ⊕ α))
@@ -65,7 +83,8 @@ private theorem simulateStep_pure (h : Handler E F) (r : α) :
       | ⟨.query a, c⟩ => bind (h a) (fun b => pure (.inl (c b)))) = pure (.inr r)
   rw [shape'_pure]
 
-theorem simulate_pure (h : Handler E F) (r : α) :
+theorem simulate_pure {E : PFunctor.{uEA, uEB}} {F : PFunctor.{uFA, uFB}}
+    {α : Type uα} (h : Handler E F) (r : α) :
     simulate h (pure (F := E) r) = pure r := by
   apply PFunctor.M.eq_of_dest_eq
   rw [simulate_eq_iter, iter, PFunctor.M.dest_corec_eq _ _
@@ -86,7 +105,9 @@ theorem simulate_pure (h : Handler E F) (r : α) :
   funext b
   exact b.elim
 
-private theorem simulateStep_step (h : Handler E F) (t : ITree E α) :
+private theorem simulateStep_step {E : PFunctor.{uEA, uEB}}
+    {F : PFunctor.{uFA, uFB}} {α : Type uα}
+    (h : Handler E F) (t : ITree E α) :
     simulateStep h (step t) = (pure (.inl t) : ITree F (ITree E α ⊕ α)) := by
   change (match shape' (step t) with
       | ⟨.pure r, _⟩ => (pure (.inr r) : ITree F (ITree E α ⊕ α))
@@ -94,7 +115,9 @@ private theorem simulateStep_step (h : Handler E F) (t : ITree E α) :
       | ⟨.query a, c⟩ => bind (h a) (fun b => pure (.inl (c b)))) = pure (.inl t)
   rw [shape'_step]
 
-private theorem simulateStep_query (h : Handler E F) (a : E.A)
+private theorem simulateStep_query {E : PFunctor.{uEA, uEB}}
+    {F : PFunctor.{uFA, uFB}} {α : Type uα}
+    (h : Handler E F) (a : E.A)
     (k : E.B a → ITree E α) :
     simulateStep h (query a k) =
       (bind (h a) (fun b => pure (.inl (k b))) : ITree F (ITree E α ⊕ α)) := by
@@ -106,7 +129,8 @@ private theorem simulateStep_query (h : Handler E F) (a : E.A)
 
 /-- One-step strong unfolding: `simulate` distributes over a leading silent
 step. -/
-theorem simulate_step_eq (h : Handler E F) (t : ITree E α) :
+theorem simulate_step_eq {E : PFunctor.{uEA, uEB}} {F : PFunctor.{uFA, uFB}}
+    {α : Type uα} (h : Handler E F) (t : ITree E α) :
     simulate h (step t) = step (simulate h t) := by
   apply PFunctor.M.eq_of_dest_eq
   rw [simulate_eq_iter, iter, PFunctor.M.dest_corec_eq _ _
@@ -122,7 +146,7 @@ theorem simulate_step_eq (h : Handler E F) (t : ITree E α) :
             ⟨.step, fun _ => simulateStep h t⟩
         rw [show PFunctor.M.dest (pure (.inl t) : ITree F (ITree E α ⊕ α)) =
           ⟨.pure (.inl t), PEmpty.elim⟩ from shape'_pure _])]
-  show ⟨.step, fun _ => PFunctor.M.corec _ (simulateStep h t)⟩ =
+  change ⟨.step, fun _ => PFunctor.M.corec _ (simulateStep h t)⟩ =
     PFunctor.M.dest (step (simulate h t))
   rw [show PFunctor.M.dest (step (simulate h t)) = ⟨.step, fun _ => simulate h t⟩
       from shape'_step _]
@@ -254,6 +278,22 @@ theorem simulate_id (t : ITree E α) :
       refine Match.query a _ _ (shape'_query _ _) (shape'_query _ _) ?_
       intro b
       exact Or.inr rfl
+
+/-! ### Handler-composition identities -/
+
+/-- Postcomposing a handler with the trivial handler is pointwise weakly
+equivalent to the original handler. -/
+theorem Handler.id_comp_apply (h : Handler E F) (a : E.A) :
+    WeakBisim ((Handler.id F).comp h a) (h a) :=
+  simulate_id (h a)
+
+/-- Precomposing a handler with the trivial handler is pointwise weakly
+equivalent to the original handler. -/
+theorem Handler.comp_id_apply (h : Handler E F) (a : E.A) :
+    WeakBisim (h.comp (Handler.id E) a) (h a) := by
+  change WeakBisim (simulate h (lift a)) (h a)
+  simpa only [lift, simulate_pure, bind_pure_right] using
+    (simulate_query h a (fun b => pure b))
 
 /-- `simulate` distributes over `bind`, up to weak bisimilarity. The `step`
 wrappers that appear after the coinductive unfolding are absorbed by the
@@ -416,7 +456,9 @@ These are direct `M.corec` unfoldings using `dest_corec_eq` and the fact
 that `M.dest` is injective (`PFunctor.M.eq_of_dest_eq`). They do **not**
 need any bisimulation tooling. -/
 
-@[simp] theorem mapSpec_pure (φ : PFunctor.Lens E F) (r : α) :
+@[simp] theorem mapSpec_pure {E : PFunctor.{uEA, uEB}}
+    {F : PFunctor.{uFA, uFB}} {α : Type uα}
+    (φ : PFunctor.Lens E F) (r : α) :
     mapSpec φ (pure (F := E) r) = pure r := by
   apply PFunctor.M.eq_of_dest_eq
   rw [mapSpec, PFunctor.M.dest_corec_eq _ _ (mapSpecStep_pure φ r)]
@@ -426,14 +468,18 @@ need any bisimulation tooling. -/
   funext b
   exact b.elim
 
-@[simp] theorem mapSpec_step (φ : PFunctor.Lens E F) (t : ITree E α) :
+@[simp] theorem mapSpec_step {E : PFunctor.{uEA, uEB}}
+    {F : PFunctor.{uFA, uFB}} {α : Type uα}
+    (φ : PFunctor.Lens E F) (t : ITree E α) :
     mapSpec φ (step t) = step (mapSpec φ t) := by
   apply PFunctor.M.eq_of_dest_eq
   rw [mapSpec, PFunctor.M.dest_corec_eq _ _ (mapSpecStep_step φ t)]
   unfold ITree.step
   rw [PFunctor.M.dest_mk]
 
-@[simp] theorem mapSpec_query (φ : PFunctor.Lens E F) (a : E.A) (k : E.B a → ITree E α) :
+@[simp] theorem mapSpec_query {E : PFunctor.{uEA, uEB}}
+    {F : PFunctor.{uFA, uFB}} {α : Type uα}
+    (φ : PFunctor.Lens E F) (a : E.A) (k : E.B a → ITree E α) :
     mapSpec φ (query a k) =
       query (φ.toFunA a) (fun b => mapSpec φ (k (φ.toFunB a b))) := by
   apply PFunctor.M.eq_of_dest_eq
@@ -443,7 +489,8 @@ need any bisimulation tooling. -/
 
 /-! ### Functoriality of `mapSpec` -/
 
-theorem mapSpec_id (t : ITree E α) :
+theorem mapSpec_id {E : PFunctor.{uEA, uEB}} {α : Type uα}
+    (t : ITree E α) :
     mapSpec (PFunctor.Lens.id E) t = t := by
   conv_rhs => rw [← PFunctor.M.corec_dest t]
   refine PFunctor.M.corec_eq_corec
@@ -461,23 +508,29 @@ theorem mapSpec_id (t : ITree E α) :
       simp only [mapSpecStep, shape', h]
   | query a =>
       refine ⟨.query a, c, c, ?_, rfl, fun _ => rfl⟩
-      show mapSpecStep (PFunctor.Lens.id E) u = ⟨.query a, c⟩
+      change mapSpecStep (PFunctor.Lens.id E) u = ⟨.query a, c⟩
       simp only [mapSpecStep, shape', h]
       rfl
 
 /-- Computing one `M.dest` step of `mapSpec`, in terms of `mapSpecStep`. -/
-theorem dest_mapSpec (φ : PFunctor.Lens E F) (u : ITree E α) :
+theorem dest_mapSpec {E : PFunctor.{uEA, uEB}}
+    {F : PFunctor.{uFA, uFB}} {α : Type uα}
+    (φ : PFunctor.Lens E F) (u : ITree E α) :
     PFunctor.M.dest (mapSpec φ u) =
       ⟨(mapSpecStep φ u).1, fun b => mapSpec φ ((mapSpecStep φ u).2 b)⟩ := by
   rw [mapSpec, PFunctor.M.dest_corec_apply]
 
 /-- Same as `dest_mapSpec` but stated with `shape'` on the LHS. -/
-theorem shape'_mapSpec (φ : PFunctor.Lens E F) (u : ITree E α) :
+theorem shape'_mapSpec {E : PFunctor.{uEA, uEB}}
+    {F : PFunctor.{uFA, uFB}} {α : Type uα}
+    (φ : PFunctor.Lens E F) (u : ITree E α) :
     shape' (mapSpec φ u) =
       ⟨(mapSpecStep φ u).1, fun b => mapSpec φ ((mapSpecStep φ u).2 b)⟩ :=
   dest_mapSpec φ u
 
-theorem mapSpec_comp (φ : PFunctor.Lens E F) (ψ : PFunctor.Lens F G) (t : ITree E α) :
+theorem mapSpec_comp {E : PFunctor.{uEA, uEB}} {F : PFunctor.{uFA, uFB}}
+    {G : PFunctor.{uGA, uGB}} {α : Type uα}
+    (φ : PFunctor.Lens E F) (ψ : PFunctor.Lens F G) (t : ITree E α) :
     mapSpec (ψ ∘ₗ φ) t = mapSpec ψ (mapSpec φ t) := by
   refine PFunctor.M.corec_eq_corec
     (mapSpecStep (ψ ∘ₗ φ)) (mapSpecStep ψ)
@@ -488,28 +541,28 @@ theorem mapSpec_comp (φ : PFunctor.Lens E F) (ψ : PFunctor.Lens F G) (t : ITre
   cases sh with
   | pure r =>
       refine ⟨.pure r, PEmpty.elim, PEmpty.elim, ?_, ?_, ?_⟩
-      · show mapSpecStep (ψ ∘ₗ φ) u = ⟨.pure r, PEmpty.elim⟩
+      · change mapSpecStep (ψ ∘ₗ φ) u = ⟨.pure r, PEmpty.elim⟩
         rw [mapSpecStep, hu]
-      · show mapSpecStep ψ (mapSpec φ u) = ⟨.pure r, PEmpty.elim⟩
+      · change mapSpecStep ψ (mapSpec φ u) = ⟨.pure r, PEmpty.elim⟩
         rw [mapSpecStep, shape'_mapSpec, mapSpecStep, hu]
       · intro b; exact b.elim
   | step =>
       refine ⟨.step, fun _ => c PUnit.unit, fun _ => mapSpec φ (c PUnit.unit),
         ?_, ?_, fun _ => rfl⟩
-      · show mapSpecStep (ψ ∘ₗ φ) u = ⟨.step, fun _ => c PUnit.unit⟩
+      · change mapSpecStep (ψ ∘ₗ φ) u = ⟨.step, fun _ => c PUnit.unit⟩
         rw [mapSpecStep, hu]
-      · show mapSpecStep ψ (mapSpec φ u) = ⟨.step, fun _ => mapSpec φ (c PUnit.unit)⟩
+      · change mapSpecStep ψ (mapSpec φ u) = ⟨.step, fun _ => mapSpec φ (c PUnit.unit)⟩
         rw [mapSpecStep, shape'_mapSpec, mapSpecStep, hu]
   | query a =>
       refine ⟨.query (ψ.toFunA (φ.toFunA a)),
         fun b => c ((ψ ∘ₗ φ).toFunB a b),
         fun b => mapSpec φ (c ((ψ ∘ₗ φ).toFunB a b)),
         ?_, ?_, fun _ => rfl⟩
-      · show mapSpecStep (ψ ∘ₗ φ) u =
+      · change mapSpecStep (ψ ∘ₗ φ) u =
           ⟨.query (ψ.toFunA (φ.toFunA a)), fun b => c ((ψ ∘ₗ φ).toFunB a b)⟩
         rw [mapSpecStep, hu]
         rfl
-      · show mapSpecStep ψ (mapSpec φ u) =
+      · change mapSpecStep ψ (mapSpec φ u) =
           ⟨.query (ψ.toFunA (φ.toFunA a)),
             fun b => mapSpec φ (c ((ψ ∘ₗ φ).toFunB a b))⟩
         rw [mapSpecStep, shape'_mapSpec, mapSpecStep, hu]
@@ -827,5 +880,15 @@ theorem simulate_ofLens (φ : PFunctor.Lens E F) (t : ITree E α) :
       refine Match.query (φ.toFunA a) _ _ (shape'_query _ _) (shape'_query _ _) ?_
       intro b
       exact Or.inr ⟨c (φ.toFunB a b), rfl, rfl⟩
+
+/-- Composition of pure-renaming handlers agrees pointwise, up to weak
+bisimilarity, with composition of their underlying lenses. -/
+theorem Handler.ofLens_comp_apply (φ : PFunctor.Lens E F)
+    (ψ : PFunctor.Lens F G) (a : E.A) :
+    WeakBisim ((Handler.ofLens ψ).comp (Handler.ofLens φ) a)
+      (Handler.ofLens (ψ ∘ₗ φ) a) := by
+  simpa only [Handler.comp_apply, Handler.ofLens, mapSpec_query, mapSpec_pure,
+    PFunctor.Lens.comp, Function.comp_apply] using
+    (simulate_ofLens ψ (Handler.ofLens φ a))
 
 end ITree

--- a/PolyFunTest/ITree/HandlerSimulationExamples.lean
+++ b/PolyFunTest/ITree/HandlerSimulationExamples.lean
@@ -35,9 +35,27 @@ def simulateSeparated (handler : ITree.Handler E F) (tree : ITree E R) :
     ITree F R :=
   ITree.simulate handler tree
 
+example (tree : ITree E R) :
+    ITree.WeakBisim (ITree.simulate (ITree.Handler.id E) tree) tree :=
+  ITree.simulate_id tree
+
 example (handler : ITree.Handler E F) (value : R) :
     ITree.simulate handler (ITree.pure value) = ITree.pure value :=
   ITree.simulate_pure handler value
+
+example (handler : ITree.Handler E F) (event : E.A)
+    (cont : E.B event → ITree E R) :
+    ITree.simulate handler (ITree.query event cont) =
+      ITree.bind (handler event)
+        (fun answer => ITree.step (ITree.simulate handler (cont answer))) :=
+  ITree.simulate_query_eq_bind handler event cont
+
+example {S : Type uQA} {RR : R → S → Prop}
+    (handler : ITree.Handler E F) {tree : ITree E R} {tree' : ITree E S}
+    (h : ITree.WeakBisimRel RR tree tree') :
+    ITree.WeakBisimRel RR (ITree.simulate handler tree)
+      (ITree.simulate handler tree') :=
+  ITree.simulate_weakBisimRel handler h
 
 /-- Pure event renaming has the same universe separation as generic
 simulation. -/
@@ -51,11 +69,57 @@ example (first : PFunctor.Lens E F) (second : PFunctor.Lens F G)
       ITree.mapSpec second (ITree.mapSpec first tree) :=
   ITree.mapSpec_comp first second tree
 
+example {S : Type uQA} (lens : PFunctor.Lens E F)
+    (tree : ITree E R) (cont : R → ITree E S) :
+    ITree.mapSpec lens (ITree.bind tree cont) =
+      ITree.bind (ITree.mapSpec lens tree)
+        (fun value => ITree.mapSpec lens (cont value)) :=
+  ITree.mapSpec_bind lens tree cont
+
+example {S : Type uQA} (lens : PFunctor.Lens E F)
+    (f : R → S) (tree : ITree E R) :
+    ITree.mapSpec lens (ITree.map f tree) =
+      ITree.map f (ITree.mapSpec lens tree) :=
+  ITree.mapSpec_map lens f tree
+
+example {S : Type uQA} (lens : PFunctor.Lens E F)
+    (body : S → ITree E (S ⊕ R)) (init : S) :
+    ITree.mapSpec lens (ITree.iter body init) =
+      ITree.iter (fun s => ITree.mapSpec lens (body s)) init :=
+  ITree.mapSpec_iter lens body init
+
+example {S : Type uQA} {T : Type uHA} (lens : PFunctor.Lens E F)
+    (first : R → ITree E S) (second : S → ITree E T) (value : R) :
+    ITree.mapSpec lens (ITree.cat first second value) =
+      ITree.cat (ITree.mapSpec lens ∘ first)
+        (ITree.mapSpec lens ∘ second) value :=
+  ITree.mapSpec_cat lens first second value
+
 /-- Handler composition permits all three signatures to use independent
 position and direction universes. -/
 def compSeparated (first : ITree.Handler E F) (second : ITree.Handler F G) :
     ITree.Handler E G :=
   second.comp first
+
+example (first : ITree.Handler E F) (second : ITree.Handler F G)
+    (tree : ITree E R) :
+    ITree.WeakBisim
+      (ITree.simulate second (ITree.simulate first tree))
+      (ITree.simulate (second.comp first) tree) :=
+  ITree.simulate_comp second first tree
+
+example {H : PFunctor.{uHA, uHB}} (first : ITree.Handler E F)
+    (second : ITree.Handler F G) (third : ITree.Handler G H) (a : E.A) :
+    ITree.WeakBisim (third.comp (second.comp first) a)
+      ((third.comp second).comp first a) :=
+  ITree.Handler.comp_assoc_apply third second first a
+
+example (first : PFunctor.Lens E F) (second : PFunctor.Lens F G)
+    (a : E.A) :
+    ITree.WeakBisim
+      ((ITree.Handler.ofLens second).comp (ITree.Handler.ofLens first) a)
+      (ITree.Handler.ofLens (second ∘ₗ first) a) :=
+  ITree.Handler.ofLens_comp_apply first second a
 
 /-- Coproduct routing only inherits the equal direction-universe constraint
 of `PFunctor.sum`; the two position universes and target universes remain
@@ -125,5 +189,15 @@ example : chooseTrueHandler.comp negateHandler .bit =
   rw [ITree.Handler.comp_apply, negateHandler, ITree.simulate_query_eq_bind,
     chooseTrueHandler, ITree.bind_pure_left, ITree.simulate_pure]
   rfl
+
+/-- Sequential and composite interpretation agree on a query whose answer is
+transformed by the inner handler and resolved by the outer handler. -/
+example : ITree.WeakBisim
+    (ITree.simulate chooseTrueHandler
+      (ITree.simulate negateHandler
+        (ITree.query .bit (fun answer => ITree.pure answer))))
+    (ITree.simulate (chooseTrueHandler.comp negateHandler)
+      (ITree.query .bit (fun answer => ITree.pure answer))) :=
+  ITree.simulate_comp chooseTrueHandler negateHandler _
 
 end ITree.HandlerSimulationExamples

--- a/PolyFunTest/ITree/HandlerSimulationExamples.lean
+++ b/PolyFunTest/ITree/HandlerSimulationExamples.lean
@@ -1,0 +1,129 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+module
+
+public import PolyFun.ITree.Sim.Facts
+
+/-!
+# Universe-polymorphic handler and simulation examples
+
+These examples pin the independent universes of source signatures, target
+signatures, returned values, and composed handlers. The concrete example also
+checks coproduct routing and makes the answer selected by a composed handler
+observable in the returned value.
+-/
+
+@[expose] public section
+
+universe uEA uEB uFA uFB uGA uGB uHA uHB uQA uR
+
+namespace ITree.HandlerSimulationExamples
+
+variable {E : PFunctor.{uEA, uEB}} {F : PFunctor.{uFA, uFB}}
+  {G : PFunctor.{uGA, uGB}} {Q : PFunctor.{uQA, uEB}} {R : Type uR}
+
+/-- A handler's sort joins the four independent universes of its source and
+target signatures. -/
+example : Type (max uEA uEB uFA uFB) := ITree.Handler E F
+
+/-- Simulation preserves a return type whose universe is independent of both
+event signatures. -/
+def simulateSeparated (handler : ITree.Handler E F) (tree : ITree E R) :
+    ITree F R :=
+  ITree.simulate handler tree
+
+example (handler : ITree.Handler E F) (value : R) :
+    ITree.simulate handler (ITree.pure value) = ITree.pure value :=
+  ITree.simulate_pure handler value
+
+/-- Pure event renaming has the same universe separation as generic
+simulation. -/
+def mapSpecSeparated (lens : PFunctor.Lens E F) (tree : ITree E R) :
+    ITree F R :=
+  ITree.mapSpec lens tree
+
+example (first : PFunctor.Lens E F) (second : PFunctor.Lens F G)
+    (tree : ITree E R) :
+    ITree.mapSpec (second ∘ₗ first) tree =
+      ITree.mapSpec second (ITree.mapSpec first tree) :=
+  ITree.mapSpec_comp first second tree
+
+/-- Handler composition permits all three signatures to use independent
+position and direction universes. -/
+def compSeparated (first : ITree.Handler E F) (second : ITree.Handler F G) :
+    ITree.Handler E G :=
+  second.comp first
+
+/-- Coproduct routing only inherits the equal direction-universe constraint
+of `PFunctor.sum`; the two position universes and target universes remain
+independent. -/
+def caseSeparated (left : ITree.Handler E G) (right : ITree.Handler Q G) :
+    ITree.Handler.{max uEA uQA, uEB, uGA, uGB} (E + Q) G :=
+  ITree.Handler.case_ left right
+
+example {H : PFunctor.{uHA, uHB}} (outer : ITree.Handler G H)
+    (left : ITree.Handler E G) (right : ITree.Handler Q G) :
+    outer.comp (ITree.Handler.case_ left right) =
+      ITree.Handler.case_ (outer.comp left) (outer.comp right) :=
+  ITree.Handler.comp_case outer left right
+
+/-! ## Observable routing and composition -/
+
+inductive ReadEvent where
+  | bit
+
+inductive CountEvent where
+  | amount
+
+inductive ChoiceEvent where
+  | choose
+
+inductive FinalEvent where
+  | tick
+
+@[reducible] def ReadSpec : PFunctor := ⟨ReadEvent, fun | .bit => Bool⟩
+
+@[reducible] def CountSpec : PFunctor := ⟨CountEvent, fun | .amount => Nat⟩
+
+@[reducible] def ChoiceSpec : PFunctor := ⟨ChoiceEvent, fun | .choose => Bool⟩
+
+@[reducible] def FinalSpec : PFunctor := ⟨FinalEvent, fun | .tick => Bool⟩
+
+def readHandler : ITree.Handler ReadSpec FinalSpec
+  | .bit => ITree.pure true
+
+def countHandler : ITree.Handler CountSpec FinalSpec
+  | .amount => ITree.pure 7
+
+example :
+    ITree.Handler.case_ readHandler countHandler (.inl .bit) = ITree.pure true :=
+  rfl
+
+example :
+    ITree.Handler.case_ readHandler countHandler (.inr .amount) =
+      countHandler .amount :=
+  rfl
+
+example : countHandler .amount = ITree.pure (7 : Nat) := rfl
+
+/-- The first handler negates the answer supplied by its target event. -/
+def negateHandler : ITree.Handler ReadSpec ChoiceSpec
+  | .bit => ITree.query .choose (fun answer => ITree.pure (!answer))
+
+/-- The second handler resolves that target event with `true`. -/
+def chooseTrueHandler : ITree.Handler ChoiceSpec FinalSpec
+  | .choose => ITree.pure true
+
+/-- Composition order and answer flow are observable: `true` is selected by
+the second handler, negated by the first handler's continuation, and returned
+as `false` after the productivity-forced silent step. -/
+example : chooseTrueHandler.comp negateHandler .bit =
+    ITree.step (ITree.pure false) := by
+  rw [ITree.Handler.comp_apply, negateHandler, ITree.simulate_query_eq_bind,
+    chooseTrueHandler, ITree.bind_pure_left, ITree.simulate_pure]
+  rfl
+
+end ITree.HandlerSimulationExamples

--- a/PolyFunTest/ITree/RelationalBisimExamples.lean
+++ b/PolyFunTest/ITree/RelationalBisimExamples.lean
@@ -1,0 +1,110 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+module
+
+public import PolyFun.ITree.Bisim.Bind
+
+/-!
+# Relational weak-bisimulation examples
+
+These examples pin the independent universes of the event signature, both
+source return types, and both continuation return types. The concrete example
+checks that a silent step can be ignored while a non-equality relation compares
+distinct return representations, and that the relation is transported through
+two-sided `bind` congruence.
+-/
+
+@[expose] public section
+
+universe uFA uFB uα uβ uγ uδ
+
+namespace ITree.RelationalBisimExamples
+
+variable {F : PFunctor.{uFA, uFB}} {α : Type uα} {β : Type uβ}
+  {γ : Type uγ} {δ : Type uδ}
+
+/-- Relational weak bisimulation accepts return types whose universes are
+independent of each other and of both event universes. -/
+def separated (RR : α → β → Prop) (left : ITree F α) (right : ITree F β) :
+    Prop :=
+  WeakBisimRel RR left right
+
+example (RR : α → β → Prop) {a : α} {b : β} (h : RR a b) :
+    WeakBisimRel RR (ITree.pure (F := F) a) (ITree.pure (F := F) b) :=
+  WeakBisimRel.pure h
+
+example (RR : α → β → Prop) (SS : β → γ → Prop)
+    {left : ITree F α} {middle : ITree F β} {right : ITree F γ}
+    (h₁ : WeakBisimRel RR left middle)
+    (h₂ : WeakBisimRel SS middle right) :
+    WeakBisimRel (Relation.Comp RR SS) left right :=
+  h₁.comp h₂
+
+/-- The equality-specialized API is definitionally the relational one. -/
+example (left right : ITree F α) :
+    WeakBisim left right = WeakBisimRel Eq left right :=
+  rfl
+
+/-- Finite silent-step stripping must not collapse termination into silent
+divergence, in either orientation. -/
+example (r : α) :
+    ¬ WeakBisim (ITree.pure (F := F) r) (ITree.diverge (F := F)) :=
+  WeakBisim.pure_not_diverge r
+
+example (r : α) :
+    ¬ WeakBisim (ITree.diverge (F := F)) (ITree.pure (F := F) r) := by
+  intro h
+  exact WeakBisim.pure_not_diverge r h.symm
+
+example (RR : α → β → Prop) (SS : γ → δ → Prop)
+    {left : ITree F α} {right : ITree F β}
+    {f : α → ITree F γ} {g : β → ITree F δ}
+    (hTree : WeakBisimRel RR left right)
+    (hCont : ∀ a b, RR a b → WeakBisimRel SS (f a) (g b)) :
+    WeakBisimRel SS (ITree.bind left f) (ITree.bind right g) :=
+  ITree.bind_weakBisimRel hTree hCont
+
+example (RR : α → β → Prop) (SS : γ → δ → Prop)
+    (f : α → γ) (g : β → δ) {left : ITree F α} {right : ITree F β}
+    (hTree : WeakBisimRel RR left right)
+    (hMap : ∀ a b, RR a b → SS (f a) (g b)) :
+    WeakBisimRel SS (ITree.map f left) (ITree.map g right) :=
+  ITree.map_weakBisimRel f g hTree hMap
+
+/-! ## Observable heterogeneous return relation -/
+
+@[reducible] def EmptySpec : PFunctor :=
+  ⟨PEmpty, PEmpty.elim⟩
+
+def SourceRel (flag : Bool) (code : Nat) : Prop :=
+  flag = true ∧ code = 1
+
+def OutputRel (label : String) (accepted : Bool) : Prop :=
+  label = "accepted" ∧ accepted = true
+
+def leftTree : ITree EmptySpec Bool :=
+  ITree.step (ITree.pure true)
+
+def rightTree : ITree EmptySpec Nat :=
+  ITree.pure 1
+
+theorem leftTree_rightTree : WeakBisimRel SourceRel leftTree rightTree := by
+  exact WeakBisimRel.step_left (WeakBisimRel.pure ⟨rfl, rfl⟩)
+
+def leftCont (flag : Bool) : ITree EmptySpec String :=
+  ITree.pure (if flag then "accepted" else "rejected")
+
+def rightCont (code : Nat) : ITree EmptySpec Bool :=
+  ITree.pure (decide (code = 1))
+
+example : WeakBisimRel OutputRel
+    (ITree.bind leftTree leftCont) (ITree.bind rightTree rightCont) := by
+  apply ITree.bind_weakBisimRel leftTree_rightTree
+  intro flag code h
+  rcases h with ⟨rfl, rfl⟩
+  exact WeakBisimRel.pure ⟨rfl, rfl⟩
+
+end ITree.RelationalBisimExamples

--- a/docs/wiki/bisimulation.md
+++ b/docs/wiki/bisimulation.md
@@ -63,8 +63,15 @@ remains the single behavioural-equality principle.
 
 - `ITree.Bisim` is strong/structural bisimulation and coincides with `Eq` by the
   M-type universal property.
-- `ITree.WeakBisim` is the coinductive `eutt`-style relation already developed
-  in `ITree/Bisim`. It strips finite `TauSteps` around observable heads.
+- `ITree.WeakBisimRel RR` is the relational `euttR`-style relation. The trees
+  share an event signature but may return types in independent universes;
+  pure leaves are compared by `RR`, while finite `TauSteps` around observable
+  heads are ignored.
+- `ITree.WeakBisim` is definitionally `WeakBisimRel Eq`. It supplies the
+  same-type equivalence and `Setoid` used by the existing simulation theory.
+- `bind_weakBisimRel` and `map_weakBisimRel` are the two-sided congruence laws:
+  they relate different source return types and different continuation return
+  types without collapsing their universes.
 
 The generic LTS weak closure and `ITree.WeakBisim` describe the same standard
 shape at different representation layers; no adapter is claimed here until it

--- a/docs/wiki/itree.md
+++ b/docs/wiki/itree.md
@@ -53,15 +53,15 @@ step are lifted to `uB`; a visible query retains its original direction type.
 | [`PolyFun/ITree/Construct.lean`](../../PolyFun/ITree/Construct.lean) | Standard combinators: `diverge` (Coq `spin`), `forever`, mixed-universe `map` / `cat`, `ignore`, `burn`. Pure consequences of `bind` / `iter` / `M.corec`. |
 | [`PolyFun/ITree/Handler.lean`](../../PolyFun/ITree/Handler.lean) | Universe-polymorphic `Handler E F`: choice of an `F`-program for every `E`-event, with identity, lens promotion, and coproduct routing via `Handler.case_`. |
 | [`PolyFun/ITree/Sim/Defs.lean`](../../PolyFun/ITree/Sim/Defs.lean) | Universe-polymorphic `ITree.simulate` (interprets every event via a handler), `Handler.comp`, and `ITree.mapSpec` (pure event-renaming via a `PFunctor.Lens`). Coq `interp` analogue. |
-| [`PolyFun/ITree/Sim/Facts.lean`](../../PolyFun/ITree/Sim/Facts.lean) | One-step, identity, bind, iteration, lens-composition, and handler-composition facts. Weak-bisimulation statements use the homogeneous fragment required by `WeakBisim`; independent strong equations retain full universe separation. |
+| [`PolyFun/ITree/Sim/Facts.lean`](../../PolyFun/ITree/Sim/Facts.lean) | Universe-polymorphic one-step, identity, relational congruence, bind, iteration, lens-composition, and handler-composition facts. `simulate_comp` identifies sequential and composite interpretation up to weak bisimulation; `Handler.comp_assoc_apply` gives pointwise associativity. |
 | [`PolyFun/ITree/Rec.lean`](../../PolyFun/ITree/Rec.lean) | `mutualRec`, `fixRec` recursive procedure-call combinators. The `CallE α β` event signature describes one recursive call expecting `α` and returning `β`. |
 
 ### Bisimulation
 
 | File | Purpose |
 |------|---------|
-| [`PolyFun/ITree/Bisim/Defs.lean`](../../PolyFun/ITree/Bisim/Defs.lean) | `ITree.Bisim` (strong / structural; coincides with definitional equality by the M-type universal property), `ITree.WeakBisim` (Coq `eutt`, modulo finitely many leading `step` nodes). |
-| [`PolyFun/ITree/Bisim/Bind.lean`](../../PolyFun/ITree/Bisim/Bind.lean) | Compatibility of bisimulation with `bind`. |
+| [`PolyFun/ITree/Bisim/Defs.lean`](../../PolyFun/ITree/Bisim/Defs.lean) | Universe-polymorphic `ITree.Bisim` (strong / structural equality), relational `ITree.WeakBisimRel RR` (Coq `euttR`), and `ITree.WeakBisim` as its equality specialization (Coq `eutt`). |
+| [`PolyFun/ITree/Bisim/Bind.lean`](../../PolyFun/ITree/Bisim/Bind.lean) | Mixed-universe monad/iteration equations plus two-sided relational congruence of `bind` and `map`. |
 | [`PolyFun/ITree/Bisim/Equiv.lean`](../../PolyFun/ITree/Bisim/Equiv.lean) | Equivalence properties of bisimulation. |
 
 ### Standard events
@@ -83,9 +83,9 @@ step are lifted to `uB`; a visible query retains its original direction type.
   `mapSpec` is the syntactically pure case (pure event rename via a
   `PFunctor.Lens`).
 - Strong bisimulation `Bisim` is set to definitional equality, courtesy
-  of the M-type universal property. Reach for `WeakBisim` whenever you
-  want to ignore finitely many leading silent `step`s, which is the
-  typical "ITree equivalence" used in Coq.
+  of the M-type universal property. `WeakBisimRel RR` ignores finitely many
+  leading silent `step`s and compares returns through `RR`; `WeakBisim` is
+  the same-type `Eq` specialization used as the ordinary ITree setoid.
 - The `Events/{State, Exception}.lean` files are small canonical patterns for
   signatures and smart constructors. Handlers for such signatures can be
   routed, composed, and executed through the generic APIs above.

--- a/docs/wiki/itree.md
+++ b/docs/wiki/itree.md
@@ -51,9 +51,9 @@ step are lifted to `uB`; a visible query retains its original direction type.
 |------|---------|
 | [`PolyFun/ITree/Basic.lean`](../../PolyFun/ITree/Basic.lean) | `ITree F α` defined as `PFunctor.M (Poly F α)`, `Shape` (one-step view), smart constructors `pure` / `step` / `query`, mixed-universe named `bind`, `iter`, and the homogeneous `Monad` instance. |
 | [`PolyFun/ITree/Construct.lean`](../../PolyFun/ITree/Construct.lean) | Standard combinators: `diverge` (Coq `spin`), `forever`, mixed-universe `map` / `cat`, `ignore`, `burn`. Pure consequences of `bind` / `iter` / `M.corec`. |
-| [`PolyFun/ITree/Handler.lean`](../../PolyFun/ITree/Handler.lean) | `Handler E F`: choice of `F`-program for every `E`-event. Source data of the simulation operator. |
-| [`PolyFun/ITree/Sim/Defs.lean`](../../PolyFun/ITree/Sim/Defs.lean) | `ITree.simulate` (interprets every event via a handler), `ITree.mapSpec` (pure event-renaming via a `PFunctor.Lens`). Coq `interp` analogue. |
-| [`PolyFun/ITree/Sim/Facts.lean`](../../PolyFun/ITree/Sim/Facts.lean) | Algebraic facts about simulation. |
+| [`PolyFun/ITree/Handler.lean`](../../PolyFun/ITree/Handler.lean) | Universe-polymorphic `Handler E F`: choice of an `F`-program for every `E`-event, with identity, lens promotion, and coproduct routing via `Handler.case_`. |
+| [`PolyFun/ITree/Sim/Defs.lean`](../../PolyFun/ITree/Sim/Defs.lean) | Universe-polymorphic `ITree.simulate` (interprets every event via a handler), `Handler.comp`, and `ITree.mapSpec` (pure event-renaming via a `PFunctor.Lens`). Coq `interp` analogue. |
+| [`PolyFun/ITree/Sim/Facts.lean`](../../PolyFun/ITree/Sim/Facts.lean) | One-step, identity, bind, iteration, lens-composition, and handler-composition facts. Weak-bisimulation statements use the homogeneous fragment required by `WeakBisim`; independent strong equations retain full universe separation. |
 | [`PolyFun/ITree/Rec.lean`](../../PolyFun/ITree/Rec.lean) | `mutualRec`, `fixRec` recursive procedure-call combinators. The `CallE α β` event signature describes one recursive call expecting `α` and returning `β`. |
 
 ### Bisimulation
@@ -68,8 +68,8 @@ step are lifted to `uB`; a visible query retains its original direction type.
 
 | File | Purpose |
 |------|---------|
-| [`PolyFun/ITree/Events/State.lean`](../../PolyFun/ITree/Events/State.lean) | `StateE σ`: `get` / `put`. Standard "state monad as ITree" embedding via a `simulate`-based handler interpreting `StateE σ` over `σ`. |
-| [`PolyFun/ITree/Events/Exception.lean`](../../PolyFun/ITree/Events/Exception.lean) | `ExceptE ε`: single `throw e` event with answer type `PEmpty` (no resume). Standard exception monad as ITree. |
+| [`PolyFun/ITree/Events/State.lean`](../../PolyFun/ITree/Events/State.lean) | `StateE σ` signature and the `get` / `put` smart constructors. |
+| [`PolyFun/ITree/Events/Exception.lean`](../../PolyFun/ITree/Events/Exception.lean) | `ExceptE ε` signature and the `throw` smart constructor; the answer type is `PEmpty`, so execution cannot resume. |
 
 ## Mental model
 
@@ -78,16 +78,17 @@ step are lifted to `uB`; a visible query retains its original direction type.
   that uniformly models pure programs, programs with effects, recursive
   procedures, and partial / non-terminating computations.
 - A `Handler E F` is the data needed to interpret one signature inside
-  another. `simulate` is the recursive interpretation. `mapSpec` is the
-  syntactically pure case (pure event rename via a `PFunctor.Lens`).
+  another. `simulate` is the recursive interpretation, `Handler.comp`
+  composes interpretations, and `Handler.case_` routes coproduct events.
+  `mapSpec` is the syntactically pure case (pure event rename via a
+  `PFunctor.Lens`).
 - Strong bisimulation `Bisim` is set to definitional equality, courtesy
   of the M-type universal property. Reach for `WeakBisim` whenever you
   want to ignore finitely many leading silent `step`s, which is the
   typical "ITree equivalence" used in Coq.
-- The `Events/{State, Exception}.lean` files are the small canonical
-  examples to read first. They are also the recommended pattern for new
-  event signatures: define the polynomial, write a `Handler`, prove the
-  small algebraic facts you need.
+- The `Events/{State, Exception}.lean` files are small canonical patterns for
+  signatures and smart constructors. Handlers for such signatures can be
+  routed, composed, and executed through the generic APIs above.
 
 ## Recovering Coq references
 


### PR DESCRIPTION
## Summary

Based on merged #42 and current `main`. Review only the unique diff on `agent/itree-handler-sim`.

- generalize `ITree.Handler`, `simulate`, and `mapSpec` across independent source, target, and result universes
- add coproduct handler routing with `Handler.case_`
- add handler composition with `Handler.comp` and its definitional distribution over routing
- generalize the primitive strong simulation/mapSpec equations and add pointwise identity and pure-renaming composition laws
- add universe compile canaries plus observable routing/composition producer tests
- update the ITree guide and correct its descriptions of the existing State/Exception event modules

## Why

This is I2 of the interaction-tree universe/generalization sequence from #33. It moves the executable handler/simulation layer off the homogeneous `PFunctor.{u, u}` restriction while adding the routing and composition APIs needed by later effect-handler work.

## Boundary

The existing `WeakBisim` relation and its bind/iteration theory are still homogeneous in this slice. Consequently, laws that consume that algebra—including `simulate_query_eq_bind`, `simulate_query`, `mapSpec_bind`, `mapSpec_iter`, `mapSpec_map`, and `mapSpec_cat`—remain homogeneous here. #45 generalizes the underlying bind/iteration and relational bisimulation layer; #46 then generalizes these simulation/mapSpec consumer laws and adds separated-universe canaries. General handler associativity and `simulate_comp` also remain in #46.

## Validation

- `./scripts/validate.sh --lint --test`
- `lake exe lint-style`
- `lake env lean PolyFunTest/ITree/HandlerSimulationExamples.lean`
- targeted build of `PolyFun.ITree.Sim.Facts`, State/Exception events, and `PolyFun.ITree.Rec`
- `git diff --check`

Part of #33.