### PR TITLE
add finite ITree trace semantics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,8 @@ and depend on this library.
 - `PolyFun/Control/`: monad and comonad infrastructure transitively
   required by the above (coalgebra, comonad, free / freecont monad
   algebra, monad iter / hom, lawful re-exports).
+- `PolyFun/Control/LTS/Trace.lean`: generic finite visible traces over the
+  silent/visible `Control.LTS` layer and preservation by weak simulation.
 - `PolyFun/Logic/`: small logic helpers (`HEq`).
 - `PolyFunTest/`: separate test / worked-example library (glob
   `PolyFunTest.+`), built by `lake test` and kept out of the `lake lint`
@@ -120,12 +122,12 @@ Control/Monad/Indexed, PFunctor/Free/Basic
   → IPFunctor/Basic → IPFunctor/Free/{Basic, Indexed}
   → IPFunctor/Notation, IPFunctor/Notation/{Indexed, Deterministic}
 
-Logic/HEq, Control/{Coalgebra, Comonad, Lawful, Monad, Bisimulation}
+Logic/HEq, Control/{Coalgebra, Comonad, Lawful, Monad, Bisimulation, LTS/Trace}
   (free-standing helpers, depended on by both PFunctor and ITree;
    Control/Bisimulation is the generic LTS bisimulation theory)
 
 PFunctor/Free → ITree/{Basic, Construct, Handler, Rec,
-                       Events, Sim, Bisim}
+                       Events, Sim, Bisim, Trace}
 PFunctor/Dynamical + ITree/Basic → ITree/Unfold
 
 PFunctor/Free + Control → Interaction/Basic/{Spec, Node, Decoration,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,8 +59,9 @@ and depend on this library.
   and their indexed free monads. `Free/Basic.lean` holds the single-index
   `FreeM` (state-polymorphic continuations); `Free/Indexed.lean` holds the
   two-index `FreeM₂` carrying a `LawfulIndexedMonad` instance.
-- `PolyFun/ITree/`: coinductive interaction trees, bisimulation,
-  simulation, handlers, event signatures.
+- `PolyFun/ITree/`: coinductive interaction trees, same-signature weak
+  bisimulation, cross-signature relational trees (`Bisim/CrossSignature.lean`),
+  simulation, handlers, event signatures, and finite observation traces.
 - `PolyFun/Interaction/`: protocol-flavored generic interaction framework.
   - `Basic/`: `Spec`, node contexts, decorations, syntax / shape /
     interaction, strategies, append / replicate / state-chain
@@ -248,7 +249,7 @@ listed declaration-by-declaration in `scripts/nolints.json`; regenerate that
 file with the Batteries `runLinter --update` driver when this surface changes,
 and review every new entry rather than treating the file as a blanket waiver.
 
-Lean toolchain and Mathlib stay in sync (both currently `v4.32.0`).
+Lean toolchain, Mathlib, and cslib stay in sync (all currently `v4.32.0`).
 Files should stay under 1500 lines.
 
 ## Further Reading

--- a/PolyFun.lean
+++ b/PolyFun.lean
@@ -27,6 +27,7 @@ import PolyFun.ITree.Bisim.Bind
 import PolyFun.ITree.Bisim.Defs
 import PolyFun.ITree.Bisim.Equiv
 import PolyFun.ITree.Bisim.Iter
+import PolyFun.ITree.Bisim.CrossSignature
 import PolyFun.ITree.Construct
 import PolyFun.ITree.Do
 import PolyFun.ITree.Events.Exception
@@ -38,6 +39,7 @@ import PolyFun.ITree.Rec
 import PolyFun.ITree.Rec.Facts
 import PolyFun.ITree.Sim.Defs
 import PolyFun.ITree.Sim.Facts
+import PolyFun.ITree.Sim.CrossSignature
 import PolyFun.ITree.Trace
 import PolyFun.ITree.Unfold
 import PolyFun.Interaction.Basic.Append

--- a/PolyFun.lean
+++ b/PolyFun.lean
@@ -2,6 +2,7 @@ import PolyFun.Control.Bisimulation
 import PolyFun.Control.Coalgebra
 import PolyFun.Control.Comonad.Basic
 import PolyFun.Control.Comonad.Instances
+import PolyFun.Control.LTS.Trace
 import PolyFun.Control.Lawful.Basic
 import PolyFun.Control.Monad.Algebra
 import PolyFun.Control.Monad.Equiv
@@ -37,6 +38,7 @@ import PolyFun.ITree.Rec
 import PolyFun.ITree.Rec.Facts
 import PolyFun.ITree.Sim.Defs
 import PolyFun.ITree.Sim.Facts
+import PolyFun.ITree.Trace
 import PolyFun.ITree.Unfold
 import PolyFun.Interaction.Basic.Append
 import PolyFun.Interaction.Basic.BundledMonad

--- a/PolyFun/Control/LTS/Trace.lean
+++ b/PolyFun/Control/LTS/Trace.lean
@@ -1,0 +1,117 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+module
+
+public import PolyFun.Control.Bisimulation
+
+/-! # Finite visible traces of labelled transition systems
+
+`Control.LTS.WeakTrace L s observations t` records a finite sequence of
+visible observations from `s` to `t`. Each visible transition is a weak
+transition, so arbitrary finite silent prefixes and suffixes are ignored.
+
+This is the trace semantics naturally preserved by `IsWeakSimulation` and
+`IsWeakBisimulation`. It deliberately lives over the existing `Control.LTS`
+layer rather than introducing a second transition-system representation.
+-/
+
+@[expose] public section
+
+universe uObs uState uMove uState₁ uMove₁ uState₂ uMove₂
+
+namespace Control.LTS
+
+variable {Obs : Type uObs} (L : Control.LTS.{uObs, uState, uMove} Obs)
+
+/-- A finite sequence of visible observations connected by weak transitions. -/
+inductive WeakTrace : L.State → List Obs → L.State → Prop where
+  /-- The empty trace leaves the state unchanged. -/
+  | nil (s : L.State) : WeakTrace s [] s
+  /-- Prepend one weak visible transition. -/
+  | cons {s middle t : L.State} {obs : Obs} {observations : List Obs}
+      (head : L.WeakStep s (some obs) middle)
+      (tail : WeakTrace middle observations t) :
+      WeakTrace s (obs :: observations) t
+
+namespace WeakTrace
+
+/-- Concatenate two finite weak traces. -/
+theorem append {s middle t : L.State} {xs ys : List Obs}
+    (first : L.WeakTrace s xs middle) (second : L.WeakTrace middle ys t) :
+    L.WeakTrace s (xs ++ ys) t := by
+  induction first with
+  | nil _ => exact second
+  | cons head _ ih => exact .cons head (ih second)
+
+end WeakTrace
+
+/-- The set of finite visible traces beginning at `s`. -/
+def traces (s : L.State) : Set (List Obs) :=
+  { observations | ∃ t, L.WeakTrace s observations t }
+
+@[simp] theorem nil_mem_traces (s : L.State) : [] ∈ L.traces s :=
+  ⟨s, .nil s⟩
+
+end Control.LTS
+
+namespace Control
+
+variable {Obs : Type uObs}
+
+namespace IsWeakSimulation
+
+/-- A weak simulation transports every finite visible trace while preserving
+the relation at its endpoint. -/
+theorem weakTrace
+    {L₁ : LTS.{uObs, uState₁, uMove₁} Obs}
+    {L₂ : LTS.{uObs, uState₂, uMove₂} Obs}
+    {rel : L₁.State → L₂.State → Prop}
+    (simulation : IsWeakSimulation L₁ L₂ rel)
+    {s₁ t₁ : L₁.State} {s₂ : L₂.State} {observations : List Obs}
+    (hrel : rel s₁ s₂) (trace : L₁.WeakTrace s₁ observations t₁) :
+    ∃ t₂, L₂.WeakTrace s₂ observations t₂ ∧ rel t₁ t₂ := by
+  induction trace generalizing s₂ with
+  | nil s => exact ⟨s₂, .nil s₂, hrel⟩
+  | cons head _ ih =>
+      obtain ⟨middle₂, head₂, hmiddle⟩ :=
+        simulation.weakStep hrel head
+      obtain ⟨t₂, tail₂, ht⟩ := ih hmiddle
+      exact ⟨t₂, .cons head₂ tail₂, ht⟩
+
+/-- Weak simulation implies inclusion of finite visible trace sets. -/
+theorem traces_subset
+    {L₁ : LTS.{uObs, uState₁, uMove₁} Obs}
+    {L₂ : LTS.{uObs, uState₂, uMove₂} Obs}
+    {rel : L₁.State → L₂.State → Prop}
+    (simulation : IsWeakSimulation L₁ L₂ rel)
+    {s₁ : L₁.State} {s₂ : L₂.State} (hrel : rel s₁ s₂) :
+    L₁.traces s₁ ⊆ L₂.traces s₂ := by
+  rintro observations ⟨t₁, trace⟩
+  obtain ⟨t₂, trace₂, _⟩ := simulation.weakTrace hrel trace
+  exact ⟨t₂, trace₂⟩
+
+end IsWeakSimulation
+
+namespace IsWeakBisimulation
+
+/-- Weakly bisimilar states have exactly the same finite visible traces. -/
+theorem traces_eq
+    {L₁ : LTS.{uObs, uState₁, uMove₁} Obs}
+    {L₂ : LTS.{uObs, uState₂, uMove₂} Obs}
+    {rel : L₁.State → L₂.State → Prop}
+    (bisimulation : IsWeakBisimulation L₁ L₂ rel)
+    {s₁ : L₁.State} {s₂ : L₂.State} (hrel : rel s₁ s₂) :
+    L₁.traces s₁ = L₂.traces s₂ := by
+  ext observations
+  constructor
+  · intro htrace
+    exact IsWeakSimulation.traces_subset bisimulation.forward hrel htrace
+  · intro htrace
+    exact IsWeakSimulation.traces_subset bisimulation.backward hrel htrace
+
+end IsWeakBisimulation
+
+end Control

--- a/PolyFun/ITree/Bisim/CrossSignature.lean
+++ b/PolyFun/ITree/Bisim/CrossSignature.lean
@@ -1,0 +1,581 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+module
+
+public import PolyFun.ITree.Bisim.Bind
+
+/-! # Weak bisimulation across event signatures
+
+`ITree.CrossSignatureWeakBisim` is the cross-signature counterpart of
+`WeakBisimRel`. It relates interaction trees whose event signatures, replies,
+and return values may all differ. An `EventSignatureRel E F` supplies a
+relation on event names and, for each related pair of names, a dependent
+relation on their replies.
+
+The Coq Interaction Trees library calls the corresponding construction `rutt`,
+short for “relation up to tau”. PolyFun uses the descriptive semantic name in
+its public API and retains `rutt` only as source provenance.
+
+As with `WeakBisimRel`, finite silent-step stripping is separated from the
+greatest fixed point.  This rules out an unsound proof that a terminating tree
+is related to silent divergence by infinitely many one-sided τ rules.
+
+The initial API is deliberately consumer-shaped rather than a port of the
+Paco up-to tower from the Coq Interaction Trees library.  It contains:
+
+* coinduction, unfolding, folding, constructors, and symmetry;
+* equivalence with `WeakBisimRel` for the identity event-signature relation;
+* two-sided `bind` and `map` congruence across signatures.
+-/
+
+@[expose] public section
+
+universe uEA uEB uFA uFB uα uβ uγ uδ
+
+namespace ITree
+
+/-! ### Relations between event signatures -/
+
+/-- A dependent relation between two event signatures.
+
+`event a b` says that the event names correspond. Once event names are
+related by `hab`, `reply a b hab x y` says that two possible replies
+correspond. No totality or functionality is imposed: this accommodates refinements and
+nondeterministic protocol relations as well as pure renamings. -/
+structure EventSignatureRel (E : PFunctor.{uEA, uEB}) (F : PFunctor.{uFA, uFB}) where
+  /-- Relation on event names. -/
+  event : E.A → F.A → Prop
+  /-- Dependent relation on replies to related event names. -/
+  reply : (a : E.A) → (b : F.A) → event a b → E.B a → F.B b → Prop
+
+namespace EventSignatureRel
+
+/-- Reverse a relation between event signatures. -/
+def flip {E : PFunctor.{uEA, uEB}} {F : PFunctor.{uFA, uFB}}
+    (r : EventSignatureRel E F) : EventSignatureRel F E where
+  event b a := r.event a b
+  reply b a hba y x := r.reply a b hba x y
+
+/-- The identity relation on an event signature.
+
+Replies use heterogeneous equality so the relation remains well typed before
+the equality of event names is eliminated. -/
+def eq (E : PFunctor.{uEA, uEB}) : EventSignatureRel E E where
+  event := Eq
+  reply _ _ _ x y := HEq x y
+
+/-- A variance-correct map between event-signature relations. Events map
+covariantly, while reply obligations map contravariantly because
+`CrossSignatureWeakBisim` quantifies over every related reply pair. -/
+structure Hom {E : PFunctor.{uEA, uEB}} {F : PFunctor.{uFA, uFB}}
+    (source target : EventSignatureRel E F) : Prop where
+  /-- Every source-related event pair is target-related. -/
+  event {a : E.A} {b : F.A} : source.event a b → target.event a b
+  /-- Every target reply obligation is available to the source relation. -/
+  reply {a : E.A} {b : F.A} (hab : source.event a b)
+      {x : E.B a} {y : F.B b} :
+    target.reply a b (event hab) x y → source.reply a b hab x y
+
+namespace Hom
+
+/-- Identity map of an event-signature relation. -/
+protected theorem refl {E : PFunctor.{uEA, uEB}} {F : PFunctor.{uFA, uFB}}
+    (eventRel : EventSignatureRel E F) : Hom eventRel eventRel where
+  event := id
+  reply _ := id
+
+end Hom
+
+end EventSignatureRel
+
+variable {E : PFunctor.{uEA, uEB}} {F : PFunctor.{uFA, uFB}}
+  {α : Type uα} {β : Type uβ}
+
+/-! ### Relational head matching -/
+
+/-- One observable-head match between trees over potentially different event
+signatures. -/
+inductive CrossSignatureWeakBisim.HeadMatch
+    (eventRel : EventSignatureRel E F) (resultRel : α → β → Prop)
+    (treeRel : ITree E α → ITree F β → Prop) :
+    ITree E α → ITree F β → Prop where
+  /-- Pure heads carry related return values. -/
+  | pure {t : ITree E α} {s : ITree F β} (x : α) (y : β) (hxy : resultRel x y)
+      (ht : shape' t = ⟨.pure x, PEmpty.elim⟩)
+      (hs : shape' s = ⟨.pure y, PEmpty.elim⟩) :
+      CrossSignatureWeakBisim.HeadMatch eventRel resultRel treeRel t s
+  /-- Query heads carry related events, and continuations are related for
+  every pair of related replies. -/
+  | query {t : ITree E α} {s : ITree F β}
+      (a : E.A) (b : F.A) (hab : eventRel.event a b)
+      (ct : E.B a → ITree E α) (cs : F.B b → ITree F β)
+      (ht : shape' t = ⟨.query a, ct⟩)
+      (hs : shape' s = ⟨.query b, cs⟩)
+      (h : ∀ x y, eventRel.reply a b hab x y → treeRel (ct x) (cs y)) :
+      CrossSignatureWeakBisim.HeadMatch eventRel resultRel treeRel t s
+  /-- Silent heads continue through the relation. -/
+  | tau {t : ITree E α} {s : ITree F β}
+      (ct : PUnit.{uEB + 1} → ITree E α)
+      (cs : PUnit.{uFB + 1} → ITree F β)
+      (ht : shape' t = ⟨.step, ct⟩) (hs : shape' s = ⟨.step, cs⟩)
+      (h : treeRel (ct PUnit.unit) (cs PUnit.unit)) :
+      CrossSignatureWeakBisim.HeadMatch eventRel resultRel treeRel t s
+
+namespace CrossSignatureWeakBisim.HeadMatch
+
+/-- Monotonicity in the continuation relation. -/
+theorem mono {eventRel : EventSignatureRel E F} {resultRel : α → β → Prop}
+    {treeRel nextTreeRel : ITree E α → ITree F β → Prop}
+    (hmono : ∀ t s, treeRel t s → nextTreeRel t s) {t : ITree E α} {s : ITree F β}
+    (h : CrossSignatureWeakBisim.HeadMatch eventRel resultRel treeRel t s) :
+    CrossSignatureWeakBisim.HeadMatch eventRel resultRel nextTreeRel t s := by
+  cases h with
+  | pure x y hxy ht hs => exact .pure x y hxy ht hs
+  | query a b hab ct cs ht hs hcont =>
+      exact .query a b hab ct cs ht hs (fun x y hxy => hmono _ _ (hcont x y hxy))
+  | tau ct cs ht hs hcont => exact .tau ct cs ht hs (hmono _ _ hcont)
+
+/-- Monotonicity in the return-value relation. -/
+theorem mono_result {eventRel : EventSignatureRel E F} {resultRel outputRel : α → β → Prop}
+    (hmono : ∀ x y, resultRel x y → outputRel x y)
+    {treeRel : ITree E α → ITree F β → Prop}
+    {t : ITree E α} {s : ITree F β}
+    (h : CrossSignatureWeakBisim.HeadMatch eventRel resultRel treeRel t s) :
+    CrossSignatureWeakBisim.HeadMatch eventRel outputRel treeRel t s := by
+  cases h with
+  | pure x y hxy ht hs => exact .pure x y (hmono x y hxy) ht hs
+  | query a b hab ct cs ht hs hcont => exact .query a b hab ct cs ht hs hcont
+  | tau ct cs ht hs hcont => exact .tau ct cs ht hs hcont
+
+/-- Change the event relation along a variance-correct signature-relation map. -/
+theorem mono_eventRel {source target : EventSignatureRel E F}
+    (map : EventSignatureRel.Hom source target)
+    {resultRel : α → β → Prop} {treeRel : ITree E α → ITree F β → Prop}
+    {t : ITree E α} {s : ITree F β}
+    (h : CrossSignatureWeakBisim.HeadMatch source resultRel treeRel t s) :
+    CrossSignatureWeakBisim.HeadMatch target resultRel treeRel t s := by
+  cases h with
+  | pure x y hxy ht hs => exact .pure x y hxy ht hs
+  | query a b hab ct cs ht hs hcont =>
+      refine .query a b (map.event hab) ct cs ht hs ?_
+      intro x y hxy
+      exact hcont x y (map.reply hab hxy)
+  | tau ct cs ht hs hcont => exact .tau ct cs ht hs hcont
+
+/-- Swap both trees and all component relations. -/
+theorem swap {eventRel : EventSignatureRel E F} {resultRel : α → β → Prop}
+    {treeRel : ITree E α → ITree F β → Prop}
+    {t : ITree E α} {s : ITree F β}
+    (h : CrossSignatureWeakBisim.HeadMatch eventRel resultRel treeRel t s) :
+    CrossSignatureWeakBisim.HeadMatch eventRel.flip
+      (fun y x => resultRel x y) (fun s t => treeRel t s) s t := by
+  cases h with
+  | pure x y hxy ht hs => exact .pure y x hxy hs ht
+  | query a b hab ct cs ht hs hcont =>
+      exact .query b a hab cs ct hs ht (fun y x hyx => hcont x y hyx)
+  | tau ct cs ht hs hcont => exact .tau cs ct hs ht hcont
+
+end CrossSignatureWeakBisim.HeadMatch
+
+/-! ### Greatest fixed point -/
+
+/-- One-step functor for cross-signature relational trees. -/
+def CrossSignatureWeakBisim.Layer
+    (eventRel : EventSignatureRel E F) (resultRel : α → β → Prop)
+    (treeRel : ITree E α → ITree F β → Prop)
+    (t : ITree E α) (s : ITree F β) : Prop :=
+  ∃ t' : ITree E α, ∃ s' : ITree F β,
+    TauSteps t t' ∧ TauSteps s s' ∧
+      CrossSignatureWeakBisim.HeadMatch eventRel resultRel treeRel t' s'
+
+namespace CrossSignatureWeakBisim.Layer
+
+/-- Monotonicity in the continuation relation. -/
+theorem mono {eventRel : EventSignatureRel E F} {resultRel : α → β → Prop}
+    {treeRel nextTreeRel : ITree E α → ITree F β → Prop}
+    (hmono : ∀ t s, treeRel t s → nextTreeRel t s) {t : ITree E α} {s : ITree F β}
+    (h : CrossSignatureWeakBisim.Layer eventRel resultRel treeRel t s) :
+    CrossSignatureWeakBisim.Layer eventRel resultRel nextTreeRel t s := by
+  obtain ⟨t', s', ht, hs, hm⟩ := h
+  exact ⟨t', s', ht, hs, hm.mono hmono⟩
+
+/-- Monotonicity in the return-value relation. -/
+theorem mono_result {eventRel : EventSignatureRel E F} {resultRel outputRel : α → β → Prop}
+    (hmono : ∀ x y, resultRel x y → outputRel x y)
+    {treeRel : ITree E α → ITree F β → Prop}
+    {t : ITree E α} {s : ITree F β}
+    (h : CrossSignatureWeakBisim.Layer eventRel resultRel treeRel t s) :
+    CrossSignatureWeakBisim.Layer eventRel outputRel treeRel t s := by
+  obtain ⟨t', s', ht, hs, hm⟩ := h
+  exact ⟨t', s', ht, hs, hm.mono_result hmono⟩
+
+end CrossSignatureWeakBisim.Layer
+
+/-- Weak bisimulation between interaction trees over potentially different
+event signatures. This is the Tarski greatest fixed point of
+`CrossSignatureWeakBisim.Layer`. -/
+def CrossSignatureWeakBisim (eventRel : EventSignatureRel E F) (resultRel : α → β → Prop)
+    (t : ITree E α) (s : ITree F β) : Prop :=
+  ∃ treeRel : ITree E α → ITree F β → Prop,
+    (∀ t s, treeRel t s →
+      CrossSignatureWeakBisim.Layer eventRel resultRel treeRel t s) ∧
+    treeRel t s
+
+namespace CrossSignatureWeakBisim
+
+variable {eventRel : EventSignatureRel E F} {resultRel : α → β → Prop}
+  {γ : Type uγ} {δ : Type uδ}
+
+/-- Coinduction principle for `CrossSignatureWeakBisim`. -/
+theorem coinduct (eventRel : EventSignatureRel E F) (resultRel : α → β → Prop)
+    (treeRel : ITree E α → ITree F β → Prop)
+    (h : ∀ t s, treeRel t s →
+      CrossSignatureWeakBisim.Layer eventRel resultRel treeRel t s)
+    {t : ITree E α} {s : ITree F β} (hts : treeRel t s) :
+    CrossSignatureWeakBisim eventRel resultRel t s :=
+  ⟨treeRel, h, hts⟩
+
+/-- Unfold a relational tree once. -/
+theorem unfold {eventRel : EventSignatureRel E F} {resultRel : α → β → Prop}
+    {t : ITree E α} {s : ITree F β}
+    (h : CrossSignatureWeakBisim eventRel resultRel t s) :
+    CrossSignatureWeakBisim.Layer eventRel resultRel
+      (CrossSignatureWeakBisim eventRel resultRel) t s := by
+  obtain ⟨treeRel, hcl, hts⟩ := h
+  obtain ⟨t', s', ht, hs, hm⟩ := hcl t s hts
+  exact ⟨t', s', ht, hs, hm.mono (fun x y hxy => ⟨treeRel, hcl, hxy⟩)⟩
+
+/-- Extract the stripped observable heads. -/
+theorem dest {eventRel : EventSignatureRel E F} {resultRel : α → β → Prop}
+    {t : ITree E α} {s : ITree F β} (h : CrossSignatureWeakBisim eventRel resultRel t s) :
+    ∃ t' : ITree E α, ∃ s' : ITree F β,
+      TauSteps t t' ∧ TauSteps s s' ∧
+        CrossSignatureWeakBisim.HeadMatch eventRel resultRel
+          (CrossSignatureWeakBisim eventRel resultRel) t' s' :=
+  unfold h
+
+/-- Fold one `CrossSignatureWeakBisim.Layer` layer. -/
+theorem fold {eventRel : EventSignatureRel E F} {resultRel : α → β → Prop}
+    {t : ITree E α} {s : ITree F β}
+    (h : CrossSignatureWeakBisim.Layer eventRel resultRel
+      (CrossSignatureWeakBisim eventRel resultRel) t s) :
+    CrossSignatureWeakBisim eventRel resultRel t s := by
+  obtain ⟨t', s', ht, hs, hm⟩ := h
+  refine coinduct eventRel resultRel
+    (fun x y => CrossSignatureWeakBisim eventRel resultRel x y ∨ (x = t ∧ y = s)) ?_
+    (Or.inr ⟨rfl, rfl⟩)
+  rintro x y (hxy | ⟨rfl, rfl⟩)
+  · exact (unfold hxy).mono (fun a b hab => Or.inl hab)
+  · exact ⟨t', s', ht, hs, hm.mono (fun a b hab => Or.inl hab)⟩
+
+/-- Pure trees are related when their return values are. -/
+theorem pure {eventRel : EventSignatureRel E F} {resultRel : α → β → Prop}
+    {x : α} {y : β} (hxy : resultRel x y) :
+    CrossSignatureWeakBisim eventRel resultRel (ITree.pure x) (ITree.pure y) := by
+  apply fold
+  exact ⟨_, _, .refl _, .refl _,
+    CrossSignatureWeakBisim.HeadMatch.pure x y hxy (shape'_pure x) (shape'_pure y)⟩
+
+/-- Related visible events produce related queries when all related replies
+lead to related continuations. -/
+theorem query {eventRel : EventSignatureRel E F} {resultRel : α → β → Prop}
+    (a : E.A) (b : F.A) (hab : eventRel.event a b)
+    (ct : E.B a → ITree E α) (cs : F.B b → ITree F β)
+    (h : ∀ x y, eventRel.reply a b hab x y →
+      CrossSignatureWeakBisim eventRel resultRel (ct x) (cs y)) :
+    CrossSignatureWeakBisim eventRel resultRel (ITree.query a ct) (ITree.query b cs) := by
+  apply fold
+  exact ⟨_, _, .refl _, .refl _,
+    CrossSignatureWeakBisim.HeadMatch.query a b hab ct cs
+      (shape'_query a ct) (shape'_query b cs) h⟩
+
+/-- Add a silent step on the left. -/
+theorem step_left {eventRel : EventSignatureRel E F} {resultRel : α → β → Prop}
+    {t : ITree E α} {s : ITree F β} (h : CrossSignatureWeakBisim eventRel resultRel t s) :
+    CrossSignatureWeakBisim eventRel resultRel (ITree.step t) s := by
+  obtain ⟨t', s', ht, hs, hm⟩ := h.dest
+  apply fold
+  exact ⟨t', s', (TauSteps.one _ (shape'_step t)).trans ht, hs, hm⟩
+
+/-- Add a silent step on the right. -/
+theorem step_right {eventRel : EventSignatureRel E F} {resultRel : α → β → Prop}
+    {t : ITree E α} {s : ITree F β} (h : CrossSignatureWeakBisim eventRel resultRel t s) :
+    CrossSignatureWeakBisim eventRel resultRel t (ITree.step s) := by
+  obtain ⟨t', s', ht, hs, hm⟩ := h.dest
+  apply fold
+  exact ⟨t', s', ht, (TauSteps.one _ (shape'_step s)).trans hs, hm⟩
+
+/-- Add silent steps to both sides. -/
+theorem step {eventRel : EventSignatureRel E F} {resultRel : α → β → Prop}
+    {t : ITree E α} {s : ITree F β} (h : CrossSignatureWeakBisim eventRel resultRel t s) :
+    CrossSignatureWeakBisim eventRel resultRel (ITree.step t) (ITree.step s) :=
+  (step_left h).step_right
+
+/-- Strip one silent step from the right endpoint of a relational tree. -/
+theorem step_absorb_right {eventRel : EventSignatureRel E F} {resultRel : α → β → Prop}
+    {t : ITree E α} {s : ITree F β}
+    (c : PUnit.{uFB + 1} → ITree F β) (h : CrossSignatureWeakBisim eventRel resultRel t s)
+    (hstep : shape' s = ⟨.step, c⟩) :
+    CrossSignatureWeakBisim eventRel resultRel t (c PUnit.unit) := by
+  refine coinduct eventRel resultRel
+    (fun x z => CrossSignatureWeakBisim eventRel resultRel x z ∨
+      ∃ (s' : ITree F β) (c' : PUnit.{uFB + 1} → ITree F β),
+        CrossSignatureWeakBisim eventRel resultRel x s' ∧
+          shape' s' = ⟨.step, c'⟩ ∧ z = c' PUnit.unit)
+    ?_ (Or.inr ⟨s, c, h, hstep, rfl⟩)
+  intro a b hab
+  rcases hab with hab | ⟨s', c', hab, hstep', rfl⟩
+  · obtain ⟨a', b', ha, hb, M⟩ := hab.dest
+    exact ⟨a', b', ha, hb, M.mono (fun _ _ hxy => Or.inl hxy)⟩
+  · obtain ⟨a', s₁, ha, hs, M⟩ := hab.dest
+    rcases TauSteps.step_cases c' hstep' hs with hs_eq | hs_strict
+    · subst hs_eq
+      cases M with
+      | pure _ _ _ _ hs_bad => exfalso; rw [hstep'] at hs_bad; cases hs_bad
+      | query _ _ _ _ _ _ hs_bad _ =>
+          exfalso; rw [hstep'] at hs_bad; cases hs_bad
+      | tau ct cs ht_a hs_a hr =>
+          have hcc : cs = c' := TauSteps.cont_eq hs_a hstep'
+          subst hcc
+          rcases hsh : shape' (cs PUnit.unit) with ⟨sh, cc⟩
+          cases sh with
+          | pure r =>
+              have hsh' : shape' (cs PUnit.unit) =
+                  ⟨Shape.pure r, PEmpty.elim⟩ := by
+                rw [hsh]
+                congr 1
+                funext z
+                exact z.elim
+              obtain ⟨X, Y, hX, hY, MXY⟩ := hr.dest
+              have hYeq : Y = cs PUnit.unit :=
+                TauSteps.rigid_of_pure r hsh' hY
+              subst hYeq
+              cases MXY with
+              | pure x y hxy hX' hY' =>
+                  have heq : (⟨Shape.pure y, PEmpty.elim⟩ :
+                      (Poly F β).Obj (ITree F β)) =
+                      ⟨Shape.pure r, PEmpty.elim⟩ := hY'.symm.trans hsh'
+                  have hyr : y = r := Shape.pure.inj (Sigma.mk.inj heq).1
+                  subst y
+                  refine ⟨X, cs PUnit.unit,
+                    ha.trans ((TauSteps.one ct ht_a).trans hX), .refl _, ?_⟩
+                  exact CrossSignatureWeakBisim.HeadMatch.pure x r hxy hX' hsh'
+              | query _ _ _ _ _ _ hY' _ =>
+                  exfalso; rw [hY'] at hsh'; cases hsh'
+              | tau _ _ _ hY' _ =>
+                  exfalso; rw [hY'] at hsh'; cases hsh'
+          | step =>
+              refine ⟨a', cs PUnit.unit, ha, .refl _, ?_⟩
+              refine CrossSignatureWeakBisim.HeadMatch.tau ct cc ht_a hsh ?_
+              exact Or.inr ⟨cs PUnit.unit, cc, hr, hsh, rfl⟩
+          | query eventF =>
+              obtain ⟨X, Y, hX, hY, MXY⟩ := hr.dest
+              have hYeq : Y = cs PUnit.unit :=
+                TauSteps.rigid_of_query eventF cc hsh hY
+              subst hYeq
+              cases MXY with
+              | pure _ _ _ _ hY' => exfalso; rw [hY'] at hsh; cases hsh
+              | query eventE eventF' hevents cX cY hX' hY' hcont =>
+                  have heq : (⟨Shape.query eventF', cY⟩ :
+                      (Poly F β).Obj (ITree F β)) =
+                      ⟨Shape.query eventF, cc⟩ := hY'.symm.trans hsh
+                  have hevent : eventF' = eventF :=
+                    Shape.query.inj (Sigma.mk.inj heq).1
+                  subst eventF'
+                  have hc : cY = cc := eq_of_heq (Sigma.mk.inj heq).2
+                  subst cY
+                  refine ⟨X, cs PUnit.unit,
+                    ha.trans ((TauSteps.one ct ht_a).trans hX), .refl _, ?_⟩
+                  exact CrossSignatureWeakBisim.HeadMatch.query
+                    eventE eventF hevents cX cc hX' hsh
+                    (fun x y hxy => Or.inl (hcont x y hxy))
+              | tau _ _ _ hY' _ => exfalso; rw [hY'] at hsh; cases hsh
+    · exact ⟨a', s₁, ha, hs_strict,
+        M.mono (fun _ _ hxy => Or.inl hxy)⟩
+
+/-- Strip finitely many silent steps from the right endpoint. -/
+theorem absorb_tauSteps_right
+    {eventRel : EventSignatureRel E F} {resultRel : α → β → Prop}
+    {t : ITree E α} {s s' : ITree F β}
+    (h : CrossSignatureWeakBisim eventRel resultRel t s)
+    (hstrip : TauSteps s s') :
+    CrossSignatureWeakBisim eventRel resultRel t s' := by
+  induction hstrip generalizing t with
+  | refl _ => exact h
+  | @step _ _ c ht hr ih => exact ih (step_absorb_right c h ht)
+
+/-- Symmetry, with the event, reply, and return relations reversed. -/
+theorem symm {eventRel : EventSignatureRel E F} {resultRel : α → β → Prop}
+    {t : ITree E α} {s : ITree F β} (h : CrossSignatureWeakBisim eventRel resultRel t s) :
+    CrossSignatureWeakBisim eventRel.flip (fun y x => resultRel x y) s t := by
+  obtain ⟨treeRel, hcl, hts⟩ := h
+  refine coinduct eventRel.flip (fun y x => resultRel x y) (fun s t => treeRel t s) ?_ hts
+  intro s t hst
+  obtain ⟨t', s', ht, hs, hm⟩ := hcl t s hst
+  exact ⟨s', t', hs, ht, hm.swap⟩
+
+/-- Strip finitely many silent steps from the left endpoint. -/
+theorem tauSteps_left
+    {eventRel : EventSignatureRel E F} {resultRel : α → β → Prop}
+    {t t' : ITree E α} {s : ITree F β}
+    (h : CrossSignatureWeakBisim eventRel resultRel t s)
+    (hstrip : TauSteps t t') :
+    CrossSignatureWeakBisim eventRel resultRel t' s := by
+  have hs := absorb_tauSteps_right (eventRel := eventRel.flip)
+    (resultRel := fun y x => resultRel x y) h.symm hstrip
+  exact hs.symm
+
+/-- Monotonicity in the relation on return values. -/
+theorem mono_result {eventRel : EventSignatureRel E F} {resultRel outputRel : α → β → Prop}
+    (hmono : ∀ x y, resultRel x y → outputRel x y)
+    {t : ITree E α} {s : ITree F β} (h : CrossSignatureWeakBisim eventRel resultRel t s) :
+    CrossSignatureWeakBisim eventRel outputRel t s := by
+  obtain ⟨treeRel, hcl, hts⟩ := h
+  exact ⟨treeRel, fun x y hxy => (hcl x y hxy).mono_result hmono, hts⟩
+
+/-- Change the event relation along a variance-correct signature-relation map. -/
+theorem mono_eventRel {source target : EventSignatureRel E F}
+    (map : EventSignatureRel.Hom source target) {resultRel : α → β → Prop}
+    {t : ITree E α} {s : ITree F β} (h : CrossSignatureWeakBisim source resultRel t s) :
+    CrossSignatureWeakBisim target resultRel t s := by
+  obtain ⟨treeRel, hcl, hts⟩ := h
+  exact ⟨treeRel, fun x y hxy => by
+    obtain ⟨x', y', hx, hy, hm⟩ := hcl x y hxy
+    exact ⟨x', y', hx, hy, hm.mono_eventRel map⟩, hts⟩
+
+/-- Related events yield relationally related single-event trees. -/
+theorem lift (a : E.A) (b : F.A) (hab : eventRel.event a b) :
+    CrossSignatureWeakBisim eventRel (eventRel.reply a b hab) (ITree.lift a) (ITree.lift b) := by
+  unfold ITree.lift
+  apply query a b hab ITree.pure ITree.pure
+  intro x y hxy
+  exact pure hxy
+
+/-! ### Compatibility with same-signature weak bisimulation -/
+
+/-- Identity-signature head matches convert to ordinary relational head
+matches. -/
+theorem identity_headMatch_to_matchRel
+    {treeRel : ITree E α → ITree E β → Prop} {t : ITree E α} {s : ITree E β}
+    (h : CrossSignatureWeakBisim.HeadMatch
+      (EventSignatureRel.eq E) resultRel treeRel t s) :
+    MatchRel resultRel treeRel t s := by
+  cases h with
+  | pure x y hxy ht hs => exact .pure x y hxy ht hs
+  | query a b hab ct cs ht hs hcont =>
+      change a = b at hab
+      subst b
+      exact .query a ct cs ht hs (fun x => hcont x x HEq.rfl)
+  | tau ct cs ht hs hcont => exact .tau ct cs ht hs hcont
+
+/-- Ordinary relational head matches embed into identity-signature matches. -/
+theorem matchRel_to_identity_headMatch
+    {treeRel : ITree E α → ITree E β → Prop} {t : ITree E α} {s : ITree E β}
+    (h : MatchRel resultRel treeRel t s) :
+    CrossSignatureWeakBisim.HeadMatch
+      (EventSignatureRel.eq E) resultRel treeRel t s := by
+  cases h with
+  | pure x y hxy ht hs => exact .pure x y hxy ht hs
+  | query a ct cs ht hs hcont =>
+      refine .query a a rfl ct cs ht hs ?_
+      intro x y hxy
+      change HEq x y at hxy
+      have : x = y := eq_of_heq hxy
+      subst y
+      exact hcont x
+  | tau ct cs ht hs hcont => exact .tau ct cs ht hs hcont
+
+/-- `CrossSignatureWeakBisim` specializes exactly to `WeakBisimRel` for the
+identity event-signature relation. -/
+theorem eq_iff_weakBisimRel {t : ITree E α} {s : ITree E β} :
+    CrossSignatureWeakBisim (EventSignatureRel.eq E) resultRel t s ↔
+      WeakBisimRel resultRel t s := by
+  constructor
+  · intro h
+    obtain ⟨treeRel, hcl, hts⟩ := h
+    refine WeakBisimRel.coinduct resultRel treeRel ?_ hts
+    intro x y hxy
+    obtain ⟨x', y', hx, hy, hm⟩ := hcl x y hxy
+    exact ⟨x', y', hx, hy, identity_headMatch_to_matchRel hm⟩
+  · intro h
+    obtain ⟨treeRel, hcl, hts⟩ := h
+    refine coinduct (EventSignatureRel.eq E) resultRel treeRel ?_ hts
+    intro x y hxy
+    obtain ⟨x', y', hx, hy, hm⟩ := hcl x y hxy
+    exact ⟨x', y', hx, hy, matchRel_to_identity_headMatch hm⟩
+
+/-- Reflexivity for the identity relations on events, replies, and return
+values. -/
+@[refl] theorem refl (t : ITree E α) :
+    CrossSignatureWeakBisim (EventSignatureRel.eq E) Eq t t :=
+  eq_iff_weakBisimRel.mpr (WeakBisim.refl t)
+
+/-! ### Monad congruence -/
+
+/-- Two-sided relational congruence for `bind` across event signatures. -/
+theorem bind {resultRel : α → β → Prop} {outputRel : γ → δ → Prop}
+    {u : ITree E α} {v : ITree F β}
+    {f : α → ITree E γ} {g : β → ITree F δ}
+    (trees_related : CrossSignatureWeakBisim eventRel resultRel u v)
+    (continuations_related : ∀ x y, resultRel x y →
+      CrossSignatureWeakBisim eventRel outputRel (f x) (g y)) :
+    CrossSignatureWeakBisim eventRel outputRel (ITree.bind u f) (ITree.bind v g) := by
+  refine coinduct eventRel outputRel
+    (fun x y =>
+      (∃ u v, CrossSignatureWeakBisim eventRel resultRel u v ∧
+        x = ITree.bind u f ∧ y = ITree.bind v g) ∨
+      CrossSignatureWeakBisim eventRel outputRel x y) ?_
+    (Or.inl ⟨u, v, trees_related, rfl, rfl⟩)
+  rintro x y (⟨u, v, trees_related, rfl, rfl⟩ | hxy)
+  · obtain ⟨u', v', hu, hv, hm⟩ := trees_related.dest
+    cases hm with
+    | pure x y hxy hu' hv' =>
+        have hut : u' = ITree.pure x := by
+          apply PFunctor.M.eq_of_dest_eq
+          change shape' u' = shape' (ITree.pure x)
+          exact hu'.trans (shape'_pure x).symm
+        have hvt : v' = ITree.pure y := by
+          apply PFunctor.M.eq_of_dest_eq
+          change shape' v' = shape' (ITree.pure y)
+          exact hv'.trans (shape'_pure y).symm
+        subst hut
+        subst hvt
+        obtain ⟨x', y', hx, hy, hm⟩ := (continuations_related x y hxy).dest
+        refine ⟨x', y', ?_, ?_, hm.mono (fun _ _ h => Or.inr h)⟩
+        · have huf : TauSteps (ITree.bind u f) (f x) := by
+            simpa only [bind_pure_left] using hu.bind f
+          exact huf.trans hx
+        · have hvg : TauSteps (ITree.bind v g) (g y) := by
+            simpa only [bind_pure_left] using hv.bind g
+          exact hvg.trans hy
+    | query a b hab cu cv hu' hv' hcont =>
+        refine ⟨ITree.bind u' f, ITree.bind v' g, hu.bind f, hv.bind g, ?_⟩
+        refine CrossSignatureWeakBisim.HeadMatch.query a b hab (fun x => ITree.bind (cu x) f)
+          (fun y => ITree.bind (cv y) g)
+          (dest_bind_query f u' a cu hu') (dest_bind_query g v' b cv hv') ?_
+        intro x y hxy
+        exact Or.inl ⟨cu x, cv y, hcont x y hxy, rfl, rfl⟩
+    | tau cu cv hu' hv' hcont =>
+        refine ⟨ITree.bind u' f, ITree.bind v' g, hu.bind f, hv.bind g, ?_⟩
+        refine CrossSignatureWeakBisim.HeadMatch.tau (fun _ => ITree.bind (cu PUnit.unit) f)
+          (fun _ => ITree.bind (cv PUnit.unit) g)
+          (dest_bind_step f u' cu hu') (dest_bind_step g v' cv hv') ?_
+        exact Or.inl ⟨cu PUnit.unit, cv PUnit.unit, hcont, rfl, rfl⟩
+  · obtain ⟨x', y', hx, hy, hm⟩ := hxy.dest
+    exact ⟨x', y', hx, hy, hm.mono (fun _ _ h => Or.inr h)⟩
+
+/-- Relational congruence for `ITree.map` across event signatures. -/
+theorem map {outputRel : γ → δ → Prop} (f : α → γ) (g : β → δ)
+    {u : ITree E α} {v : ITree F β}
+    (trees_related : CrossSignatureWeakBisim eventRel resultRel u v)
+    (continuations_related : ∀ x y, resultRel x y → outputRel (f x) (g y)) :
+    CrossSignatureWeakBisim eventRel outputRel (ITree.map f u) (ITree.map g v) := by
+  unfold ITree.map
+  exact trees_related.bind (fun x y hxy => pure (continuations_related x y hxy))
+
+end CrossSignatureWeakBisim
+
+end ITree

--- a/PolyFun/ITree/Sim/CrossSignature.lean
+++ b/PolyFun/ITree/Sim/CrossSignature.lean
@@ -1,0 +1,96 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+module
+
+public import PolyFun.ITree.Bisim.CrossSignature
+public import PolyFun.ITree.Sim.Facts
+
+/-! # Event-renaming facts for relational interaction trees
+
+This module connects the core `ITree.CrossSignatureWeakBisim` relation to pure
+event renaming. It is kept outside `Bisim.CrossSignature` so the core
+relational theory does not acquire a public dependency on the complete
+simulation law surface.
+-/
+
+@[expose] public section
+
+universe uEA uEB uFA uFB uα
+
+namespace ITree
+
+namespace EventSignatureRel
+
+/-- The graph relation induced by a polynomial-functor lens.
+
+A target reply is related precisely to the source reply obtained by pulling
+it back along the lens. -/
+def ofLens {E : PFunctor.{uEA, uEB}} {F : PFunctor.{uFA, uFB}}
+    (φ : PFunctor.Lens E F) : EventSignatureRel E F where
+  event a b := b = φ.toFunA a
+  reply a b hab x y := by
+    subst b
+    exact x = φ.toFunB a y
+
+end EventSignatureRel
+
+namespace CrossSignatureWeakBisim
+
+variable {E : PFunctor.{uEA, uEB}} {F : PFunctor.{uFA, uFB}}
+  {α : Type uα}
+
+/-- Every tree is related to its pure event-renaming by the lens's graph
+relation. -/
+theorem mapSpec (φ : PFunctor.Lens E F) (t : ITree E α) :
+    CrossSignatureWeakBisim (EventSignatureRel.ofLens φ) Eq t (ITree.mapSpec φ t) := by
+  refine coinduct (EventSignatureRel.ofLens φ) Eq
+    (fun x y => ∃ t : ITree E α, x = t ∧ y = ITree.mapSpec φ t) ?_
+    ⟨t, rfl, rfl⟩
+  rintro x y ⟨t, hxt, hyt⟩
+  subst x
+  subst y
+  rcases ht : shape' t with ⟨sh, c⟩
+  cases sh with
+  | pure r =>
+      have ht' : t = ITree.pure r := by
+        apply PFunctor.M.eq_of_dest_eq
+        change shape' t = shape' (ITree.pure r)
+        rw [ht, shape'_pure]
+        congr 1
+        funext z
+        exact z.elim
+      subst t
+      rw [ITree.mapSpec_pure]
+      exact ⟨_, _, .refl _, .refl _,
+        CrossSignatureWeakBisim.HeadMatch.pure r r rfl (shape'_pure r) (shape'_pure r)⟩
+  | step =>
+      have ht' : t = ITree.step (c PUnit.unit) := by
+        apply PFunctor.M.eq_of_dest_eq
+        change shape' t = shape' (ITree.step (c PUnit.unit))
+        rw [ht, shape'_step]
+      subst t
+      rw [ITree.mapSpec_step]
+      exact ⟨_, _, .refl _, .refl _,
+        CrossSignatureWeakBisim.HeadMatch.tau _ _ (shape'_step _) (shape'_step _)
+          ⟨c PUnit.unit, rfl, rfl⟩⟩
+  | query a =>
+      have ht' : t = ITree.query a c := by
+        apply PFunctor.M.eq_of_dest_eq
+        change shape' t = shape' (ITree.query a c)
+        rw [ht, shape'_query]
+      subst t
+      rw [ITree.mapSpec_query]
+      refine ⟨_, _, .refl _, .refl _, ?_⟩
+      refine CrossSignatureWeakBisim.HeadMatch.query a (φ.toFunA a) rfl c
+        (fun y => ITree.mapSpec φ (c (φ.toFunB a y)))
+        (shape'_query a c) (shape'_query _ _) ?_
+      intro x y hxy
+      subst x
+      exact ⟨c (φ.toFunB a y), rfl, rfl⟩
+
+end CrossSignatureWeakBisim
+
+end ITree

--- a/PolyFun/ITree/Trace.lean
+++ b/PolyFun/ITree/Trace.lean
@@ -1,0 +1,416 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+module
+
+public import PolyFun.Control.LTS.Trace
+public import PolyFun.ITree.Bisim.Bind
+
+/-! # Finite observations of interaction trees
+
+This module gives `ITree F α` a labelled transition system and reuses
+`Control.LTS.WeakTrace` as its finite trace semantics.
+
+A visible observation is either:
+
+* `Observation.event a reply`, recording a complete visible interaction—the
+  event position and the environment reply that selects its continuation; or
+* `Observation.ret r`, recording terminal return value `r`.
+
+Silent `ITree.step` nodes are unlabelled. The LTS state is
+`Option (ITree F α)`: `none` is the terminal state reached after observing a
+return. This explicit policy means finite traces observe replies and returns,
+but not the number of silent steps.
+-/
+
+@[expose] public section
+
+universe uFA uFB uα
+
+namespace ITree
+
+variable {F : PFunctor.{uFA, uFB}} {α : Type uα}
+
+/-- A visible ITree observation: a completed event/reply interaction or a
+terminal return. -/
+inductive Observation (F : PFunctor.{uFA, uFB}) (α : Type uα) :
+    Type (max uFA uFB uα) where
+  | event (a : F.A) (reply : F.B a) : Observation F α
+  | ret (result : α) : Observation F α
+
+/-- Proof-relevant moves of the ITree transition system. The shape equality
+records which destructor case supplies the move. -/
+inductive LTSMove (F : PFunctor.{uFA, uFB}) (α : Type uα) :
+    Option (ITree F α) → Type (max uFA uFB uα) where
+  | step (t : ITree F α) (c : PUnit.{uFB + 1} → ITree F α)
+      (head : shape' t = ⟨.step, c⟩) : LTSMove F α (some t)
+  | event (t : ITree F α) (a : F.A) (c : F.B a → ITree F α)
+      (head : shape' t = ⟨.query a, c⟩) (reply : F.B a) :
+      LTSMove F α (some t)
+  | ret (t : ITree F α) (result : α)
+      (head : shape' t = ⟨.pure result, PEmpty.elim⟩) :
+      LTSMove F α (some t)
+
+namespace LTSMove
+
+/-- State reached by one ITree LTS move. -/
+def next : {state : Option (ITree F α)} → LTSMove F α state →
+    Option (ITree F α)
+  | _, .step _ c _ => some (c PUnit.unit)
+  | _, .event _ _ c _ reply => some (c reply)
+  | _, .ret _ _ _ => none
+
+/-- Optional label of one ITree LTS move. -/
+def label : {state : Option (ITree F α)} → LTSMove F α state →
+    Option (Observation F α)
+  | _, .step _ _ _ => none
+  | _, .event _ a _ _ reply => some (.event a reply)
+  | _, .ret _ result _ => some (.ret result)
+
+end LTSMove
+
+/-- The labelled transition system derived from an interaction tree.
+Silent steps are labelled `none`; completed event/reply interactions and
+terminal returns are visible observations. -/
+def toLTS (F : PFunctor.{uFA, uFB}) (α : Type uα) :
+    Control.LTS (Observation F α) where
+  State := Option (ITree F α)
+  Move := LTSMove F α
+  next := fun _ move => move.next
+  label := fun _ move => move.label
+
+@[simp] theorem LTSMove.next_step (t : ITree F α)
+    (c : PUnit.{uFB + 1} → ITree F α) (head : shape' t = ⟨.step, c⟩) :
+    (@LTSMove.next F α _ (.step t c head)) = some (c PUnit.unit) := rfl
+
+@[simp] theorem LTSMove.next_event (t : ITree F α) (a : F.A)
+    (c : F.B a → ITree F α) (head : shape' t = ⟨.query a, c⟩)
+    (reply : F.B a) :
+    (@LTSMove.next F α _ (.event t a c head reply)) = some (c reply) := rfl
+
+@[simp] theorem LTSMove.next_ret (t : ITree F α) (result : α)
+    (head : shape' t = ⟨.pure result, PEmpty.elim⟩) :
+    (@LTSMove.next F α _ (.ret t result head)) = none := rfl
+
+@[simp] theorem LTSMove.label_step (t : ITree F α)
+    (c : PUnit.{uFB + 1} → ITree F α) (head : shape' t = ⟨.step, c⟩) :
+    (@LTSMove.label F α _ (.step t c head)) = none := rfl
+
+@[simp] theorem LTSMove.label_event (t : ITree F α) (a : F.A)
+    (c : F.B a → ITree F α) (head : shape' t = ⟨.query a, c⟩)
+    (reply : F.B a) :
+    (@LTSMove.label F α _ (.event t a c head reply)) =
+      some (.event a reply) := rfl
+
+@[simp] theorem LTSMove.label_ret (t : ITree F α) (result : α)
+    (head : shape' t = ⟨.pure result, PEmpty.elim⟩) :
+    (@LTSMove.label F α _ (.ret t result head)) = some (.ret result) := rfl
+
+/-! ## Primitive transitions -/
+
+theorem toLTS_silentStep_of_step {t : ITree F α}
+    (c : PUnit.{uFB + 1} → ITree F α) (head : shape' t = ⟨.step, c⟩) :
+    (toLTS F α).SilentStep (some t) (some (c PUnit.unit)) :=
+  ⟨.step t c head, rfl, rfl⟩
+
+theorem toLTS_visibleStep_of_query {t : ITree F α} (a : F.A)
+    (c : F.B a → ITree F α) (head : shape' t = ⟨.query a, c⟩)
+    (reply : F.B a) :
+    (toLTS F α).VisibleStep (some t) (.event a reply) (some (c reply)) :=
+  ⟨.event t a c head reply, rfl, rfl⟩
+
+theorem toLTS_visibleStep_of_pure {t : ITree F α} (result : α)
+    (head : shape' t = ⟨.pure result, PEmpty.elim⟩) :
+    (toLTS F α).VisibleStep (some t) (.ret result) none :=
+  ⟨.ret t result head, rfl, rfl⟩
+
+@[simp] theorem toLTS_silentStep_step (t : ITree F α) :
+    (toLTS F α).SilentStep (some (step t)) (some t) :=
+  toLTS_silentStep_of_step (fun _ => t) (shape'_step t)
+
+@[simp] theorem toLTS_visibleStep_query (a : F.A)
+    (k : F.B a → ITree F α) (reply : F.B a) :
+    (toLTS F α).VisibleStep (some (query a k)) (.event a reply)
+      (some (k reply)) :=
+  toLTS_visibleStep_of_query a k (shape'_query a k) reply
+
+@[simp] theorem toLTS_visibleStep_pure (result : α) :
+    (toLTS F α).VisibleStep (some (pure (F := F) result)) (.ret result) none :=
+  toLTS_visibleStep_of_pure result (shape'_pure result)
+
+/-- ITree τ-stripping embeds into silent closure of the derived LTS. -/
+theorem TauSteps.toLTSSilentSteps {t t' : ITree F α} (steps : TauSteps t t') :
+    (toLTS F α).SilentSteps (some t) (some t') := by
+  induction steps with
+  | refl t => exact .refl
+  | step c head _ ih =>
+      exact Control.LTS.SilentSteps.trans (toLTS F α)
+        (toLTS_silentStep_of_step c head).silentSteps ih
+
+/-! ## Weak bisimulation as LTS weak bisimulation -/
+
+/-- Lift ITree weak bisimulation to optional LTS states. -/
+def LTSRel : Option (ITree F α) → Option (ITree F α) → Prop
+  | none, none => True
+  | some t, some s => WeakBisim t s
+  | _, _ => False
+
+namespace LTSRel
+
+theorem symm {left right : Option (ITree F α)}
+    (h : LTSRel left right) : LTSRel right left := by
+  cases left with
+  | none =>
+      cases right <;> simp_all [LTSRel]
+  | some t =>
+      cases right with
+      | none => simp_all [LTSRel]
+      | some s => exact WeakBisim.symm h
+
+end LTSRel
+
+/-- ITree weak bisimulation is a weak simulation on the derived LTS. -/
+theorem weakBisim_isWeakSimulation :
+    Control.IsWeakSimulation (toLTS F α) (toLTS F α) LTSRel := by
+  intro left right hrel label target transition
+  cases left with
+  | none =>
+      rcases transition with ⟨move, _, _⟩
+      cases move
+  | some t =>
+      cases right with
+      | none => simp_all [LTSRel]
+      | some s =>
+          change WeakBisim t s at hrel
+          rcases transition with ⟨move, hlabel, hnext⟩
+          cases move with
+          | step _ c head =>
+              subst label
+              subst target
+              have ht : t = step (c PUnit.unit) := by
+                apply PFunctor.M.eq_of_dest_eq
+                exact head.trans (shape'_step (c PUnit.unit)).symm
+              rw [ht] at hrel
+              have hcont : WeakBisim (c PUnit.unit) s :=
+                (step_weakBisim (c PUnit.unit)).symm.trans hrel
+              exact ⟨some s, .refl, hcont⟩
+          | ret _ result head =>
+              subst label
+              subst target
+              obtain ⟨t', s', ht', hs', matched⟩ := WeakBisim.dest hrel
+              have ht'eq : t' = t := TauSteps.rigid_of_pure result head ht'
+              subst t'
+              cases matched with
+              | pure observed htMatch hsMatch =>
+                  have heq :
+                      (⟨Shape.pure observed, PEmpty.elim⟩ :
+                        (Poly F α).Obj (ITree F α)) =
+                      ⟨Shape.pure result, PEmpty.elim⟩ :=
+                    htMatch.symm.trans head
+                  have hresult : observed = result :=
+                    Shape.pure.inj (Sigma.mk.inj heq).1
+                  subst observed
+                  exact ⟨none,
+                    ⟨some s', none, hs'.toLTSSilentSteps,
+                      toLTS_visibleStep_of_pure result hsMatch, .refl⟩,
+                    trivial⟩
+              | query _ _ _ htMatch _ _ =>
+                  exfalso
+                  rw [head] at htMatch
+                  cases htMatch
+              | tau _ _ htMatch _ _ =>
+                  exfalso
+                  rw [head] at htMatch
+                  cases htMatch
+          | event _ a c head reply =>
+              subst label
+              subst target
+              obtain ⟨t', s', ht', hs', matched⟩ := WeakBisim.dest hrel
+              have ht'eq : t' = t := TauSteps.rigid_of_query a c head ht'
+              subst t'
+              cases matched with
+              | pure _ htMatch _ =>
+                  exfalso
+                  rw [head] at htMatch
+                  cases htMatch
+              | query observed ct cs htMatch hsMatch hcont =>
+                  have heq :
+                      (⟨Shape.query observed, ct⟩ :
+                        (Poly F α).Obj (ITree F α)) =
+                      ⟨Shape.query a, c⟩ := htMatch.symm.trans head
+                  have ha : observed = a :=
+                    Shape.query.inj (Sigma.mk.inj heq).1
+                  subst observed
+                  have hc : ct = c := eq_of_heq (Sigma.mk.inj heq).2
+                  subst ct
+                  exact ⟨some (cs reply),
+                    ⟨some s', some (cs reply), hs'.toLTSSilentSteps,
+                      toLTS_visibleStep_of_query a cs hsMatch reply, .refl⟩,
+                    hcont reply⟩
+              | tau _ _ htMatch _ _ =>
+                  exfalso
+                  rw [head] at htMatch
+                  cases htMatch
+
+/-- The lifted relation is a weak bisimulation on the derived LTS. -/
+theorem weakBisim_isLTSWeakBisimulation :
+    Control.IsWeakBisimulation (toLTS F α) (toLTS F α) LTSRel where
+  forward := weakBisim_isWeakSimulation
+  backward := by
+    intro left right hrel label target transition
+    obtain ⟨matched, weakStep, hmatched⟩ :=
+      weakBisim_isWeakSimulation (LTSRel.symm hrel) transition
+    exact ⟨matched, weakStep, LTSRel.symm hmatched⟩
+
+/-! ## Finite trace semantics -/
+
+/-- Finite visible traces of an ITree, inherited from its derived LTS. -/
+def traces (t : ITree F α) : Set (List (Observation F α)) :=
+  (toLTS F α).traces (some t)
+
+private theorem silentSteps_from_none
+    {target : Option (ITree F α)}
+    (steps : (toLTS F α).SilentSteps none target) : target = none := by
+  induction steps with
+  | refl => rfl
+  | tail _ last ih =>
+      subst ih
+      rcases last with ⟨move, _, _⟩
+      cases move
+
+private theorem silentSteps_from_pure (result : α)
+    {target : Option (ITree F α)}
+    (steps : (toLTS F α).SilentSteps (some (pure result)) target) :
+    target = some (pure result) := by
+  induction steps with
+  | refl => rfl
+  | tail _ last ih =>
+      subst ih
+      rcases last with ⟨move, hlabel, _⟩
+      cases move with
+      | step _ _ head =>
+          exfalso
+          rw [shape'_pure] at head
+          cases head
+      | event _ _ _ _ _ => cases hlabel
+      | ret _ _ _ => cases hlabel
+
+private theorem visibleStep_from_pure (result : α)
+    {observation : Observation F α} {target : Option (ITree F α)}
+    (step : (toLTS F α).VisibleStep (some (pure result)) observation target) :
+    observation = .ret result ∧ target = none := by
+  rcases step with ⟨move, hlabel, hnext⟩
+  cases move with
+  | step _ _ _ => cases hlabel
+  | event _ _ _ head _ =>
+      exfalso
+      rw [shape'_pure] at head
+      cases head
+  | ret _ observed head =>
+      rw [shape'_pure] at head
+      cases head
+      exact ⟨(Option.some.inj hlabel).symm, hnext.symm⟩
+
+private theorem weakTrace_from_none_aux
+    {source : Option (ITree F α)}
+    {observations : List (Observation F α)}
+    {target : Option (ITree F α)}
+    (hsource : source = none)
+    (trace : (toLTS F α).WeakTrace source observations target) :
+    observations = [] ∧ target = none := by
+  exact Control.LTS.WeakTrace.rec
+    (motive := fun initial obs final _ =>
+      initial = none → obs = [] ∧ final = none)
+    (fun s hs => ⟨rfl, hs⟩)
+    (fun {s middle t} {obs observations}
+        (head : (toLTS F α).WeakStep s (some obs) middle)
+        (_ : (toLTS F α).WeakTrace middle observations t) _ hs => by
+      subst s
+      rcases head with ⟨before, after, hpre, hvis, _⟩
+      have : before = none := silentSteps_from_none hpre
+      subst before
+      rcases hvis with ⟨move, _, _⟩
+      cases move)
+    trace hsource
+
+private theorem weakTrace_from_none
+    {observations : List (Observation F α)}
+    {target : Option (ITree F α)}
+    (trace : (toLTS F α).WeakTrace none observations target) :
+    observations = [] ∧ target = none :=
+  weakTrace_from_none_aux rfl trace
+
+private theorem weakTrace_from_pure_aux (result : α)
+    {source : Option (ITree F α)}
+    {observations : List (Observation F α)}
+    {target : Option (ITree F α)}
+    (hsource : source = some (pure result))
+    (trace : (toLTS F α).WeakTrace source observations target) :
+    observations = [] ∨ observations = [.ret result] := by
+  exact Control.LTS.WeakTrace.rec
+    (motive := fun initial obs _ _ =>
+      initial = some (pure result) →
+        obs = [] ∨ obs = [.ret result])
+    (fun _ _ => Or.inl rfl)
+    (fun {s middle t} {obs observations}
+        (head : (toLTS F α).WeakStep s (some obs) middle)
+        (tail : (toLTS F α).WeakTrace middle observations t) _ hs => by
+      subst s
+      rcases head with ⟨before, after, hpre, hvis, hpost⟩
+      have hbefore : before = some (pure (F := F) result) :=
+        silentSteps_from_pure result hpre
+      subst before
+      obtain ⟨hobs, hafter⟩ := visibleStep_from_pure result hvis
+      subst obs
+      subst after
+      have hmiddle : middle = none := silentSteps_from_none hpost
+      subst middle
+      obtain ⟨hrest, _⟩ := weakTrace_from_none tail
+      subst observations
+      exact Or.inr rfl)
+    trace hsource
+
+/-- Weakly bisimilar ITrees have exactly the same finite observations. -/
+theorem traces_eq_of_weakBisim {t s : ITree F α} (h : WeakBisim t s) :
+    traces t = traces s :=
+  Control.IsWeakBisimulation.traces_eq weakBisim_isLTSWeakBisimulation h
+
+@[simp] theorem traces_step (t : ITree F α) : traces (step t) = traces t :=
+  traces_eq_of_weakBisim (step_weakBisim t)
+
+@[simp] theorem nil_mem_traces (t : ITree F α) : [] ∈ traces t :=
+  Control.LTS.nil_mem_traces (toLTS F α) (some t)
+
+/-- A pure return contributes its terminal return observation. -/
+theorem ret_mem_traces (result : α) :
+    [.ret result] ∈ traces (pure (F := F) result) := by
+  refine ⟨none, .cons ?_
+    (Control.LTS.WeakTrace.nil (L := toLTS F α) none)⟩
+  exact ((toLTS_visibleStep_pure result).delay).weak
+
+/-- A completed event/reply interaction can be prepended to every trace of
+the selected continuation. -/
+theorem event_cons_mem_traces (a : F.A) (k : F.B a → ITree F α)
+    (reply : F.B a) {observations : List (Observation F α)}
+    (h : observations ∈ traces (k reply)) :
+    .event a reply :: observations ∈ traces (query a k) := by
+  obtain ⟨target, tail⟩ := h
+  exact ⟨target,
+    .cons ((toLTS_visibleStep_query a k reply).delay.weak) tail⟩
+
+/-- Exact finite traces of a pure tree: either the empty prefix or its single
+terminal-return observation. -/
+@[simp] theorem mem_traces_pure_iff (result : α)
+    (observations : List (Observation F α)) :
+    observations ∈ traces (pure (F := F) result) ↔
+      observations = [] ∨ observations = [.ret result] := by
+  constructor
+  · rintro ⟨target, trace⟩
+    exact weakTrace_from_pure_aux result rfl trace
+  · rintro (rfl | rfl)
+    · exact nil_mem_traces _
+    · exact ret_mem_traces result
+
+end ITree

--- a/PolyFunTest/ITree/CrossSignatureExamples.lean
+++ b/PolyFunTest/ITree/CrossSignatureExamples.lean
@@ -1,0 +1,122 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+module
+
+public import PolyFun.ITree.Sim.CrossSignature
+
+/-!
+# Cross-signature relational ITree examples
+
+These compile-time examples exercise the event/reply-dependent
+`CrossSignatureWeakBisim` API, its same-signature specialization, monadic
+congruence, lens graph theorem, and separation of all event and return
+universes.
+-/
+
+@[expose] public section
+
+universe uEA uEB uFA uFB uα uβ
+
+namespace ITree.CrossSignatureExamples
+
+variable {E : PFunctor.{uEA, uEB}} {F : PFunctor.{uFA, uFB}}
+  {α : Type uα} {β : Type uβ}
+
+/-- Event signatures, replies, and return values may all inhabit independent
+universes. -/
+def separated (eventRel : ITree.EventSignatureRel E F) (resultRel : α → β → Prop)
+    (left : ITree E α) (right : ITree F β) : Prop :=
+  ITree.CrossSignatureWeakBisim eventRel resultRel left right
+
+/-- The identity event-signature relation recovers the established relational weak
+bisimulation semantics exactly. -/
+example (resultRel : α → β → Prop) (left : ITree E α) (right : ITree E β) :
+    ITree.CrossSignatureWeakBisim (ITree.EventSignatureRel.eq E) resultRel left right ↔
+      ITree.WeakBisimRel resultRel left right :=
+  ITree.CrossSignatureWeakBisim.eq_iff_weakBisimRel
+
+example (tree : ITree E α) :
+    ITree.CrossSignatureWeakBisim (ITree.EventSignatureRel.eq E) Eq tree tree :=
+  ITree.CrossSignatureWeakBisim.refl tree
+
+/-! ## A concrete relation between distinct protocols -/
+
+inductive ReadEvent where
+  | read
+
+inductive SampleEvent where
+  | sample
+
+@[reducible] def ReadSpec : PFunctor :=
+  ⟨ReadEvent, fun | .read => Bool⟩
+
+@[reducible] def SampleSpec : PFunctor :=
+  ⟨SampleEvent, fun | .sample => Fin 2⟩
+
+/-- `false` corresponds to zero and `true` to one. -/
+def readSampleRel : ITree.EventSignatureRel ReadSpec SampleSpec where
+  event
+    | .read, .sample => True
+  reply
+    | .read, .sample, _, flag, sample =>
+        sample.val = if flag then 1 else 0
+
+def boolFinRel (flag : Bool) (sample : Fin 2) : Prop :=
+  sample.val = if flag then 1 else 0
+
+def readTree : ITree ReadSpec Bool :=
+  ITree.query .read ITree.pure
+
+def sampleTree : ITree SampleSpec (Fin 2) :=
+  ITree.query .sample ITree.pure
+
+/-- The relation is observable at both the query and returned value. -/
+theorem readTree_sampleTree :
+    ITree.CrossSignatureWeakBisim readSampleRel boolFinRel readTree sampleTree := by
+  unfold readTree sampleTree
+  apply ITree.CrossSignatureWeakBisim.query (eventRel := readSampleRel)
+    ReadEvent.read SampleEvent.sample trivial ITree.pure ITree.pure
+  intro flag sample h
+  exact ITree.CrossSignatureWeakBisim.pure h
+
+example : ITree.CrossSignatureWeakBisim readSampleRel
+    (readSampleRel.reply ReadEvent.read SampleEvent.sample trivial)
+    (ITree.lift ReadEvent.read) (ITree.lift SampleEvent.sample) :=
+  ITree.CrossSignatureWeakBisim.lift (eventRel := readSampleRel)
+    ReadEvent.read SampleEvent.sample trivial
+
+def leftCont (flag : Bool) : ITree ReadSpec String :=
+  ITree.pure (if flag then "one" else "zero")
+
+def rightCont (sample : Fin 2) : ITree SampleSpec Bool :=
+  ITree.pure (sample.val = 1)
+
+def stringBoolRel (label : String) (isOne : Bool) : Prop :=
+  (label = "one" ∧ isOne = true) ∨ (label = "zero" ∧ isOne = false)
+
+/-- Cross-signature relations compose with the monadic program structure. -/
+example : ITree.CrossSignatureWeakBisim readSampleRel stringBoolRel
+    (ITree.bind readTree leftCont) (ITree.bind sampleTree rightCont) := by
+  apply readTree_sampleTree.bind
+  intro flag sample h
+  unfold boolFinRel at h
+  unfold leftCont rightCont
+  cases flag <;> apply ITree.CrossSignatureWeakBisim.pure <;> simp_all [stringBoolRel]
+
+/-! ## Lens graphs -/
+
+def readToSample : PFunctor.Lens ReadSpec SampleSpec where
+  toFunA
+    | .read => .sample
+  toFunB
+    | .read, sample => sample.val = 1
+
+example (tree : ITree ReadSpec Nat) :
+    ITree.CrossSignatureWeakBisim (ITree.EventSignatureRel.ofLens readToSample) Eq tree
+      (ITree.mapSpec readToSample tree) :=
+  ITree.CrossSignatureWeakBisim.mapSpec readToSample tree
+
+end ITree.CrossSignatureExamples

--- a/PolyFunTest/ITree/TraceExamples.lean
+++ b/PolyFunTest/ITree/TraceExamples.lean
@@ -1,0 +1,74 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+module
+
+public import PolyFun.ITree.Trace
+
+/-! # Finite ITree observation examples -/
+
+@[expose] public section
+
+namespace PolyFunTest.TraceExamples
+
+inductive Command where
+  | choose
+
+@[reducible] def ChoiceE : PFunctor where
+  A := Command
+  B _ := Bool
+
+open ITree
+
+def chooseNat : ITree ChoiceE Nat :=
+  ITree.query (F := ChoiceE) Command.choose fun answer : Bool =>
+    ITree.pure (if answer then 1 else 0)
+
+example : [Observation.ret 7] ∈
+    ITree.traces (ITree.pure (F := ChoiceE) 7) :=
+  ret_mem_traces 7
+
+example : [Observation.ret 8] ∉
+    ITree.traces (ITree.pure (F := ChoiceE) 7) := by
+  simp
+
+example : [Observation.event Command.choose true] ∉
+    ITree.traces (ITree.pure (F := ChoiceE) 7) := by
+  simp
+
+example : [Observation.event Command.choose true, Observation.ret 1] ∈
+    ITree.traces chooseNat := by
+  unfold chooseNat
+  apply event_cons_mem_traces (F := ChoiceE) (α := Nat)
+    (observations := [Observation.ret 1]) Command.choose
+    (fun answer : Bool => ITree.pure (if answer then 1 else 0)) true
+  simp
+
+example : [Observation.event Command.choose false, Observation.ret 0] ∈
+    ITree.traces chooseNat := by
+  unfold chooseNat
+  apply event_cons_mem_traces (F := ChoiceE) (α := Nat)
+    (observations := [Observation.ret 0]) Command.choose
+    (fun answer : Bool => ITree.pure (if answer then 1 else 0)) false
+  simp
+
+example : ITree.traces (ITree.step chooseNat) = ITree.traces chooseNat :=
+  traces_step chooseNat
+
+example (t s : ITree ChoiceE Nat) (h : WeakBisim t s) :
+    ITree.traces t = ITree.traces s :=
+  traces_eq_of_weakBisim h
+
+/-! Observation, event-reply, and return universes remain independent. -/
+
+def LargeReplyE : PFunctor.{0, 1} where
+  A := Bool
+  B _ := Type
+
+def mixedUniverseTraces (t : ITree LargeReplyE (Type 1)) :
+    Set (List (Observation LargeReplyE (Type 1))) :=
+  ITree.traces t
+
+end PolyFunTest.TraceExamples

--- a/docs/wiki/bisimulation.md
+++ b/docs/wiki/bisimulation.md
@@ -73,9 +73,12 @@ remains the single behavioural-equality principle.
   they relate different source return types and different continuation return
   types without collapsing their universes.
 
-The generic LTS weak closure and `ITree.WeakBisim` describe the same standard
-shape at different representation layers; no adapter is claimed here until it
-preserves dependent event labels and continuations explicitly.
+`ITree.toLTS F α` is the explicit adapter to the generic LTS layer. Its states
+are `Option (ITree F α)` so a visible return can enter terminal state `none`;
+its labels record either a dependent event/reply pair or a returned value.
+`weakBisim_isLTSWeakBisimulation` proves that `ITree.WeakBisim`, lifted to
+optional states, is a generic weak bisimulation, and
+`traces_eq_of_weakBisim` derives equality of finite visible trace sets.
 
 ## UC open processes
 

--- a/docs/wiki/itree.md
+++ b/docs/wiki/itree.md
@@ -57,6 +57,7 @@ step are lifted to `uB`; a visible query retains its original direction type.
 | [`PolyFun/ITree/Sim/Facts.lean`](../../PolyFun/ITree/Sim/Facts.lean) | Universe-polymorphic one-step, identity, relational congruence, bind, iteration, lens-composition, and handler-composition facts. `simulate_comp` identifies sequential and composite interpretation up to weak bisimulation; `Handler.comp_assoc_apply` gives pointwise associativity. |
 | [`PolyFun/ITree/Rec.lean`](../../PolyFun/ITree/Rec.lean) | Universe-polymorphic `mutualRec`, `fixRec` recursive procedure-call combinators. `CallE α β : PFunctor.{uα,uβ}` separates call inputs from results; recursive coproducts retain only the equal reply-universe constraint of `PFunctor.sum`. |
 | [`PolyFun/ITree/Rec/Facts.lean`](../../PolyFun/ITree/Rec/Facts.lean) | Exact head equations for `interpMrec`, bind compatibility, external-event renaming naturality, and the guarded characteristic equations for `mutualRec` / `fixRec`. |
+| [`PolyFun/ITree/Trace.lean`](../../PolyFun/ITree/Trace.lean) | Derived labelled transition system and finite weak traces. Visible labels record complete event/reply interactions or terminal returns; `step` is silent. `traces_eq_of_weakBisim` proves weak-bisimulation invariance through the generic `Control.LTS` trace layer. |
 
 ### Bisimulation
 
@@ -95,6 +96,13 @@ step are lifted to `uB`; a visible query retains its original direction type.
   of the M-type universal property. `WeakBisimRel RR` ignores finitely many
   leading silent `step`s and compares returns through `RR`; `WeakBisim` is
   the same-type `Eq` specialization used as the ordinary ITree setoid.
+- `ITree.toLTS F α` has states `Option (ITree F α)`, with `none` as the
+  terminal state after a return. Its finite traces ignore silent steps and
+  observe `Observation.event a reply` and `Observation.ret result`. Thus a
+  trace records which reply selected each query continuation and whether the
+  observed prefix terminated. The generic `Control.LTS.WeakTrace` semantics
+  is preserved by weak simulation, so `WeakBisim`-related trees have equal
+  trace sets.
 - The state and exception runners are direct productive corecursors. State
   operations become one silent step while threading the current state;
   exceptions terminate as `Except.error`; untouched external events remain

--- a/docs/wiki/itree.md
+++ b/docs/wiki/itree.md
@@ -55,18 +55,20 @@ step are lifted to `uB`; a visible query retains its original direction type.
 | [`PolyFun/ITree/Handler.lean`](../../PolyFun/ITree/Handler.lean) | Universe-polymorphic `Handler E F`: choice of an `F`-program for every `E`-event, with identity, lens promotion, and coproduct routing via `Handler.case_`. |
 | [`PolyFun/ITree/Sim/Defs.lean`](../../PolyFun/ITree/Sim/Defs.lean) | Universe-polymorphic `ITree.simulate` (interprets every event via a handler), `Handler.comp`, and `ITree.mapSpec` (pure event-renaming via a `PFunctor.Lens`). Coq `interp` analogue. |
 | [`PolyFun/ITree/Sim/Facts.lean`](../../PolyFun/ITree/Sim/Facts.lean) | Universe-polymorphic one-step, identity, relational congruence, bind, iteration, lens-composition, and handler-composition facts. `simulate_comp` identifies sequential and composite interpretation up to weak bisimulation; `Handler.comp_assoc_apply` gives pointwise associativity. |
+| [`PolyFun/ITree/Sim/CrossSignature.lean`](../../PolyFun/ITree/Sim/CrossSignature.lean) | Lens-specific bridge from core `CrossSignatureWeakBisim` to simulation: the dependent lens-graph relation and the theorem relating every tree to its `mapSpec` image. |
 | [`PolyFun/ITree/Rec.lean`](../../PolyFun/ITree/Rec.lean) | Universe-polymorphic `mutualRec`, `fixRec` recursive procedure-call combinators. `CallE α β : PFunctor.{uα,uβ}` separates call inputs from results; recursive coproducts retain only the equal reply-universe constraint of `PFunctor.sum`. |
-| [`PolyFun/ITree/Rec/Facts.lean`](../../PolyFun/ITree/Rec/Facts.lean) | Exact head equations for `interpMrec`, bind compatibility, external-event renaming naturality, and the guarded characteristic equations for `mutualRec` / `fixRec`. |
+| [`PolyFun/ITree/Rec/Facts.lean`](../../PolyFun/ITree/Rec/Facts.lean) | Exact head equations for `interpMrec`, bind compatibility, external-event renaming naturality, and definition bridges for `mutualRec` / `fixRec`; `interpMrec_query_recursive` exposes the recursive-call guard. |
 | [`PolyFun/ITree/Trace.lean`](../../PolyFun/ITree/Trace.lean) | Derived labelled transition system and finite weak traces. Visible labels record complete event/reply interactions or terminal returns; `step` is silent. `traces_eq_of_weakBisim` proves weak-bisimulation invariance through the generic `Control.LTS` trace layer. |
 
 ### Bisimulation
 
 | File | Purpose |
 |------|---------|
-| [`PolyFun/ITree/Bisim/Defs.lean`](../../PolyFun/ITree/Bisim/Defs.lean) | Universe-polymorphic `ITree.Bisim` (strong / structural equality), relational `ITree.WeakBisimRel RR` (Coq `euttR`), and `ITree.WeakBisim` as its equality specialization (Coq `eutt`). |
+| [`PolyFun/ITree/Bisim/Defs.lean`](../../PolyFun/ITree/Bisim/Defs.lean) | Universe-polymorphic `ITree.Bisim` (strong / structural equality), relational `ITree.WeakBisimRel resultRel` (Coq `euttR`), and `ITree.WeakBisim` as its equality specialization (Coq `eutt`). |
 | [`PolyFun/ITree/Bisim/Bind.lean`](../../PolyFun/ITree/Bisim/Bind.lean) | Mixed-universe monad/iteration equations, the homogeneous `LawfulMonad` instance, and two-sided relational congruence of `bind` and `map`. |
 | [`PolyFun/ITree/Bisim/Equiv.lean`](../../PolyFun/ITree/Bisim/Equiv.lean) | Equivalence properties of bisimulation. |
 | [`PolyFun/ITree/Bisim/Iter.lean`](../../PolyFun/ITree/Bisim/Iter.lean) | Relational iteration congruence and the `LawfulMonadIter` instance over `WeakBisim`, including unfolding, naturality, dinaturality, and codiagonal laws. |
+| [`PolyFun/ITree/Bisim/CrossSignature.lean`](../../PolyFun/ITree/Bisim/CrossSignature.lean) | `CrossSignatureWeakBisim`: weak bisimulation across two event signatures, with supplied relations on event names, dependent replies, and results; includes finite-τ-safe coinduction, symmetry, monotonicity, `bind` / `map` congruence, and identity specialization to `WeakBisimRel`. |
 
 ### Standard events
 
@@ -92,10 +94,21 @@ step are lifted to `uB`; a visible query retains its original direction type.
   composes interpretations, and `Handler.case_` routes coproduct events.
   `mapSpec` is the syntactically pure case (pure event rename via a
   `PFunctor.Lens`).
-- Strong bisimulation `Bisim` is set to definitional equality, courtesy
-  of the M-type universal property. `WeakBisimRel RR` ignores finitely many
-  leading silent `step`s and compares returns through `RR`; `WeakBisim` is
+- Strong bisimulation `Bisim` is set to Lean equality, courtesy
+  of the M-type universal property. `WeakBisimRel resultRel` ignores finitely many
+  leading silent `step`s and compares returns through `resultRel`; `WeakBisim` is
   the same-type `Eq` specialization used as the ordinary ITree setoid.
+- `CrossSignatureWeakBisim eventRel resultRel` generalizes `WeakBisimRel` to
+  two different event signatures. `eventRel.event` relates event names and
+  `eventRel.reply` dependently relates their replies. The identity event-signature
+  relation recovers `WeakBisimRel` exactly, while `EventSignatureRel.ofLens`
+  relates every tree to its `mapSpec` image. The current API
+  adds only coinduction and congruence principles used by concrete consumers;
+  it intentionally does not duplicate the upstream Paco up-to tower.
+- Reader, writer, failure, and nondeterminism event libraries remain
+  consumer-driven follow-ups. State and exception are the current canonical
+  interpreted effects; the conditional event-library roadmap item is not
+  part of this foundational stack.
 - `ITree.toLTS F α` has states `Option (ITree F α)`, with `none` as the
   terminal state after a return. Its finite traces ignore silent steps and
   observe `Observation.event a reply` and `Observation.ret result`. Thus a

--- a/docs/wiki/quickstart.md
+++ b/docs/wiki/quickstart.md
@@ -126,7 +126,7 @@ deliberately outside the `lake lint` scope.
 
 ## Toolchain
 
-Lean toolchain and Mathlib stay in sync. Both currently `v4.32.0`. When
+Lean toolchain, Mathlib, and cslib stay in sync. All currently `v4.32.0`. When
 upgrading, update [`lean-toolchain`](../../lean-toolchain) and the
-`require mathlib` line in [`lakefile.toml`](../../lakefile.toml)
-simultaneously.
+`require mathlib` / `require cslib` pins in
+[`lakefile.toml`](../../lakefile.toml) simultaneously.

--- a/docs/wiki/repo-map.md
+++ b/docs/wiki/repo-map.md
@@ -15,15 +15,15 @@ PolyFun/
   IPFunctor/         state-indexed polynomial functors and their free monads
                      (single-index FreeM, two-index FreeM₂ + IndexedMonad)
   ITree/             coinductive interaction trees, bisim/sim, handlers,
-                     event signatures
+                     event signatures, relational trees, finite traces
   Interaction/       generic interaction framework
     Basic/           Spec, Node, Decoration, Strategy, Append, ...
     TwoParty/        sender/receiver roles, paired strategies
     Multiparty/      per-party local view modes, observation kernels
     Concurrent/      structural and dynamic concurrent semantics
     UC/              open-process / open-theory layer (no security content)
-  Control/           monad and comonad infrastructure (Coalg, Comonad,
-                     Lawful, Free, FreeCont, Hom, Iter, Trace)
+  Control/           monad/comonad and LTS infrastructure (Coalgebra,
+                     Comonad, Lawful, Free, Iter, Bisimulation, LTS/Trace)
   Logic/             small logic helpers (HEq)
 
 docs/wiki/           agent-facing notes (this directory)
@@ -49,7 +49,7 @@ PFunctor/Free/Basic
   -> PFunctor/Free/Cursor/Fork
 PFunctor/{Resumption, Free/Basic} -> PFunctor/Free/Resumption
 
-Logic/HEq, Control/{Coalgebra, Comonad, Lawful, Monad}
+Logic/HEq, Control/{Coalgebra, Comonad, Lawful, Monad, Bisimulation, LTS/Trace}
   (free-standing helpers, depended on by both PFunctor and ITree)
 
 PFunctor/Lens/{Basic, Cartesian, State}
@@ -66,7 +66,7 @@ PFunctor/{Lens, Cofree, M} + Control/Coalgebra
    PFunctor/Lens/Duoidal for Game.)
 
 PFunctor/Free -> ITree/{Basic, Construct, Handler, Rec,
-                        Events, Sim, Bisim}
+                        Events, Sim, Bisim, Trace}
 PFunctor/Dynamical + ITree/Basic -> ITree/Unfold
 
 PFunctor/Free + Control -> Interaction/Basic/{Spec, Node, Decoration,


### PR DESCRIPTION
## What changed

- add generic `Control.LTS.WeakTrace` and finite visible trace sets over the existing silent/visible LTS layer
- prove weak simulations preserve finite traces and weak bisimulations induce trace-set equality
- derive an LTS from `ITree F α` with optional terminal states
- make the observation policy explicit: visible labels are complete event/reply interactions or terminal returns; `step` remains silent
- prove ITree `WeakBisim` is a weak bisimulation of the derived LTS
- derive `traces_eq_of_weakBisim`, silent-step invariance, and trace constructors for returns and events
- add executable examples, mixed-universe canaries, and documentation

## Why

Issue #33 calls for finite trace/observation semantics connected to PolyFun existing transition-system theory, with a precise account of replies and returns and a proof of weak-bisimulation invariance.

This PR builds on `Control.LTS` rather than duplicating an ITree-only transition relation. The generic trace preservation theorem does the reusable work; ITree invariance follows after proving that the existing coinductive `WeakBisim` relation is an LTS weak bisimulation.

An event observation is atomic in its event position and environment reply, which identifies the selected continuation. A return observation transitions to the explicit terminal state `none`. Finite traces intentionally forget all silent-step counts.

## Stack

This is I8, stacked on #49. Review only commit `b71ba87` / the diff against `agent/itree-recursion-effects`.

## Validation

- `./scripts/validate.sh --lint --test`
- `lake build PolyFun.ITree.Trace PolyFunTest.ITree.TraceExamples`
- `git diff --check`
- key theorem axiom audit: generic trace transport is axiom-free; ITree invariance uses only the existing `propext`, `Classical.choice`, and `Quot.sound` substrate

Advances #33 P1 finite traces and weak-bisimulation invariance.