### PR TITLE
skip PR review without API key

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -37,9 +37,21 @@
         contents: read
         pull-requests: write
       steps:
+        - name: Skip if API key missing
+          id: gate
+          env:
+            API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          run: |
+            if [[ -z "${API_KEY}" ]]; then
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              echo "::notice::GEMINI_API_KEY secret is not set; skipping PR review."
+            else
+              echo "skip=false" >> "$GITHUB_OUTPUT"
+            fi
+
         - name: Extract arguments from comment
           id: get_args
-          if: github.event_name == 'issue_comment'
+          if: steps.gate.outputs.skip == 'false' && github.event_name == 'issue_comment'
           env:
             COMMENT_BODY: ${{ github.event.comment.body }}
           run: |
@@ -83,6 +95,7 @@
           shell: bash
 
         - uses: alexanderlhicks/lean-review-workflow@main
+          if: steps.gate.outputs.skip == 'false'
           with:
             github_token: ${{ secrets.GITHUB_TOKEN }}
             api_key: ${{ secrets.GEMINI_API_KEY }}
@@ -92,4 +105,3 @@
             external_refs: "${{ steps.get_args.outputs.external_refs }}"
             repo_context_refs: "${{ steps.get_args.outputs.repo_context_refs }}"
             additional_comments: "${{ steps.get_args.outputs.additional_comments }}"
-


### PR DESCRIPTION
## Investigation

The ITree stack failures were not Lean review failures. The external review action was invoked with an unset `GEMINI_API_KEY`; after checkout, build, and Lean-info extraction, it exited with `API_KEY not set`.

The axiom-scanner diagnostics seen in those logs were nonfatal context noise. Its source parser can construct incorrect fully qualified names for declarations inside namespaces, and its default build does not make the `PolyFunTest` library available. Those issues belong upstream in `lean-review-workflow` and did not cause the red checks.

The `review` job is an optional advisory integration, not a required branch-protection check. Required correctness checks remain fail-closed.

## Resolution

Mirror the existing PR-summary policy with an explicit key gate:

- when `GEMINI_API_KEY` is absent, emit a notice and skip argument extraction and the external action;
- when the key is configured, run the existing review path unchanged;
- when a configured review genuinely fails, preserve the failing check.

This makes missing optional infrastructure a visible successful no-op without weakening Lean CI or swallowing real review failures. The successful six-second `review` check on this PR exercised the missing-key path: the gate passed and both downstream steps were skipped.

Historical red `review` checks on PRs #42 and #44–#50 can be ignored because the check is optional. Commenting `/review` after this merges would create an `issue_comment` workflow run on the default-branch SHA; with no key it would only skip, and it would not replace the old PR-head check. Actual automated reviews still require provisioning the provider key.

## Deferred upstream follow-up

- Validate the provider key before checkout/build/scanning.
- Fix namespace-aware axiom extraction and build/load the appropriate Lake target for `PolyFunTest`.
- Ensure the manual `/review` path analyzes the intended PR revision while preserving the security boundary around secrets and untrusted PR code.
- Pin the external action to a reviewed immutable revision.

## Validation

- `git diff --check`
- `lake exe lint-style`
- Hosted `review` missing-key path: passed in 6 seconds
- Hosted build, test, environment lint, imports, and docs-integrity checks: passed
