### PR TITLE
Add substitution monoids for polynomial composition

### DIFF
--- a/PolyFun.lean
+++ b/PolyFun.lean
@@ -146,4 +146,5 @@ import PolyFun.PFunctor.Lens.Factorization
 import PolyFun.PFunctor.Lens.State
 import PolyFun.PFunctor.M
 import PolyFun.PFunctor.Resumption
+import PolyFun.PFunctor.SubstMonoid
 import PolyFun.PFunctor.Trace

--- a/PolyFun/PFunctor/SubstMonoid.lean
+++ b/PolyFun/PFunctor/SubstMonoid.lean
@@ -1,0 +1,162 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+module
+
+public import PolyFun.PFunctor.Lens.Basic
+public import Mathlib.CategoryTheory.Category.Basic
+import Batteries.Tactic.Lint
+
+/-!
+# Monoids for polynomial substitution
+
+A `SubstMonoid` is a monoid object in the composition-monoidal category
+`(Poly, ◃, y)`: a polynomial `p`, a unit lens `y ⇆ p`, and a multiplication
+lens `p ◃ p ⇆ p` satisfying the two unit laws and associativity. Under
+polynomial extension, every substitution monoid induces a monad on `Type`.
+
+The laws are stated directly with the composition unitors and associator from
+`PFunctor.Lens.Equiv`. This à-la-carte presentation avoids choosing between the
+lens and chart category instances on `PFunctor` and matches the existing
+`PFunctor.Comonoid` API.
+
+`SubstMonoid.Hom` packages the polynomial monad morphisms: lenses preserving
+the unit and multiplication. They form a category under ordinary lens
+composition.
+
+This file records the polynomial-level structure and its morphisms. Packaging
+the induced monad on each extension, and constructing the free substitution
+monoid, are separate layers.
+
+## References
+
+* Libkind and Spivak, *Pattern Runs on Matter: The Free Monad Monad as a
+  Module over the Cofree Comonad Comonad*.
+* Niu and Spivak, *Polynomial Functors: A Mathematical Theory of Interaction*,
+  Chapter 7.
+-/
+
+@[expose] public section
+
+universe uA uB
+
+open CategoryTheory
+
+namespace PFunctor
+
+/-! ## Substitution monoids -/
+
+set_option linter.checkUnivs false in
+/-- A monoid object in the composition-monoidal category `(Poly, ◃, y)`.
+
+The unit and multiplication are polynomial lenses. The laws use the explicit
+unitors `XComp` and `compX` and associator `compAssoc`; no ambient monoidal
+category instance is required. -/
+-- The carrier's position and direction universes are independent; `checkUnivs`
+-- sees only their joint contribution to the structure's resulting sort.
+structure SubstMonoid where
+  /-- The carrier polynomial. -/
+  carrier : PFunctor.{uA, uB}
+  /-- The unit `η : y ⇆ p`. Its universe instance agrees with the composition
+  unit appearing beside `carrier ◃ carrier`. -/
+  unit : Lens X.{max uA uB, uB} carrier
+  /-- The multiplication `μ : p ◃ p ⇆ p`. -/
+  mult : Lens (carrier ◃ carrier) carrier
+  /-- Left unitality: `μ ∘ (η ◃ id) ∘ λ⁻¹ = id`. -/
+  unit_left : mult ∘ₗ (unit ◃ₗ Lens.id carrier) ∘ₗ
+      Lens.Equiv.XComp.invLens = Lens.id carrier
+  /-- Right unitality: `μ ∘ (id ◃ η) ∘ ρ⁻¹ = id`. -/
+  unit_right : mult ∘ₗ (Lens.id carrier ◃ₗ unit) ∘ₗ
+      Lens.Equiv.compX.invLens = Lens.id carrier
+  /-- Associativity: multiplying the outer pair or the inner pair agrees. -/
+  assoc : mult ∘ₗ (mult ◃ₗ Lens.id carrier) =
+      mult ∘ₗ (Lens.id carrier ◃ₗ mult) ∘ₗ Lens.Equiv.compAssoc.toLens
+
+namespace SubstMonoid
+
+/-! ## Morphisms -/
+
+/-- A homomorphism of substitution monoids. It is a lens on carriers that
+preserves the unit and multiplication. -/
+structure Hom (M N : SubstMonoid.{uA, uB}) where
+  /-- The underlying lens between carrier polynomials. -/
+  toLens : Lens M.carrier N.carrier
+  /-- Preservation of the unit. -/
+  map_unit : toLens ∘ₗ M.unit = N.unit
+  /-- Preservation of multiplication. -/
+  map_mult : toLens ∘ₗ M.mult =
+    N.mult ∘ₗ (toLens ◃ₗ toLens)
+
+instance {M N : SubstMonoid.{uA, uB}} :
+    Coe (Hom M N) (Lens M.carrier N.carrier) :=
+  ⟨Hom.toLens⟩
+
+@[ext]
+theorem Hom.ext {M N : SubstMonoid.{uA, uB}} (f g : Hom M N)
+    (h : f.toLens = g.toLens) : f = g := by
+  cases f
+  cases g
+  cases h
+  rfl
+
+/-- The identity substitution-monoid homomorphism. -/
+def Hom.id (M : SubstMonoid.{uA, uB}) : Hom M M where
+  toLens := Lens.id M.carrier
+  map_unit := rfl
+  map_mult := by simp
+
+/-- Composition of substitution-monoid homomorphisms, in diagrammatic order. -/
+def Hom.comp {M N O : SubstMonoid.{uA, uB}} (f : Hom M N) (g : Hom N O) : Hom M O where
+  toLens := g.toLens ∘ₗ f.toLens
+  map_unit := by
+    rw [Lens.comp_assoc, f.map_unit, g.map_unit]
+  map_mult := by
+    calc
+      (g.toLens ∘ₗ f.toLens) ∘ₗ M.mult =
+          g.toLens ∘ₗ (f.toLens ∘ₗ M.mult) := rfl
+      _ = g.toLens ∘ₗ (N.mult ∘ₗ (f.toLens ◃ₗ f.toLens)) := by
+        rw [f.map_mult]
+      _ = (g.toLens ∘ₗ N.mult) ∘ₗ (f.toLens ◃ₗ f.toLens) := rfl
+      _ = (O.mult ∘ₗ (g.toLens ◃ₗ g.toLens)) ∘ₗ
+          (f.toLens ◃ₗ f.toLens) := by
+        rw [g.map_mult]
+      _ = O.mult ∘ₗ ((g.toLens ◃ₗ g.toLens) ∘ₗ
+          (f.toLens ◃ₗ f.toLens)) := rfl
+      _ = O.mult ∘ₗ ((g.toLens ∘ₗ f.toLens) ◃ₗ
+          (g.toLens ∘ₗ f.toLens)) := by
+        rw [Lens.compMap_comp]
+
+@[simp] theorem Hom.id_toLens (M : SubstMonoid.{uA, uB}) :
+    (Hom.id M).toLens = Lens.id M.carrier := rfl
+
+@[simp] theorem Hom.comp_toLens {M N O : SubstMonoid.{uA, uB}}
+    (f : Hom M N) (g : Hom N O) :
+    (f.comp g).toLens = g.toLens ∘ₗ f.toLens := rfl
+
+@[simp] theorem Hom.id_comp {M N : SubstMonoid.{uA, uB}} (f : Hom M N) :
+    (Hom.id M).comp f = f :=
+  Hom.ext _ _ (Lens.comp_id f.toLens)
+
+@[simp] theorem Hom.comp_id {M N : SubstMonoid.{uA, uB}} (f : Hom M N) :
+    f.comp (Hom.id N) = f :=
+  Hom.ext _ _ (Lens.id_comp f.toLens)
+
+theorem Hom.comp_assoc {M N O P : SubstMonoid.{uA, uB}}
+    (f : Hom M N) (g : Hom N O) (h : Hom O P) :
+    (f.comp g).comp h = f.comp (g.comp h) :=
+  Hom.ext _ _ (Lens.comp_assoc h.toLens g.toLens f.toLens)
+
+/-- The category of substitution monoids and their homomorphisms. -/
+instance : Category SubstMonoid.{uA, uB} where
+  Hom := Hom
+  id := Hom.id
+  comp f g := f.comp g
+  id_comp := Hom.id_comp
+  comp_id := Hom.comp_id
+  assoc := Hom.comp_assoc
+
+end SubstMonoid
+
+end PFunctor

--- a/PolyFunTest/PFunctor/SubstMonoid.lean
+++ b/PolyFunTest/PFunctor/SubstMonoid.lean
@@ -1,0 +1,141 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+module
+
+public import PolyFun.PFunctor.SubstMonoid
+
+/-!
+# Regression tests for substitution monoids
+
+The main canary is the substitution monoid of words. Its unary operations are
+lists of bits and multiplication concatenates the outer word before the inner
+word. The noncommutative example distinguishes the orientation of
+multiplication and of homomorphism composition.
+-/
+
+@[expose] public section
+
+universe u v
+
+open CategoryTheory
+
+namespace PFunctor
+namespace SubstMonoidTest
+
+/-- The polynomial of unary operations labelled by bit strings. -/
+abbrev wordP : PFunctor := ⟨List Bool, fun _ => PUnit⟩
+
+/-- The empty word is the substitution unit. -/
+def wordUnit : Lens X wordP :=
+  (fun _ => []) ⇆ (fun _ _ => PUnit.unit)
+
+/-- Substitution concatenates the outer label before the inner label. -/
+def wordMult : Lens (wordP ◃ wordP) wordP :=
+  (fun a => a.1 ++ a.2 PUnit.unit) ⇆
+    (fun _ _ => ⟨PUnit.unit, PUnit.unit⟩)
+
+/-- Bit strings under concatenation form a noncommutative substitution
+monoid. -/
+def wordMonoid : SubstMonoid where
+  carrier := wordP
+  unit := wordUnit
+  mult := wordMult
+  unit_left := by
+    apply Lens.ext _ _ (fun _ => rfl)
+    intro a
+    exact Subsingleton.elim _ _
+  unit_right := by
+    apply Lens.ext _ _ (fun a => List.append_nil a)
+    intro a
+    exact Subsingleton.elim _ _
+  assoc := by
+    let hA : ∀ a : ((wordP ◃ wordP) ◃ wordP).A,
+        (wordMult ∘ₗ (wordMult ◃ₗ Lens.id wordP)).toFunA a =
+          (wordMult ∘ₗ (Lens.id wordP ◃ₗ wordMult) ∘ₗ
+            Lens.Equiv.compAssoc.toLens).toFunA a := fun a => by
+      exact List.append_assoc a.1.1 (a.1.2 PUnit.unit)
+        (a.2 ⟨PUnit.unit, PUnit.unit⟩)
+    apply Lens.ext _ _ hA
+    intro a
+    funext d
+    letI : Subsingleton (((wordP ◃ wordP) ◃ wordP).B a) :=
+      ⟨fun x y => by
+        rcases x with ⟨⟨x₁, x₂⟩, x₃⟩
+        rcases y with ⟨⟨y₁, y₂⟩, y₃⟩
+        cases x₁
+        cases x₂
+        cases x₃
+        cases y₁
+        cases y₂
+        cases y₃
+        rfl⟩
+    exact Subsingleton.elim _ _
+
+/-- The multiplication order is observable and is outer-before-inner. -/
+example : wordMonoid.mult.toFunA
+    (⟨[false], fun _ : PUnit => [true]⟩ : (wordP ◃ wordP).A) =
+      [false, true] := rfl
+
+/-- Extending a map on bit generators to words gives a substitution-monoid
+homomorphism. -/
+def wordMapHom (f : Bool → List Bool) :
+    SubstMonoid.Hom wordMonoid wordMonoid where
+  toLens := List.flatMap f ⇆ (fun _ d => d)
+  map_unit := rfl
+  map_mult := by
+    let hA : ∀ a : (wordP ◃ wordP).A,
+        ((List.flatMap f ⇆ fun _ d => d) ∘ₗ wordMult).toFunA a =
+          (wordMult ∘ₗ ((List.flatMap f ⇆ fun _ d => d) ◃ₗ
+            (List.flatMap f ⇆ fun _ d => d))).toFunA a := fun a => by
+      exact List.flatMap_append
+    apply Lens.ext _ _ hA
+    intro a
+    funext d
+    letI : Subsingleton ((wordP ◃ wordP).B a) :=
+      ⟨fun x y => by
+        rcases x with ⟨x₁, x₂⟩
+        rcases y with ⟨y₁, y₂⟩
+        cases x₁
+        cases x₂
+        cases y₁
+        cases y₂
+        rfl⟩
+    exact Subsingleton.elim _ _
+
+/-- Expand the `false` generator by a trailing `true`. -/
+def expandFalse : Bool → List Bool
+  | false => [false, true]
+  | true => [true]
+
+/-- Collapse either generator to `false`. -/
+def collapseTrue : Bool → List Bool
+  | false => [false]
+  | true => [false]
+
+/-- Hom composition is observable in diagrammatic order: first expand, then
+collapse. Reversing the two maps produces `[false, true]` instead. -/
+example : ((wordMapHom expandFalse).comp (wordMapHom collapseTrue)).toLens.toFunA
+    [false] = [false, false] := rfl
+
+/-- Identity and composition expose the underlying lens in diagrammatic
+order. -/
+example (M : SubstMonoid.{u, v}) : SubstMonoid.Hom M M :=
+  SubstMonoid.Hom.id M
+
+example {M N O : SubstMonoid.{u, v}} (f : SubstMonoid.Hom M N)
+    (g : SubstMonoid.Hom N O) :
+    (f.comp g).toLens = g.toLens ∘ₗ f.toLens := rfl
+
+example {M N O : SubstMonoid.{u, v}} (f : M ⟶ N) (g : N ⟶ O) :
+    (f ≫ g).toLens = g.toLens ∘ₗ f.toLens := rfl
+
+/-- Position and direction universes of substitution monoids are independent. -/
+example (M : SubstMonoid.{u, v}) : M.mult ∘ₗ
+    (M.unit ◃ₗ Lens.id M.carrier) ∘ₗ Lens.Equiv.XComp.invLens =
+    Lens.id M.carrier := M.unit_left
+
+end SubstMonoidTest
+end PFunctor

--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -57,18 +57,20 @@ Used in: `PolyFun/PFunctor/Trace.lean`, `PolyFun/PFunctor/Lens/State.lean`,
 `PolyFun/Interaction/UC/Interface.lean`, and
 companion files in `PolyFun/Interaction/UC/`.
 
-### LS22 — Libkind and Spivak, *Pattern runs on matter*
+### LS25 — Libkind and Spivak, *Pattern runs on matter*
 
 Sophie Libkind and David I. Spivak.
 *Pattern runs on matter: the free monad monad as a module over the
 cofree comonad comonad*.
-arXiv:2208.12504, 2022.
+Electronic Proceedings in Theoretical Computer Science 429 (2025), pp. 1–28.
+DOI 10.4204/EPTCS.429.1; arXiv:2404.16321.
 
 Free polynomial monads as terminating decision trees, with the
 free-monad-as-module-over-cofree-comonad structure made explicit (a module
 action, not an adjunction).
 
-Used in: `PolyFun/PFunctor/Free/Path.lean`.
+Used in: `PolyFun/PFunctor/SubstMonoid.lean`,
+`PolyFun/PFunctor/Free/Path.lean`.
 
 ### XZHHMPZ20 — Xia, Zakowski, He, Hur, Malecha, Pierce, Zdancewic, *Interaction Trees*
 


### PR DESCRIPTION
## What changed

- add `PFunctor.SubstMonoid`, the monoid-object structure for polynomial
  substitution `(Poly, ◃, y)` with explicit unitor and associator laws;
- add substitution-monoid homomorphisms, identity/composition, extensionality,
  and their category instance;
- add nontrivial producer tests using unary bit-string operations, including
  noncommutative multiplication and noncommuting homomorphisms;
- correct the Libkind–Spivak bibliography entry to the published 2025 paper and
  current arXiv identifier.

## Why

This is the first algebraic foundation for #28. The free polynomial monad must
be constructed as a monoid for substitution, rather than only as a Lean
`LawfulMonad`, because the later free universal property, convolution internal
hom, and free–cofree module action live at the polynomial/lens level.

The slice deliberately does not yet add `FreeP`, an induced `LawfulMonad`
bridge, convolution, or the module action. It also avoids choosing between the
existing lens and chart category instances on bare `PFunctor` by stating the
monoid laws directly, matching `PFunctor.Comonoid`.

## Validation

- `lake build PolyFun.PFunctor.SubstMonoid`
- `lake build PolyFunTest.PFunctor.SubstMonoid`
- `./scripts/validate.sh --lint --test`
- `lake exe lint-style`
- `git diff --check`
- added-code trust scan for `sorry`, `admit`, `stop`, unsafe declarations,
  axioms, and linter suppression
- `#print axioms` on the principal hom extensionality/category theorem: no
  axioms
