### PR TITLE
test(pfunctor): harden free polynomial path laws

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,9 @@ PFunctor/Lens/{Basic, Cartesian, State}
   → PFunctor/Lens/{Composite, Distributivity, Factorization, Duoidal}
   → PFunctor/{InternalHom, CartesianClosed, Adjunctions, Comonoid}
 
+PFunctor/Lens/Basic → PFunctor/SubstMonoid
+PFunctor/{Free/Path, SubstMonoid} → PFunctor/Free/Polynomial
+
 PFunctor/{Lens, Cofree, M} + Control/Coalgebra
   → PFunctor/Dynamical/{Basic, Safety, Combinators, Run, Speedup, Trajectory}
   → PFunctor/Dynamical/{Behavior, Simulation, RunN, DynComputation, IOMachine}

--- a/PolyFun/PFunctor/Free/Polynomial.lean
+++ b/PolyFun/PFunctor/Free/Polynomial.lean
@@ -333,7 +333,9 @@ theorem map_obj_comp (l₂ : Lens Q R) (l₁ : Lens P Q)
         (map_obj_comp l₂ l₁
           (rest (l₁.toFunB a (l₂.toFunB (l₁.toFunA a) d))))
 
-@[simp]
+/-- Mapping preserves lens composition. This is intentionally not a simp
+lemma: `Lens.mapObj_comp` already selects the canonical normal form for
+composition acting on polynomial extensions. -/
 theorem map_comp (l₂ : Lens Q R) (l₁ : Lens P Q) :
     map l₂ ∘ₗ map l₁ = map (l₂ ∘ₗ l₁) := by
   let hA : ∀ s, (map l₂ ∘ₗ map l₁).toFunA s =

--- a/PolyFunTest/PFunctor/FreePolynomial.lean
+++ b/PolyFunTest/PFunctor/FreePolynomial.lean
@@ -25,6 +25,18 @@ namespace FreePolynomialTest
 /-- A binary-branching signature whose operation positions are also bits. -/
 abbrev binaryP : PFunctor := ⟨Bool, fun _ => Bool⟩
 
+def binaryLeaf : FreeM binaryP PUnit :=
+  .pure PUnit.unit
+
+def binaryOp (label : Bool) : FreeM binaryP PUnit :=
+  .liftBind label fun _ => binaryLeaf
+
+/-- Three binary substitution layers with independently observable path
+components. -/
+def binaryTriple : ((FreeP binaryP ◃ FreeP binaryP) ◃ FreeP binaryP).A :=
+  ⟨⟨binaryOp false, fun _ => binaryOp true⟩,
+    fun _ => binaryOp false⟩
+
 /-- A binary tree with distinguishable payloads at its two leaves. -/
 def labelledBinaryTree : FreeM binaryP Nat :=
   .liftBind false fun branch => .pure (if branch then 7 else 3)
@@ -78,6 +90,31 @@ example :
     ⟨⟨PUnit.unit, ⟨⟩⟩, ⟨PUnit.unit, ⟨⟩⟩⟩ :=
   rfl
 
+/-- Splitting must preserve both nontrivial branch choices; a unary signature
+would not detect swapping or duplicating the outer and inner components. -/
+example :
+    (FreeP.mult (P := binaryP)).toFunB
+      ⟨binaryOp false, fun _ => binaryOp true⟩
+      ⟨false, true, ⟨⟩⟩ =
+    ⟨⟨false, ⟨⟩⟩, ⟨true, ⟨⟩⟩⟩ :=
+  rfl
+
+/-- Left-associated multiplication reassociates all three path components
+without permuting them. -/
+example :
+    (FreeP.multAssocLeft (P := binaryP)).toFunB binaryTriple
+      ⟨false, true, false, ⟨⟩⟩ =
+    ⟨⟨⟨false, ⟨⟩⟩, ⟨true, ⟨⟩⟩⟩, ⟨false, ⟨⟩⟩⟩ :=
+  rfl
+
+/-- The right-associated composite has the same observable reassociation of
+three nontrivial path components. -/
+example :
+    (FreeP.multAssocRight (P := binaryP)).toFunB binaryTriple
+      ⟨false, true, false, ⟨⟩⟩ =
+    ⟨⟨⟨false, ⟨⟩⟩, ⟨true, ⟨⟩⟩⟩, ⟨false, ⟨⟩⟩⟩ :=
+  rfl
+
 /-- A target signature with natural-number operation labels. -/
 abbrev natBinaryP : PFunctor := ⟨Nat, fun _ => Bool⟩
 
@@ -99,6 +136,13 @@ example : FreeP.mapShape reverseBranchLens controlTree =
   apply congrArg (FreeM.liftBind (P := natBinaryP) 0)
   funext branch
   cases branch <;> rfl
+
+/-- The mapped polynomial's backward component itself reverses both runtime
+branch choices. This pins path pullback directly, rather than observing it
+only through the mapped tree shape. -/
+example : (FreeP.map reverseBranchLens).toFunB controlTree
+    ⟨false, true, ⟨⟩⟩ = ⟨true, false, ⟨⟩⟩ :=
+  rfl
 
 /-- Mapping `FreeP` does not couple source and target position or direction
 universes. -/

--- a/docs/wiki/repo-map.md
+++ b/docs/wiki/repo-map.md
@@ -57,6 +57,9 @@ PFunctor/Lens/{Basic, Cartesian, State}
   -> PFunctor/Lens/{Composite, Distributivity, Factorization, Duoidal}
   -> PFunctor/{InternalHom, CartesianClosed, Adjunctions, Comonoid}
 
+PFunctor/Lens/Basic -> PFunctor/SubstMonoid
+PFunctor/{Free/Path, SubstMonoid} -> PFunctor/Free/Polynomial
+
 PFunctor/{Lens, Cofree, M} + Control/Coalgebra
   -> PFunctor/Dynamical/{Basic, Safety, Combinators, Run, Speedup, Trajectory}
   -> PFunctor/Dynamical/{Behavior, Simulation, RunN, DynComputation, IOMachine}


### PR DESCRIPTION
## Why this PR changed

The original free-polynomial construction was absorbed into `main` through
#64, including the substitution-monoid structure and its universal-property
foundation. Keeping the old branch would therefore duplicate already-landed
code and conflict with `main`.

This PR has been rebuilt on current `main` as the remaining review-hardening
slice.

## What remains in this PR

- Keep `FreeP.map_comp` out of the simp set so `Lens.mapObj_comp` determines
  the canonical object-level normal form.
- Add a direct `FreeP.map.toFunB` canary for a branch-reversing generator
  lens.
- Test multiplication path splitting with distinct Boolean outer and inner
  directions; the previous unary test could not detect swapping or copying.
- Test both sides of three-layer associativity on three independently
  observable backward path components.
- Record the actual `Lens.Basic -> SubstMonoid` and
  `{Free.Path, SubstMonoid} -> Free.Polynomial` import edges in both module-DAG
  documents.

## Review outcome

The landed construction correctly presents finite `P`-trees as positions,
complete paths as directions, and grafting/path splitting as substitution
multiplication. The full lens unit and associativity laws cover both forward
tree behavior and dependent backward path behavior. No mathematical or trust
boundary blocker was found.

This hardening delta specifically closes the remaining executable-coverage,
simp-normalization, and documentation issues found during review.

## Validation

- `./scripts/validate.sh --lint --test`
- `lake exe lint-style`
- direct compilation of `PolyFunTest/PFunctor/FreePolynomial.lean`
- `git diff --check`
- no added `sorry`, `admit`, `unsafe`, or axioms

## Stack

This remains the oldest open PR in the pattern-runs-on-matter train. #55 is
the next logical slice and will be compared against current `main` and
restacked after this PR merges.
