### PR TITLE
feat(pfunctor): sharpen free polynomial universal property

### DIFF
--- a/PolyFun/PFunctor/Free/Universal.lean
+++ b/PolyFun/PFunctor/Free/Universal.lean
@@ -205,29 +205,9 @@ including its backward path map. -/
 theorem foldLens_comp_mult :
     foldLens M l ∘ₗ mult (P := P) =
       M.mult ∘ₗ (foldLens M l ◃ₗ foldLens M l) := by
-  let hA : ∀ x : (FreeP P ◃ FreeP P).A,
-      (foldLens M l ∘ₗ mult (P := P)).toFunA x =
-        (M.mult ∘ₗ (foldLens M l ◃ₗ foldLens M l)).toFunA x :=
-    fun x => by
-      rcases x with ⟨s, next⟩
-      exact congrArg Sigma.fst (foldLens_mult_obj M l s next)
-  refine Lens.ext _ _ hA ?_
-  intro x
-  rcases x with ⟨s, next⟩
-  apply eq_of_heq
-  have hraw :
-      (foldLens M l ∘ₗ mult (P := P)).toFunB ⟨s, next⟩ ≍
-        (M.mult ∘ₗ (foldLens M l ◃ₗ foldLens M l)).toFunB
-          ⟨s, next⟩ :=
-    (Sigma.ext_iff.mp (foldLens_mult_obj M l s next)).2
-  have hcast :
-      (hA ⟨s, next⟩ ▸
-        (M.mult ∘ₗ (foldLens M l ◃ₗ foldLens M l)).toFunB
-          ⟨s, next⟩) ≍
-        (M.mult ∘ₗ (foldLens M l ◃ₗ foldLens M l)).toFunB
-          ⟨s, next⟩ :=
-    eqRec_heq_self _ _
-  exact hraw.trans hcast.symm
+  apply Lens.ext_mapObj
+  rintro ⟨s, next⟩
+  exact foldLens_mult_obj M l s next
 
 /-- Extend a generator lens uniquely to a substitution-monoid homomorphism
 out of the free substitution monoid. -/
@@ -256,18 +236,9 @@ theorem foldLens_comp_generator_obj (a : P.A) :
 /-- The free fold extends the supplied generator lens. -/
 theorem foldLens_comp_generator :
     foldLens M l ∘ₗ generator P = l := by
-  let hA : ∀ a, (foldLens M l ∘ₗ generator P).toFunA a =
-      l.toFunA a :=
-    fun a => congrArg Sigma.fst (foldLens_comp_generator_obj M l a)
-  refine Lens.ext _ _ hA ?_
+  apply Lens.ext_mapObj
   intro a
-  apply eq_of_heq
-  have hraw : (foldLens M l ∘ₗ generator P).toFunB a ≍
-      l.toFunB a :=
-    (Sigma.ext_iff.mp (foldLens_comp_generator_obj M l a)).2
-  have hcast : (hA a ▸ l.toFunB a) ≍ l.toFunB a :=
-    eqRec_heq_self _ _
-  exact hraw.trans hcast.symm
+  exact foldLens_comp_generator_obj M l a
 
 /-- Folding into the free substitution monoid with its own generator is the
 identity on every path-labelled free-tree object. -/
@@ -346,21 +317,8 @@ theorem foldLens_generator_comp (lPQ : Lens P Q) :
         (FreeP Q).Obj ((FreeP P).B s)) =
       ⟨(map lPQ).toFunA s, (map lPQ).toFunB s⟩ at h
     exact h
-  let hA : ∀ s,
-      (foldLens (substMonoid Q) (generator Q ∘ₗ lPQ)).toFunA s =
-        (map lPQ).toFunA s :=
-    fun s => congrArg Sigma.fst (hobj s)
-  refine Lens.ext _ _ hA ?_
-  intro s
-  apply eq_of_heq
-  have hraw :
-      (foldLens (substMonoid Q) (generator Q ∘ₗ lPQ)).toFunB s ≍
-        (map lPQ).toFunB s :=
-    (Sigma.ext_iff.mp (hobj s)).2
-  have hcast : (hA s ▸ (map lPQ).toFunB s) ≍
-      (map lPQ).toFunB s :=
-    eqRec_heq_self _ _
-  exact hraw.trans hcast.symm
+  apply Lens.ext_mapObj
+  exact hobj
 
 /-- `FreeP.map` packaged as the substitution-monoid homomorphism induced by
 a generator lens. -/
@@ -466,18 +424,16 @@ theorem extend_restrict
         ⟨foldShape M (restrict M f) s,
           foldPath M (restrict M f) s⟩ at h
     exact h.symm
-  let hA : ∀ s, (foldLens M (restrict M f)).toFunA s =
-      f.toLens.toFunA s :=
-    fun s => congrArg Sigma.fst (hobj s)
-  refine Lens.ext _ _ hA ?_
-  intro s
-  apply eq_of_heq
-  have hraw : (foldLens M (restrict M f)).toFunB s ≍
-      f.toLens.toFunB s :=
-    (Sigma.ext_iff.mp (hobj s)).2
-  have hcast : (hA s ▸ f.toLens.toFunB s) ≍ f.toLens.toFunB s :=
-    eqRec_heq_self _ _
-  exact hraw.trans hcast.symm
+  apply Lens.ext_mapObj
+  exact hobj
+
+/-- A homomorphism out of the free substitution monoid is uniquely determined
+by its restriction to the generator polynomial. -/
+theorem extend_unique (f : SubstMonoid.Hom (substMonoid P) M)
+    (h : f.toLens ∘ₗ generator P = l) : f = extend M l := by
+  calc
+    f = extend M (restrict M f) := (extend_restrict M f).symm
+    _ = extend M l := congrArg (extend M) h
 
 /-- The universal property of the free substitution monoid: homomorphisms
 out of `substMonoid P` are equivalent to lenses out of the generator

--- a/PolyFun/PFunctor/Lens/Basic.lean
+++ b/PolyFun/PFunctor/Lens/Basic.lean
@@ -76,6 +76,25 @@ theorem mapObj_comp {P : PFunctor.{uA₁, uB₁}}
     mapObj (g ∘ₗ f) x = mapObj g (mapObj f x) :=
   rfl
 
+/-- Two lenses are equal when they act equally on every source position
+equipped with its identity direction labelling. This packages the dependent
+position equality and direction-map transport needed by `Lens.ext`. -/
+theorem ext_mapObj {P : PFunctor.{uA₁, uB₁}} {Q : PFunctor.{uA₂, uB₂}}
+    (l₁ l₂ : Lens P Q)
+    (h : ∀ a, mapObj l₁ (⟨a, id⟩ : P.Obj (P.B a)) =
+      mapObj l₂ ⟨a, id⟩) :
+    l₁ = l₂ := by
+  let hA : ∀ a, l₁.toFunA a = l₂.toFunA a :=
+    fun a => congrArg Sigma.fst (h a)
+  refine Lens.ext _ _ hA ?_
+  intro a
+  apply eq_of_heq
+  have hraw : l₁.toFunB a ≍ l₂.toFunB a :=
+    (Sigma.ext_iff.mp (h a)).2
+  have hcast : (hA a ▸ l₂.toFunB a) ≍ l₂.toFunB a :=
+    eqRec_heq_self _ _
+  exact hraw.trans hcast.symm
+
 /-- Diagrammatic composition of lenses: `l₁ ⨟ l₂` applies `l₁` first and `l₂`
 second, the book's left-to-right composition order, so `l₁ ⨟ l₂ = l₂ ∘ₗ l₁`.
 This is the same `⨟` used for machine sequential composition and throughout

--- a/PolyFunTest/PFunctor/FreeUniversal.lean
+++ b/PolyFunTest/PFunctor/FreeUniversal.lean
@@ -64,6 +64,12 @@ example (f : SubstMonoid.Hom (FreeP.substMonoid bitUnary) wordMonoid) :
     FreeP.extend wordMonoid (FreeP.restrict wordMonoid f) = f :=
   FreeP.extend_restrict wordMonoid f
 
+/-- Agreement on generators determines a homomorphism out of `FreeP`. -/
+example (f : SubstMonoid.Hom (FreeP.substMonoid bitUnary) wordMonoid)
+    (h : f.toLens ∘ₗ FreeP.generator bitUnary = bitToWord) :
+    f = FreeP.extend wordMonoid bitToWord :=
+  FreeP.extend_unique wordMonoid bitToWord f h
+
 /-- The packaged equivalence exposes both inverse laws. -/
 example : (FreeP.homEquiv wordMonoid).symm
     ((FreeP.homEquiv wordMonoid) (FreeP.extend wordMonoid bitToWord)) =
@@ -83,6 +89,15 @@ def oneBinaryNode : (FreeP binaryP).A :=
 the nontrivial backward component, not only the mapped shape. -/
 example : (FreeP.mapHom reverseBranchLens).toLens.toFunB oneBinaryNode
     ⟨false, ⟨⟩⟩ = ⟨true, ⟨⟩⟩ :=
+  rfl
+
+/-- The universal fold's backward interpreter splits a two-node target path
+through free multiplication and reverses both target branches. This pins
+`foldPath` directly, rather than restating `FreeP.map.toFunB`. -/
+example :
+    (FreeP.extend (FreeP.substMonoid natBinaryP)
+      (FreeP.generator natBinaryP ∘ₗ reverseBranchLens)).toLens.toFunB
+        controlTree ⟨false, true, ⟨⟩⟩ = ⟨true, false, ⟨⟩⟩ :=
   rfl
 
 /-- The polynomial fold is definitionally the existing `FreeM.liftM` fold on


### PR DESCRIPTION
## Why this PR changed

The original free-polynomial universal-property implementation was absorbed
into `main` through #64. Its old stacked history therefore duplicated landed
code and conflicted with the current repository.

This PR has been rebuilt on current `main` as the remaining API and proof
hardening from review.

## What remains in this PR

- Add `Lens.ext_mapObj`, a reusable dependent extensionality theorem for
  proving lens equality from equality on identity-labelled polynomial
  objects.
- Route four universal-property proofs through that abstraction, removing 80
  lines of repeated `HEq` and transport plumbing.
- Add `FreeP.extend_unique`: agreement on the one-node generators uniquely
  determines a homomorphism out of the free substitution monoid.
- Add a direct Boolean canary for `(FreeP.extend ...).toLens.toFunB` on a
  two-node tree, making path splitting and both branch reversals observable.

## Review outcome

The landed construction proves the genuine free-object property. `extend`
is a substitution-monoid homomorphism, `restrict` recovers its action on
generators, and the two inverse laws are established as full lens equalities,
including dependent backward direction maps. The uniqueness direction is
routed through `FreeM.liftM_natural`, which is the correct abstraction layer.

The existing homogeneous `SubstMonoid.Hom` universe boundary is preserved;
this PR makes no claim to generalize that upstream interface. No mathematical
or trust-boundary blocker was found.

## Validation

- `./scripts/validate.sh --lint --test`
- `lake exe lint-style`
- targeted builds of `Lens.Basic`, `Free.Universal`, and its producer tests
- `git diff --check`
- no added `sorry`, `admit`, `unsafe`, or axioms
- principal axiom footprints remain `propext`, `Classical.choice`, and
  `Quot.sound`

## Stack

This is now the oldest open PR in the pattern-runs-on-matter train. #56 is the
next semantic slice and develops finite vertices of polynomial M-types.
