### PR TITLE
feat(pfunctor): develop finite vertices of polynomial M-types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,7 @@ Imports flow strictly downward; cycles are a build error.
 PFunctor/{Basic, Bound, M, Equiv, Chart, Lens}
   → PFunctor/{Cofree, Trace}
   → PFunctor/Resumption
+Logic/HEq + PFunctor/{M, Lens/Basic} → PFunctor/M/Vertex
 PFunctor/Free/Basic
   → PFunctor/Free/Displayed
   → PFunctor/Free/{Path, Displayed/Decoration}

--- a/PolyFun.lean
+++ b/PolyFun.lean
@@ -157,6 +157,7 @@ import PolyFun.PFunctor.Lens.Duoidal
 import PolyFun.PFunctor.Lens.Factorization
 import PolyFun.PFunctor.Lens.State
 import PolyFun.PFunctor.M
+import PolyFun.PFunctor.M.Vertex
 import PolyFun.PFunctor.Resumption
 import PolyFun.PFunctor.SubstMonoid
 import PolyFun.PFunctor.SubstMonoid.Extension

--- a/PolyFun/Logic/HEq.lean
+++ b/PolyFun/Logic/HEq.lean
@@ -14,7 +14,24 @@ domain-specific developments.
 
 @[expose] public section
 
-universe u v
+universe u v w
+
+namespace PolyFun
+namespace Logic
+
+/-- Apply a dependent binary function to equal indices and heterogeneously
+equal arguments. -/
+theorem dependent_apply_heq
+    {A : Sort u} {B : A → Sort v} {C : A → Sort w}
+    (function : (a : A) → B a → C a)
+    {a a' : A} (ha : a = a') {b : B a} {b' : B a'} (hb : b ≍ b') :
+    function a b ≍ function a' b' := by
+  subst a'
+  cases hb
+  rfl
+
+end Logic
+end PolyFun
 
 namespace Prod
 

--- a/PolyFun/PFunctor/M/Vertex.lean
+++ b/PolyFun/PFunctor/M/Vertex.lean
@@ -132,6 +132,23 @@ theorem mapLens_corec {α : Type v} (l : Lens P Q) (step : α → P α)
     rfl
   · rfl
 
+/-! ## Dependent transport along tree equalities -/
+
+/-- Transport a root direction along an equality of its ambient M-type
+trees. -/
+def castDirection {tree tree' : M P} (h : tree = tree')
+    (direction : P.B (M.head tree)) : P.B (M.head tree') :=
+  cast (congrArg (fun current => P.B (M.head current)) h) direction
+
+/-- Selecting a transported direction in an equal M-type tree recovers the
+same child subtree. -/
+theorem children_castDirection {tree tree' : M P} (h : tree = tree')
+    (direction : P.B (M.head tree)) :
+    M.children tree direction =
+      M.children tree' (castDirection h direction) := by
+  subst h
+  rfl
+
 /-- A finite rooted vertex of an M-type tree. -/
 inductive Vertex : (t : M P) → Type (max uA uB) where
   /-- The root vertex. -/
@@ -391,6 +408,23 @@ theorem splitAt_fst_isPrefix (n : Nat) {t : M P} (vertex : Vertex t) :
 /-- Transport finite vertices along an equality of their ambient trees. -/
 def castEquiv {t t' : M P} (h : t = t') : Vertex t ≃ Vertex t' :=
   _root_.Equiv.cast (congrArg Vertex h)
+
+@[simp]
+theorem cast_root {t t' : M P} (h : t = t') :
+    cast (congrArg Vertex h) (.root t) = .root t' := by
+  subst h
+  rfl
+
+@[simp]
+theorem cast_child {t t' : M P} (h : t = t')
+    (direction : P.B (M.head t))
+    (next : Vertex (M.children t direction)) :
+    cast (congrArg Vertex h) (.child direction next) =
+      .child (M.castDirection h direction)
+        (cast (congrArg Vertex
+          (M.children_castDirection h direction)) next) := by
+  subst h
+  rfl
 
 @[simp]
 theorem castEquiv_rfl {t : M P} (vertex : Vertex t) :

--- a/PolyFun/PFunctor/M/Vertex.lean
+++ b/PolyFun/PFunctor/M/Vertex.lean
@@ -1,0 +1,485 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+module
+
+public import PolyFun.PFunctor.M
+public import PolyFun.PFunctor.Lens.Basic
+
+/-!
+# Finite vertices of polynomial M-types
+
+`M.Vertex t` is a finite rooted path selecting a vertex of the potentially
+infinite polynomial tree `t : M P`.  The root is a vertex, and a child
+direction followed by a finite vertex in that child subtree is a vertex of the
+original tree.
+
+The API exposes the selected rooted subtree, path concatenation, canonical
+splitting at a depth, prefix structure, and dependent transport.  These are
+the direction-level operations needed by the polynomial cofree comonoid: its
+comultiplication sends a tree to all of its rooted subtrees, while its backward
+map concatenates finite vertices.
+-/
+
+@[expose] public section
+
+universe uA uB uA₂ uB₂ uA₃ uB₃
+
+namespace PFunctor
+namespace M
+
+variable {P : PFunctor.{uA, uB}}
+
+/-! ## Mapping M-types along lenses -/
+
+variable {Q : PFunctor.{uA₂, uB₂}}
+
+/-- Map a potentially infinite polynomial tree along a lens. Target
+directions are pulled back through the lens to select the corresponding source
+child. -/
+def mapLens (l : Lens P Q) (tree : M P) : M Q :=
+  M.corec (fun source =>
+    ⟨l.toFunA (M.head source), fun direction =>
+      M.children source (l.toFunB (M.head source) direction)⟩) tree
+
+/-- One-step unfolding of `mapLens`. -/
+theorem dest_mapLens (l : Lens P Q) (tree : M P) :
+    M.dest (mapLens l tree) =
+      ⟨l.toFunA (M.head tree), fun direction =>
+        mapLens l (M.children tree
+          (l.toFunB (M.head tree) direction))⟩ := by
+  simpa only [mapLens] using M.dest_corec_apply
+    (fun source : M P =>
+      ⟨l.toFunA (M.head source), fun direction =>
+        M.children source (l.toFunB (M.head source) direction)⟩) tree
+
+/-- The root position of a mapped M-type tree. -/
+theorem head_mapLens (l : Lens P Q) (tree : M P) :
+    M.head (mapLens l tree) = l.toFunA (M.head tree) :=
+  congrArg Sigma.fst (dest_mapLens l tree)
+
+/-- Pull a root direction of a mapped tree back to the source root. -/
+def pullDirection (l : Lens P Q) (tree : M P)
+    (direction : Q.B (M.head (mapLens l tree))) : P.B (M.head tree) :=
+  l.toFunB (M.head tree)
+    (cast (congrArg Q.B (head_mapLens l tree)) direction)
+
+/-- Selecting a child after mapping agrees with mapping the source child
+selected by the pulled-back direction. -/
+theorem children_mapLens (l : Lens P Q) (tree : M P)
+    (direction : Q.B (M.head (mapLens l tree))) :
+    M.children (mapLens l tree) direction =
+      mapLens l (M.children tree (pullDirection l tree direction)) := by
+  have h := dest_mapLens l tree
+  have hA := congrArg Sigma.fst h
+  have hB := (Sigma.ext_iff.mp h).2
+  cases hA
+  exact congrFun (eq_of_heq hB) direction
+
+@[simp]
+theorem mapLens_id (tree : M P) : mapLens (Lens.id P) tree = tree := by
+  change M.corec M.dest tree = tree
+  exact M.corec_dest tree
+
+/-- Mapping M-type trees respects composition of polynomial lenses. -/
+theorem mapLens_comp {R : PFunctor.{uA₃, uB₃}} (g : Lens Q R)
+    (f : Lens P Q) (tree : M P) :
+    mapLens (g ∘ₗ f) tree = mapLens g (mapLens f tree) := by
+  change M.corec (fun source => Lens.mapObj (g ∘ₗ f) (M.dest source)) tree =
+    M.corec (fun source => Lens.mapObj g (M.dest source)) (mapLens f tree)
+  refine M.corec_eq_corec
+    (fun source => Lens.mapObj (g ∘ₗ f) (M.dest source))
+    (fun source => Lens.mapObj g (M.dest source))
+    (fun source mapped => mapped = mapLens f source)
+    tree (mapLens f tree) rfl ?_
+  rintro source _ rfl
+  rcases hsource : M.dest source with ⟨shape, children⟩
+  refine ⟨g.toFunA (f.toFunA shape),
+    fun direction => children ((g ∘ₗ f).toFunB shape direction),
+    fun direction => mapLens f
+      (children ((g ∘ₗ f).toFunB shape direction)), ?_, ?_, fun _ => rfl⟩
+  · simp only [Lens.mapObj]
+    rfl
+  · have hmapped : M.dest (mapLens f source) =
+        Q.map (mapLens f) (Lens.mapObj f (M.dest source)) := by
+      change M.dest
+          (M.corec (fun source => Lens.mapObj f (M.dest source)) source) = _
+      exact M.dest_corec _ _
+    rw [hmapped, hsource]
+    rfl
+
+/-- A finite rooted vertex of an M-type tree. -/
+inductive Vertex : (t : M P) → Type (max uA uB) where
+  /-- The root vertex. -/
+  | root (t : M P) : Vertex t
+  /-- Descend through one direction and continue in the selected child. -/
+  | child {t : M P} (direction : P.B (M.head t))
+      (next : Vertex (M.children t direction)) : Vertex t
+
+namespace Vertex
+
+/-- The rooted subtree selected by a finite vertex. -/
+def subtree : {t : M P} → Vertex t → M P
+  | _, .root t => t
+  | _, .child _ next => subtree next
+
+@[simp]
+theorem subtree_root (t : M P) : subtree (.root t) = t :=
+  rfl
+
+@[simp]
+theorem subtree_child {t : M P} (direction : P.B (M.head t))
+    (next : Vertex (M.children t direction)) :
+    subtree (.child direction next) = subtree next :=
+  rfl
+
+/-- The number of child edges from the root to a vertex. -/
+def depth : {t : M P} → Vertex t → Nat
+  | _, .root _ => 0
+  | _, .child _ next => depth next + 1
+
+@[simp]
+theorem depth_root (t : M P) : depth (.root t) = 0 :=
+  rfl
+
+@[simp]
+theorem depth_child {t : M P} (direction : P.B (M.head t))
+    (next : Vertex (M.children t direction)) :
+    depth (.child direction next) = depth next + 1 :=
+  rfl
+
+/-- Concatenate a vertex from `t` with a vertex in the selected rooted
+subtree. -/
+def append : {t : M P} → (initial : Vertex t) →
+    Vertex (subtree initial) → Vertex t
+  | _, .root _, suffix => suffix
+  | _, .child direction next, suffix =>
+      .child direction (append next suffix)
+
+@[simp]
+theorem append_root (t : M P) (suffix : Vertex t) :
+    append (.root t) suffix = suffix :=
+  rfl
+
+@[simp]
+theorem append_child {t : M P} (direction : P.B (M.head t))
+    (next : Vertex (M.children t direction))
+    (suffix : Vertex (subtree next)) :
+    append (.child direction next) suffix =
+      .child direction (append next suffix) :=
+  rfl
+
+@[simp]
+theorem append_root_right {t : M P} (vertex : Vertex t) :
+    append vertex (.root (subtree vertex)) = vertex := by
+  induction vertex with
+  | root => rfl
+  | child direction next ih =>
+      exact congrArg (Vertex.child direction) ih
+
+@[simp]
+theorem subtree_append {t : M P} (initial : Vertex t)
+    (suffix : Vertex (subtree initial)) :
+    subtree (append initial suffix) = subtree suffix := by
+  match initial with
+  | .root _ => rfl
+  | .child _ next => exact subtree_append next suffix
+
+@[simp]
+theorem depth_append {t : M P} (initial : Vertex t)
+    (suffix : Vertex (subtree initial)) :
+    depth (append initial suffix) = depth initial + depth suffix := by
+  match initial with
+  | .root _ =>
+      simp only [append_root, depth_root, Nat.zero_add]
+      rfl
+  | .child direction next =>
+      simp only [append_child, depth_child]
+      rw [depth_append next suffix]
+      exact Nat.add_right_comm (depth next) (depth suffix) 1
+
+theorem append_assoc {t : M P} (first : Vertex t)
+    (second : Vertex (subtree first))
+    (third : Vertex (subtree second)) :
+    append (append first second)
+        (cast (congrArg Vertex (subtree_append first second).symm) third) =
+      append first (append second third) := by
+  induction first with
+  | root => rfl
+  | child direction next ih =>
+      exact congrArg (Vertex.child direction) (ih second third)
+
+/-- Canonically split a vertex after at most `n` edges.  The first component
+is a prefix vertex of the original tree and the second is the residual vertex
+inside its selected subtree. -/
+def splitAt : (n : Nat) → {t : M P} → (vertex : Vertex t) →
+    Σ initial : Vertex t, Vertex (subtree initial)
+  | 0, t, vertex => ⟨.root t, vertex⟩
+  | _ + 1, t, .root _ => ⟨.root t, .root t⟩
+  | n + 1, _, .child direction next =>
+      let split := splitAt n next
+      ⟨.child direction split.1, split.2⟩
+
+@[simp]
+theorem splitAt_zero {t : M P} (vertex : Vertex t) :
+    splitAt 0 vertex = ⟨.root t, vertex⟩ :=
+  rfl
+
+@[simp]
+theorem splitAt_succ_root (n : Nat) (t : M P) :
+    splitAt (n + 1) (.root t) = ⟨.root t, .root t⟩ :=
+  rfl
+
+@[simp]
+theorem splitAt_succ_child (n : Nat) {t : M P}
+    (direction : P.B (M.head t))
+    (next : Vertex (M.children t direction)) :
+    splitAt (n + 1) (.child direction next) =
+      ⟨.child direction (splitAt n next).1, (splitAt n next).2⟩ :=
+  rfl
+
+/-- Recombining the canonical split recovers the original vertex. -/
+@[simp]
+theorem append_splitAt (n : Nat) {t : M P} (vertex : Vertex t) :
+    append (splitAt n vertex).1 (splitAt n vertex).2 = vertex := by
+  induction n generalizing t with
+  | zero => rfl
+  | succ n ih =>
+      cases vertex with
+      | root => rfl
+      | child direction next =>
+          exact congrArg (Vertex.child direction) (ih next)
+
+/-- The depth of the canonical prefix is `min n depth`. -/
+theorem depth_splitAt_fst (n : Nat) {t : M P} (vertex : Vertex t) :
+    depth (splitAt n vertex).1 = min n (depth vertex) := by
+  induction n generalizing t with
+  | zero => rfl
+  | succ n ih =>
+      cases vertex with
+      | root => simp
+      | child direction next =>
+          simp only [splitAt_succ_child, depth_child]
+          rw [ih]
+          omega
+
+/-- The residual depth is the original depth minus the split depth. -/
+theorem depth_splitAt_snd (n : Nat) {t : M P} (vertex : Vertex t) :
+    depth (splitAt n vertex).2 = depth vertex - n := by
+  induction n generalizing t with
+  | zero => simp
+  | succ n ih =>
+      cases vertex with
+      | root => simp
+      | child direction next =>
+          simp only [splitAt_succ_child, depth_child]
+          calc
+            depth (splitAt n next).2 = depth next - n := ih next
+            _ = depth next + 1 - (n + 1) := by omega
+
+/-- Splitting at the full depth yields the vertex itself followed by the root
+of its selected subtree. -/
+theorem splitAt_depth {t : M P} (vertex : Vertex t) :
+    splitAt (depth vertex) vertex =
+      ⟨vertex, .root (subtree vertex)⟩ := by
+  induction vertex with
+  | root => rfl
+  | child direction next ih =>
+      exact congrArg
+        (fun split : Σ initial : Vertex (M.children _ direction),
+            Vertex (subtree initial) =>
+          (⟨.child direction split.1, split.2⟩ :
+            Σ initial : Vertex _, Vertex (subtree initial))) ih
+
+/-- Descend one additional edge from an already selected vertex. -/
+def descend {t : M P} (vertex : Vertex t)
+    (direction : P.B (M.head (subtree vertex))) : Vertex t :=
+  append vertex (.child direction (.root (M.children (subtree vertex) direction)))
+
+@[simp]
+theorem subtree_descend {t : M P} (vertex : Vertex t)
+    (direction : P.B (M.head (subtree vertex))) :
+    subtree (descend vertex direction) =
+      M.children (subtree vertex) direction := by
+  simp [descend]
+
+@[simp]
+theorem depth_descend {t : M P} (vertex : Vertex t)
+    (direction : P.B (M.head (subtree vertex))) :
+    depth (descend vertex direction) = depth vertex + 1 := by
+  simp [descend]
+
+/-- The position label exposed at a selected vertex. -/
+def positionAt {t : M P} (vertex : Vertex t) : P.A :=
+  M.head (subtree vertex)
+
+@[simp]
+theorem positionAt_root (t : M P) : positionAt (.root t) = M.head t :=
+  rfl
+
+@[simp]
+theorem positionAt_child {t : M P} (direction : P.B (M.head t))
+    (next : Vertex (M.children t direction)) :
+    positionAt (.child direction next) = positionAt next :=
+  rfl
+
+/-- `initial ≤ vertex` means that `vertex` is obtained by appending a residual
+vertex to `initial`. -/
+def IsPrefix {t : M P} (initial vertex : Vertex t) : Prop :=
+  ∃ suffix : Vertex (subtree initial), append initial suffix = vertex
+
+@[simp]
+theorem root_isPrefix {t : M P} (vertex : Vertex t) :
+    IsPrefix (.root t) vertex :=
+  ⟨vertex, rfl⟩
+
+@[refl]
+theorem isPrefix_refl {t : M P} (vertex : Vertex t) :
+    IsPrefix vertex vertex :=
+  ⟨.root (subtree vertex), append_root_right vertex⟩
+
+@[trans]
+theorem IsPrefix.trans {t : M P} {first second third : Vertex t}
+    (hFirst : IsPrefix first second) (hSecond : IsPrefix second third) :
+    IsPrefix first third := by
+  rcases hFirst with ⟨middle, rfl⟩
+  rcases hSecond with ⟨last, hlast⟩
+  let hsub := subtree_append first middle
+  let last' : Vertex (subtree middle) :=
+    cast (congrArg Vertex hsub) last
+  refine ⟨append middle last', ?_⟩
+  have hround :
+      cast (congrArg Vertex hsub.symm) last' = last := by
+    simp [last']
+  calc
+    append first (append middle last') =
+        append (append first middle)
+          (cast (congrArg Vertex hsub.symm) last') :=
+      (append_assoc first middle last').symm
+    _ = append (append first middle) last := by rw [hround]
+    _ = third := hlast
+
+/-- The prefix returned by `splitAt` is a prefix of the original vertex. -/
+theorem splitAt_fst_isPrefix (n : Nat) {t : M P} (vertex : Vertex t) :
+    IsPrefix (splitAt n vertex).1 vertex :=
+  ⟨(splitAt n vertex).2, append_splitAt n vertex⟩
+
+/-- Transport finite vertices along an equality of their ambient trees. -/
+def castEquiv {t t' : M P} (h : t = t') : Vertex t ≃ Vertex t' :=
+  _root_.Equiv.cast (congrArg Vertex h)
+
+@[simp]
+theorem castEquiv_rfl {t : M P} (vertex : Vertex t) :
+    castEquiv rfl vertex = vertex :=
+  rfl
+
+@[simp]
+theorem depth_cast {t t' : M P} (h : t = t') (vertex : Vertex t) :
+    depth (cast (congrArg Vertex h) vertex) = depth vertex := by
+  subst h
+  rfl
+
+@[simp]
+theorem subtree_cast {t t' : M P} (h : t = t') (vertex : Vertex t) :
+    subtree (cast (congrArg Vertex h) vertex) = subtree vertex := by
+  subst h
+  rfl
+
+/-- Pull a finite vertex of a mapped M-type tree back through the generating
+lens. -/
+def pullMapLens (l : Lens P Q) (tree : M P) :
+    Vertex (M.mapLens l tree) → Vertex tree
+  | .root _ => .root tree
+  | .child direction next =>
+      let sourceDirection := M.pullDirection l tree direction
+      let childEq := M.children_mapLens l tree direction
+      .child sourceDirection
+        (pullMapLens l (M.children tree sourceDirection)
+          (cast (congrArg Vertex childEq) next))
+termination_by vertex => depth vertex
+decreasing_by
+  calc
+    depth (cast (congrArg Vertex childEq) next) = depth next :=
+      depth_cast childEq next
+    _ < depth (.child direction next) := Nat.lt_succ_self _
+
+@[simp]
+theorem pullMapLens_root (l : Lens P Q) (tree : M P) :
+    pullMapLens l tree (.root (M.mapLens l tree)) = .root tree :=
+  by rw [pullMapLens.eq_def]
+
+/-- Constructor equation for pulling a non-root vertex through a lens. -/
+@[simp]
+theorem pullMapLens_child (l : Lens P Q) (tree : M P)
+    (direction : Q.B (M.head (M.mapLens l tree)))
+    (next : Vertex (M.children (M.mapLens l tree) direction)) :
+    pullMapLens l tree (.child direction next) =
+      .child (M.pullDirection l tree direction)
+        (pullMapLens l
+          (M.children tree (M.pullDirection l tree direction))
+          (cast (congrArg Vertex (M.children_mapLens l tree direction)) next)) := by
+  rw [pullMapLens.eq_def]
+
+/-- Pulling a vertex through a lens preserves its finite depth. -/
+@[simp]
+theorem depth_pullMapLens (l : Lens P Q) (tree : M P)
+    (vertex : Vertex (M.mapLens l tree)) :
+    depth (pullMapLens l tree vertex) = depth vertex := by
+  induction hdepth : depth vertex using Nat.strong_induction_on generalizing tree with
+  | h n ih =>
+      rw [pullMapLens.eq_def]
+      cases vertex with
+      | root => simpa only [depth_root] using hdepth
+      | child direction next =>
+          let sourceDirection := M.pullDirection l tree direction
+          let childEq := M.children_mapLens l tree direction
+          simp only [depth_child]
+          rw [ih (depth (cast (congrArg Vertex childEq) next))]
+          · calc
+              depth (cast (congrArg Vertex childEq) next) + 1 =
+                  depth next + 1 :=
+                congrArg (· + 1) (depth_cast childEq next)
+              _ = _ := hdepth
+          · calc
+              depth (cast (congrArg Vertex childEq) next) = depth next :=
+                depth_cast childEq next
+              _ < depth next + 1 := Nat.lt_succ_self _
+              _ = _ := hdepth
+          · rfl
+
+/-- Pulling a mapped vertex selects exactly the source subtree whose image is
+the target subtree. -/
+@[simp]
+theorem subtree_pullMapLens (l : Lens P Q) (tree : M P)
+    (vertex : Vertex (M.mapLens l tree)) :
+    M.mapLens l (subtree (pullMapLens l tree vertex)) = subtree vertex := by
+  induction hdepth : depth vertex using Nat.strong_induction_on generalizing tree with
+  | h n ih =>
+      rw [pullMapLens.eq_def]
+      cases vertex with
+      | root => rfl
+      | child direction next =>
+          let sourceDirection := M.pullDirection l tree direction
+          let childEq := M.children_mapLens l tree direction
+          simp only [subtree_child]
+          calc
+            M.mapLens l
+                (subtree (pullMapLens l (M.children tree sourceDirection)
+                  (cast (congrArg Vertex childEq) next))) =
+                subtree (cast (congrArg Vertex childEq) next) := by
+              have hlt : depth (cast (congrArg Vertex childEq) next) < n := by
+                calc
+                  depth (cast (congrArg Vertex childEq) next) = depth next :=
+                    depth_cast childEq next
+                  _ < depth next + 1 := Nat.lt_succ_self _
+                  _ = _ := hdepth
+              exact ih (depth (cast (congrArg Vertex childEq) next)) hlt
+                (M.children tree sourceDirection)
+                (cast (congrArg Vertex childEq) next) rfl
+            _ = subtree next := subtree_cast childEq next
+
+end Vertex
+end M
+end PFunctor

--- a/PolyFun/PFunctor/M/Vertex.lean
+++ b/PolyFun/PFunctor/M/Vertex.lean
@@ -7,6 +7,7 @@ module
 
 public import PolyFun.PFunctor.M
 public import PolyFun.PFunctor.Lens.Basic
+import PolyFun.Logic.HEq
 
 /-!
 # Finite vertices of polynomial M-types
@@ -21,6 +22,13 @@ splitting at a depth, prefix structure, and dependent transport.  These are
 the direction-level operations needed by the polynomial cofree comonoid: its
 comultiplication sends a tree to all of its rooted subtrees, while its backward
 map concatenates finite vertices.
+
+This is the coinductive counterpart of `FreeM.Cursor`: both are finite
+prefixes selecting a residual tree.  Here `append`, `depth`, and `subtree`
+correspond to the cursor operations `comp`, `length`, and `residual`.
+`Vertex` keeps only the source tree as an index because the selected subtree
+is computed by `subtree`; this makes vertices the direct direction type of the
+cofree polynomial, at the cost of explicit transports when composing paths.
 -/
 
 @[expose] public section
@@ -40,9 +48,7 @@ variable {Q : PFunctor.{uA₂, uB₂}}
 directions are pulled back through the lens to select the corresponding source
 child. -/
 def mapLens (l : Lens P Q) (tree : M P) : M Q :=
-  M.corec (fun source =>
-    ⟨l.toFunA (M.head source), fun direction =>
-      M.children source (l.toFunB (M.head source) direction)⟩) tree
+  M.corec (fun source => l.mapObj (M.dest source)) tree
 
 /-- One-step unfolding of `mapLens`. -/
 theorem dest_mapLens (l : Lens P Q) (tree : M P) :
@@ -50,10 +56,8 @@ theorem dest_mapLens (l : Lens P Q) (tree : M P) :
       ⟨l.toFunA (M.head tree), fun direction =>
         mapLens l (M.children tree
           (l.toFunB (M.head tree) direction))⟩ := by
-  simpa only [mapLens] using M.dest_corec_apply
-    (fun source : M P =>
-      ⟨l.toFunA (M.head source), fun direction =>
-        M.children source (l.toFunB (M.head source) direction)⟩) tree
+  rw [mapLens, M.dest_corec_apply]
+  rfl
 
 /-- The root position of a mapped M-type tree. -/
 theorem head_mapLens (l : Lens P Q) (tree : M P) :
@@ -80,15 +84,12 @@ theorem children_mapLens (l : Lens P Q) (tree : M P)
 
 @[simp]
 theorem mapLens_id (tree : M P) : mapLens (Lens.id P) tree = tree := by
-  change M.corec M.dest tree = tree
-  exact M.corec_dest tree
+  simpa only [mapLens, Lens.mapObj_id] using M.corec_dest tree
 
 /-- Mapping M-type trees respects composition of polynomial lenses. -/
 theorem mapLens_comp {R : PFunctor.{uA₃, uB₃}} (g : Lens Q R)
     (f : Lens P Q) (tree : M P) :
     mapLens (g ∘ₗ f) tree = mapLens g (mapLens f tree) := by
-  change M.corec (fun source => Lens.mapObj (g ∘ₗ f) (M.dest source)) tree =
-    M.corec (fun source => Lens.mapObj g (M.dest source)) (mapLens f tree)
   refine M.corec_eq_corec
     (fun source => Lens.mapObj (g ∘ₗ f) (M.dest source))
     (fun source => Lens.mapObj g (M.dest source))
@@ -104,8 +105,6 @@ theorem mapLens_comp {R : PFunctor.{uA₃, uB₃}} (g : Lens Q R)
     rfl
   · have hmapped : M.dest (mapLens f source) =
         Q.map (mapLens f) (Lens.mapObj f (M.dest source)) := by
-      change M.dest
-          (M.corec (fun source => Lens.mapObj f (M.dest source)) source) = _
       exact M.dest_corec _ _
     rw [hmapped, hsource]
     rfl
@@ -115,9 +114,6 @@ theorem mapLens_corec {α : Type v} (l : Lens P Q) (step : α → P α)
     (seed : α) :
     mapLens l (M.corec step seed) =
       M.corec (fun state => Lens.mapObj l (step state)) seed := by
-  change M.corec (fun tree => Lens.mapObj l (M.dest tree))
-      (M.corec step seed) =
-    M.corec (fun state => Lens.mapObj l (step state)) seed
   refine M.corec_eq_corec
     (fun tree => Lens.mapObj l (M.dest tree))
     (fun state => Lens.mapObj l (step state))
@@ -147,15 +143,6 @@ theorem children_castDirection {tree tree' : M P} (h : tree = tree')
     M.children tree direction =
       M.children tree' (castDirection h direction) := by
   subst h
-  rfl
-
-private theorem dependent_apply_heq {A : Sort uA}
-    {B : A → Sort uB} {C : A → Sort uB₂}
-    (function : (a : A) → B a → C a)
-    {a a' : A} (ha : a = a') {b : B a} {b' : B a'} (hb : b ≍ b') :
-    function a b ≍ function a' b' := by
-  subst a'
-  cases hb
   rfl
 
 /-- Pulling a root direction through a composite lens is the same as pulling
@@ -191,7 +178,7 @@ theorem pullDirection_comp {R : PFunctor.{uA₃, uB₃}}
   have houtputs :
       g.toFunB (f.toFunA (M.head tree)) leftInput ≍
         g.toFunB (M.head (M.mapLens f tree)) rightInput :=
-    dependent_apply_heq g.toFunB
+    PolyFun.Logic.dependent_apply_heq g.toFunB
       (M.head_mapLens f tree).symm hinputs
   exact houtputs.trans (cast_heq _ _).symm
 
@@ -204,6 +191,10 @@ inductive Vertex : (t : M P) → Type (max uA uB) where
       (next : Vertex (M.children t direction)) : Vertex t
 
 namespace Vertex
+
+/-- Transport finite vertices along an equality of their ambient trees. -/
+def castEquiv {t t' : M P} (h : t = t') : Vertex t ≃ Vertex t' :=
+  _root_.Equiv.cast (congrArg Vertex h)
 
 /-- The rooted subtree selected by a finite vertex. -/
 def subtree : {t : M P} → Vertex t → M P
@@ -289,7 +280,7 @@ theorem append_assoc {t : M P} (first : Vertex t)
     (second : Vertex (subtree first))
     (third : Vertex (subtree second)) :
     append (append first second)
-        (cast (congrArg Vertex (subtree_append first second).symm) third) =
+        (castEquiv (subtree_append first second).symm third) =
       append first (append second third) := by
   induction first with
   | root => rfl
@@ -432,16 +423,15 @@ theorem IsPrefix.trans {t : M P} {first second third : Vertex t}
   rcases hFirst with ⟨middle, rfl⟩
   rcases hSecond with ⟨last, hlast⟩
   let hsub := subtree_append first middle
-  let last' : Vertex (subtree middle) :=
-    cast (congrArg Vertex hsub) last
+  let last' : Vertex (subtree middle) := castEquiv hsub last
   refine ⟨append middle last', ?_⟩
   have hround :
-      cast (congrArg Vertex hsub.symm) last' = last := by
-    simp [last']
+      castEquiv hsub.symm last' = last := by
+    simp [last', castEquiv]
   calc
     append first (append middle last') =
         append (append first middle)
-          (cast (congrArg Vertex hsub.symm) last') :=
+          (castEquiv hsub.symm last') :=
       (append_assoc first middle last').symm
     _ = append (append first middle) last := by rw [hround]
     _ = third := hlast
@@ -451,13 +441,9 @@ theorem splitAt_fst_isPrefix (n : Nat) {t : M P} (vertex : Vertex t) :
     IsPrefix (splitAt n vertex).1 vertex :=
   ⟨(splitAt n vertex).2, append_splitAt n vertex⟩
 
-/-- Transport finite vertices along an equality of their ambient trees. -/
-def castEquiv {t t' : M P} (h : t = t') : Vertex t ≃ Vertex t' :=
-  _root_.Equiv.cast (congrArg Vertex h)
-
 @[simp]
 theorem cast_root {t t' : M P} (h : t = t') :
-    cast (congrArg Vertex h) (.root t) = .root t' := by
+    castEquiv h (.root t) = .root t' := by
   subst h
   rfl
 
@@ -465,23 +451,11 @@ theorem cast_root {t t' : M P} (h : t = t') :
 theorem cast_child {t t' : M P} (h : t = t')
     (direction : P.B (M.head t))
     (next : Vertex (M.children t direction)) :
-    cast (congrArg Vertex h) (.child direction next) =
-      .child (M.castDirection h direction)
-        (cast (congrArg Vertex
-          (M.children_castDirection h direction)) next) := by
-  subst h
-  rfl
-
-@[simp]
-theorem castEquiv_child {t t' : M P} (h : t = t')
-    (direction : P.B (M.head t))
-    (next : Vertex (M.children t direction)) :
     castEquiv h (.child direction next) =
       .child (M.castDirection h direction)
-        (cast (congrArg Vertex
-          (M.children_castDirection h direction)) next) := by
-  change cast (congrArg Vertex h) (.child direction next) = _
-  exact cast_child h direction next
+        (castEquiv (M.children_castDirection h direction) next) := by
+  subst h
+  rfl
 
 @[simp]
 theorem castEquiv_rfl {t : M P} (vertex : Vertex t) :
@@ -490,38 +464,49 @@ theorem castEquiv_rfl {t : M P} (vertex : Vertex t) :
 
 @[simp]
 theorem depth_cast {t t' : M P} (h : t = t') (vertex : Vertex t) :
-    depth (cast (congrArg Vertex h) vertex) = depth vertex := by
+    depth (castEquiv h vertex) = depth vertex := by
   subst h
   rfl
 
 @[simp]
 theorem subtree_cast {t t' : M P} (h : t = t') (vertex : Vertex t) :
-    subtree (cast (congrArg Vertex h) vertex) = subtree vertex := by
+    subtree (castEquiv h vertex) = subtree vertex := by
   subst h
   rfl
 
+/-- Structural implementation of vertex pullback.  The equality records that
+the current target subtree is the image of the current source subtree, so the
+recursive call can follow the vertex constructor directly. -/
+def pullMapLensAux (l : Lens P Q) (tree : M P) :
+    (target : M Q) → target = M.mapLens l tree → Vertex target → Vertex tree
+  | _, _, .root _ => .root tree
+  | target, htarget, .child direction next =>
+      let mappedDirection := M.castDirection htarget direction
+      let sourceDirection := M.pullDirection l tree mappedDirection
+      let childEq := (M.children_castDirection htarget direction).trans
+        (M.children_mapLens l tree mappedDirection)
+      .child sourceDirection
+        (pullMapLensAux l (M.children tree sourceDirection)
+          (M.children target direction) childEq next)
+
 /-- Pull a finite vertex of a mapped M-type tree back through the generating
 lens. -/
-def pullMapLens (l : Lens P Q) (tree : M P) :
-    Vertex (M.mapLens l tree) → Vertex tree
-  | .root _ => .root tree
-  | .child direction next =>
-      let sourceDirection := M.pullDirection l tree direction
-      let childEq := M.children_mapLens l tree direction
-      .child sourceDirection
-        (pullMapLens l (M.children tree sourceDirection)
-          (cast (congrArg Vertex childEq) next))
-termination_by vertex => depth vertex
-decreasing_by
-  calc
-    depth (cast (congrArg Vertex childEq) next) = depth next :=
-      depth_cast childEq next
-    _ < depth (.child direction next) := Nat.lt_succ_self _
+def pullMapLens (l : Lens P Q) (tree : M P)
+    (vertex : Vertex (M.mapLens l tree)) : Vertex tree :=
+  pullMapLensAux l tree (M.mapLens l tree) rfl vertex
+
+private theorem pullMapLensAux_eq_pullMapLens (l : Lens P Q) (tree : M P)
+    (target : M Q) (htarget : target = M.mapLens l tree)
+    (vertex : Vertex target) :
+    pullMapLensAux l tree target htarget vertex =
+      pullMapLens l tree (castEquiv htarget vertex) := by
+  subst target
+  simp only [castEquiv_rfl, pullMapLens]
 
 @[simp]
 theorem pullMapLens_root (l : Lens P Q) (tree : M P) :
     pullMapLens l tree (.root (M.mapLens l tree)) = .root tree :=
-  by rw [pullMapLens.eq_def]
+  rfl
 
 /-- Constructor equation for pulling a non-root vertex through a lens. -/
 @[simp]
@@ -532,83 +517,69 @@ theorem pullMapLens_child (l : Lens P Q) (tree : M P)
       .child (M.pullDirection l tree direction)
         (pullMapLens l
           (M.children tree (M.pullDirection l tree direction))
-          (cast (congrArg Vertex (M.children_mapLens l tree direction)) next)) := by
-  rw [pullMapLens.eq_def]
+          (castEquiv (M.children_mapLens l tree direction) next)) := by
+  change
+    Vertex.child (M.pullDirection l tree direction)
+        (pullMapLensAux l
+          (M.children tree (M.pullDirection l tree direction))
+          (M.children (M.mapLens l tree) direction)
+          (M.children_mapLens l tree direction) next) = _
+  exact congrArg (Vertex.child (M.pullDirection l tree direction))
+    (pullMapLensAux_eq_pullMapLens l
+      (M.children tree (M.pullDirection l tree direction))
+      (M.children (M.mapLens l tree) direction)
+      (M.children_mapLens l tree direction) next)
+
+private theorem depth_pullMapLensAux (l : Lens P Q) (tree : M P)
+    (target : M Q) (htarget : target = M.mapLens l tree)
+    (vertex : Vertex target) :
+    depth (pullMapLensAux l tree target htarget vertex) = depth vertex := by
+  induction vertex generalizing tree with
+  | root => rfl
+  | child direction next ih =>
+      simp only [pullMapLensAux, depth_child]
+      exact congrArg (fun value => value + 1) (ih _ _)
 
 /-- Pulling a vertex through a lens preserves its finite depth. -/
 @[simp]
 theorem depth_pullMapLens (l : Lens P Q) (tree : M P)
     (vertex : Vertex (M.mapLens l tree)) :
-    depth (pullMapLens l tree vertex) = depth vertex := by
-  induction hdepth : depth vertex using Nat.strong_induction_on generalizing tree with
-  | h n ih =>
-      rw [pullMapLens.eq_def]
-      cases vertex with
-      | root => simpa only [depth_root] using hdepth
-      | child direction next =>
-          let sourceDirection := M.pullDirection l tree direction
-          let childEq := M.children_mapLens l tree direction
-          simp only [depth_child]
-          rw [ih (depth (cast (congrArg Vertex childEq) next))]
-          · calc
-              depth (cast (congrArg Vertex childEq) next) + 1 =
-                  depth next + 1 :=
-                congrArg (· + 1) (depth_cast childEq next)
-              _ = _ := hdepth
-          · calc
-              depth (cast (congrArg Vertex childEq) next) = depth next :=
-                depth_cast childEq next
-              _ < depth next + 1 := Nat.lt_succ_self _
-              _ = _ := hdepth
-          · rfl
+    depth (pullMapLens l tree vertex) = depth vertex :=
+  depth_pullMapLensAux l tree (M.mapLens l tree) rfl vertex
+
+private theorem subtree_pullMapLensAux (l : Lens P Q) (tree : M P)
+    (target : M Q) (htarget : target = M.mapLens l tree)
+    (vertex : Vertex target) :
+    M.mapLens l (subtree (pullMapLensAux l tree target htarget vertex)) =
+      subtree vertex := by
+  induction vertex generalizing tree with
+  | root => exact htarget.symm
+  | child direction next ih =>
+      simp only [pullMapLensAux, subtree_child]
+      exact ih _ _
 
 /-- Pulling a mapped vertex selects exactly the source subtree whose image is
 the target subtree. -/
 @[simp]
 theorem subtree_pullMapLens (l : Lens P Q) (tree : M P)
     (vertex : Vertex (M.mapLens l tree)) :
-    M.mapLens l (subtree (pullMapLens l tree vertex)) = subtree vertex := by
-  induction hdepth : depth vertex using Nat.strong_induction_on generalizing tree with
-  | h n ih =>
-      rw [pullMapLens.eq_def]
-      cases vertex with
-      | root => rfl
-      | child direction next =>
-          let sourceDirection := M.pullDirection l tree direction
-          let childEq := M.children_mapLens l tree direction
-          simp only [subtree_child]
-          calc
-            M.mapLens l
-                (subtree (pullMapLens l (M.children tree sourceDirection)
-                  (cast (congrArg Vertex childEq) next))) =
-                subtree (cast (congrArg Vertex childEq) next) := by
-              have hlt : depth (cast (congrArg Vertex childEq) next) < n := by
-                calc
-                  depth (cast (congrArg Vertex childEq) next) = depth next :=
-                    depth_cast childEq next
-                  _ < depth next + 1 := Nat.lt_succ_self _
-                  _ = _ := hdepth
-              exact ih (depth (cast (congrArg Vertex childEq) next)) hlt
-                (M.children tree sourceDirection)
-                (cast (congrArg Vertex childEq) next) rfl
-            _ = subtree next := subtree_cast childEq next
+    M.mapLens l (subtree (pullMapLens l tree vertex)) = subtree vertex :=
+  subtree_pullMapLensAux l tree (M.mapLens l tree) rfl vertex
 
-private theorem append_congr {tree : M P}
-    {initial initial' : Vertex tree} (hinitial : initial = initial')
-    {suffix : Vertex (subtree initial)}
-    {suffix' : Vertex (subtree initial')} (hsuffix : suffix ≍ suffix') :
-    append initial suffix = append initial' suffix' := by
-  subst initial'
-  cases hsuffix
-  rfl
-
-private theorem cast_append {tree tree' : M P} (h : tree = tree')
-    (initial : Vertex tree) (suffix : Vertex (subtree initial)) :
-    cast (congrArg Vertex h) (append initial suffix) =
-      append (cast (congrArg Vertex h) initial)
-        (cast (congrArg Vertex (subtree_cast h initial).symm) suffix) := by
-  subst h
-  rfl
+private theorem pullMapLensAux_append (l : Lens P Q) (tree : M P)
+    (target : M Q) (htarget : target = M.mapLens l tree)
+    (initial : Vertex target) (suffix : Vertex (subtree initial)) :
+    pullMapLensAux l tree target htarget (append initial suffix) =
+      append (pullMapLensAux l tree target htarget initial)
+        (pullMapLensAux l
+          (subtree (pullMapLensAux l tree target htarget initial))
+          (subtree initial)
+          (subtree_pullMapLensAux l tree target htarget initial).symm suffix) := by
+  induction initial generalizing tree with
+  | root => rfl
+  | child direction next ih =>
+      simp only [append_child, pullMapLensAux, subtree_child]
+      exact congrArg (Vertex.child _) (ih _ _ _)
 
 /-- Pulling a mapped finite path commutes with concatenation. The explicit
 transport puts the target suffix in the mapped copy of the selected source
@@ -620,292 +591,174 @@ theorem pullMapLens_append (l : Lens P Q) (tree : M P)
       append (pullMapLens l tree initial)
         (pullMapLens l (subtree (pullMapLens l tree initial))
           (castEquiv (subtree_pullMapLens l tree initial).symm suffix)) := by
-  change pullMapLens l tree (append initial suffix) =
-    append (pullMapLens l tree initial)
-      (pullMapLens l (subtree (pullMapLens l tree initial))
-        (cast (congrArg Vertex
-          (subtree_pullMapLens l tree initial).symm) suffix))
-  induction hdepth : depth initial using Nat.strong_induction_on generalizing tree with
-  | h n ih =>
-      cases initial with
-      | root =>
-          have hpulled :
-              pullMapLens l tree (.root (M.mapLens l tree)) =
-                .root tree := pullMapLens_root l tree
-          have hsource :
-              subtree (pullMapLens l tree (.root (M.mapLens l tree))) =
-                tree := by rw [hpulled, subtree_root]
-          have hinput :
-              cast (congrArg Vertex
-                  (subtree_pullMapLens l tree
-                    (.root (M.mapLens l tree))).symm) suffix ≍
-                suffix := cast_heq _ suffix
-          have hsuffix :
-              pullMapLens l
-                  (subtree (pullMapLens l tree
-                    (.root (M.mapLens l tree))))
-                  (cast (congrArg Vertex
-                    (subtree_pullMapLens l tree
-                      (.root (M.mapLens l tree))).symm) suffix) ≍
-                pullMapLens l tree suffix :=
-            dependent_apply_heq
-              (fun source : M P => pullMapLens l source) hsource hinput
-          calc
-            pullMapLens l tree
-                (append (.root (M.mapLens l tree)) suffix) =
-                pullMapLens l tree suffix := by rw [append_root]
-            _ = append (pullMapLens l tree (.root (M.mapLens l tree)))
-                (pullMapLens l
-                  (subtree (pullMapLens l tree
-                    (.root (M.mapLens l tree))))
-                  (cast (congrArg Vertex
-                    (subtree_pullMapLens l tree
-                      (.root (M.mapLens l tree))).symm) suffix)) := by
-              symm
-              calc
-                append (pullMapLens l tree (.root (M.mapLens l tree)))
-                    (pullMapLens l
-                      (subtree (pullMapLens l tree
-                        (.root (M.mapLens l tree))))
-                      (cast (congrArg Vertex
-                        (subtree_pullMapLens l tree
-                          (.root (M.mapLens l tree))).symm) suffix)) =
-                    append (.root tree) (pullMapLens l tree suffix) :=
-                  append_congr hpulled hsuffix
-                _ = pullMapLens l tree suffix := append_root _ _
-      | child direction next =>
-          simp only [subtree_child] at suffix
-          let sourceDirection := M.pullDirection l tree direction
-          let childEq := M.children_mapLens l tree direction
-          let sourceChild := M.children tree sourceDirection
-          let next' : Vertex (M.mapLens l sourceChild) :=
-            cast (congrArg Vertex childEq) next
-          let subtreeEq : subtree next' = subtree next :=
-            subtree_cast childEq next
-          let suffix' : Vertex (subtree next') :=
-            cast (congrArg Vertex subtreeEq.symm) suffix
-          have hlt : depth next' < n := by
-            calc
-              depth next' = depth next := depth_cast childEq next
-              _ < depth next + 1 := Nat.lt_succ_self _
-              _ = n := hdepth
-          have hrecursive := ih (depth next') hlt sourceChild next' suffix' rfl
-          let pulledNext := pullMapLens l sourceChild next'
-          let recursiveSuffix :=
-            pullMapLens l (subtree pulledNext)
-              (cast (congrArg Vertex
-                (subtree_pullMapLens l sourceChild next').symm) suffix')
-          have hleftInput :
-              cast (congrArg Vertex childEq) (append next suffix) =
-                append next' suffix' := by
-            exact cast_append childEq next suffix
-          have hleft :
-              pullMapLens l tree
-                  (append (.child direction next) suffix) =
-                .child sourceDirection
-                  (pullMapLens l sourceChild (append next' suffix')) := by
-            rw [append_child, pullMapLens_child]
-            exact congrArg (Vertex.child sourceDirection)
-              (congrArg (pullMapLens l sourceChild) hleftInput)
-          have hpulled :
-              pullMapLens l tree (.child direction next) =
-                .child sourceDirection pulledNext := by
-            exact pullMapLens_child l tree direction next
-          have hsource :
-              subtree (pullMapLens l tree (.child direction next)) =
-                subtree pulledNext := by
-            rw [hpulled, subtree_child]
-          have hinput :
-              cast (congrArg Vertex
-                    (subtree_pullMapLens l tree (.child direction next)).symm)
-                  suffix ≍
-                cast (congrArg Vertex
-                  (subtree_pullMapLens l sourceChild next').symm)
-                  suffix' := by
-            exact (cast_heq _ suffix).trans
-              (((cast_heq (congrArg Vertex subtreeEq.symm) suffix).symm).trans
-                (cast_heq _ suffix').symm)
-          have hsuffix :
-              pullMapLens l
-                  (subtree (pullMapLens l tree (.child direction next)))
-                  (cast (congrArg Vertex
-                    (subtree_pullMapLens l tree (.child direction next)).symm)
-                    suffix) ≍
-                recursiveSuffix := by
-            exact dependent_apply_heq
-              (fun source : M P => pullMapLens l source) hsource hinput
-          have hright :
-              append (pullMapLens l tree (.child direction next))
-                  (pullMapLens l
-                    (subtree (pullMapLens l tree (.child direction next)))
-                    (cast (congrArg Vertex
-                      (subtree_pullMapLens l tree (.child direction next)).symm)
-                      suffix)) =
-                .child sourceDirection (append pulledNext recursiveSuffix) := by
-            calc
-              append (pullMapLens l tree (.child direction next))
-                  (pullMapLens l
-                    (subtree (pullMapLens l tree (.child direction next)))
-                    (cast (congrArg Vertex
-                      (subtree_pullMapLens l tree (.child direction next)).symm)
-                      suffix)) =
-                  append (.child sourceDirection pulledNext) recursiveSuffix :=
-                append_congr hpulled hsuffix
-              _ = .child sourceDirection (append pulledNext recursiveSuffix) :=
-                append_child _ _ _
-          calc
-            pullMapLens l tree (append (.child direction next) suffix) =
-                .child sourceDirection
-                  (pullMapLens l sourceChild (append next' suffix')) := hleft
-            _ = .child sourceDirection (append pulledNext recursiveSuffix) :=
-              congrArg (Vertex.child sourceDirection) hrecursive
-            _ = append (pullMapLens l tree (.child direction next))
-                (pullMapLens l
-                  (subtree (pullMapLens l tree (.child direction next)))
-                  (cast (congrArg Vertex
-                    (subtree_pullMapLens l tree (.child direction next)).symm)
-                    suffix)) := hright.symm
+  have happend := pullMapLensAux_append l tree (M.mapLens l tree) rfl
+    initial suffix
+  unfold pullMapLens
+  rw [happend]
+  exact congrArg (append (pullMapLens l tree initial))
+    (pullMapLensAux_eq_pullMapLens l
+      (subtree (pullMapLens l tree initial)) (subtree initial)
+      (subtree_pullMapLens l tree initial).symm suffix)
 
 /-- Pulling finite vertices through the identity lens is the dependent
 identity transport induced by `M.mapLens_id`. -/
+private theorem pullMapLensAux_id (tree : M P) (target : M P)
+    (htarget : target = M.mapLens (Lens.id P) tree)
+    (vertex : Vertex target) :
+    pullMapLensAux (Lens.id P) tree target htarget vertex =
+      castEquiv (htarget.trans (M.mapLens_id tree)) vertex := by
+  induction vertex generalizing tree with
+  | @root target => rw [pullMapLensAux, cast_root]
+  | @child target direction next ih =>
+      let mappedDirection := M.castDirection htarget direction
+      let sourceDirection :=
+        M.pullDirection (Lens.id P) tree mappedDirection
+      let targetDirection :=
+        M.castDirection (htarget.trans (M.mapLens_id tree)) direction
+      let childEq := (M.children_castDirection htarget direction).trans
+        (M.children_mapLens (Lens.id P) tree mappedDirection)
+      have hmapped : mappedDirection ≍ direction := by
+        unfold mappedDirection M.castDirection
+        exact cast_heq _ direction
+      have hsource : sourceDirection ≍ direction := by
+        unfold sourceDirection M.pullDirection
+        change cast
+            (congrArg P.B (M.head_mapLens (Lens.id P) tree))
+            mappedDirection ≍ direction
+        exact (cast_heq
+          (congrArg P.B (M.head_mapLens (Lens.id P) tree))
+          mappedDirection).trans hmapped
+      have htargetDirection : targetDirection ≍ direction := by
+        unfold targetDirection M.castDirection
+        exact cast_heq _ direction
+      have hdirection : sourceDirection = targetDirection :=
+        eq_of_heq (hsource.trans htargetDirection.symm)
+      rw [pullMapLensAux, cast_child, Vertex.child.injEq]
+      refine ⟨hdirection, ?_⟩
+      have hrecursive := ih
+        (M.children tree sourceDirection)
+        childEq
+      exact (heq_of_eq hrecursive).trans
+        ((cast_heq _ next).trans (cast_heq _ next).symm)
+
 @[simp]
 theorem pullMapLens_id (tree : M P)
     (vertex : Vertex (M.mapLens (Lens.id P) tree)) :
     pullMapLens (Lens.id P) tree vertex =
-      cast (congrArg Vertex (M.mapLens_id tree)) vertex := by
-  induction hdepth : depth vertex using Nat.strong_induction_on generalizing tree with
-  | h n ih =>
-      cases vertex with
-      | root =>
-          rw [pullMapLens_root]
-          exact (cast_root (M.mapLens_id tree)).symm
-      | child direction next =>
-          let sourceDirection := M.pullDirection (Lens.id P) tree direction
-          let targetDirection := M.castDirection (M.mapLens_id tree) direction
-          let childEq := M.children_mapLens (Lens.id P) tree direction
-          have hsource : sourceDirection ≍ direction := by
-            unfold sourceDirection M.pullDirection
-            exact cast_heq
-              (congrArg P.B (M.head_mapLens (Lens.id P) tree)) direction
-          have htarget : targetDirection ≍ direction := by
-            unfold targetDirection M.castDirection
-            exact cast_heq
-              (congrArg (fun current => P.B (M.head current))
-                (M.mapLens_id tree)) direction
-          have hdirection : sourceDirection = targetDirection :=
-            eq_of_heq (hsource.trans htarget.symm)
-          rw [pullMapLens_child, cast_child (M.mapLens_id tree)]
-          rw [Vertex.child.injEq]
-          refine ⟨hdirection, ?_⟩
-          have hrecursive := ih
-            (depth (cast (congrArg Vertex childEq) next)) (by
-              calc
-                depth (cast (congrArg Vertex childEq) next) = depth next :=
-                  depth_cast childEq next
-                _ < depth next + 1 := Nat.lt_succ_self _
-                _ = n := hdepth)
-            (M.children tree sourceDirection)
-            (cast (congrArg Vertex childEq) next) rfl
-          exact (heq_of_eq hrecursive).trans
-            ((cast_heq _ (cast (congrArg Vertex childEq) next)).trans
-              ((cast_heq (congrArg Vertex childEq) next).trans
-                (cast_heq _ next).symm))
+      castEquiv (M.mapLens_id tree) vertex :=
+  pullMapLensAux_id tree (M.mapLens (Lens.id P) tree) rfl vertex
 
 /-- Pulling a finite vertex through a composite lens agrees with pulling it
 through the two lenses successively. -/
+private theorem pullMapLensAux_comp {R : PFunctor.{uA₃, uB₃}}
+    (g : Lens Q R) (f : Lens P Q) (tree : M P) (target : M R)
+    (htarget : target = M.mapLens (g ∘ₗ f) tree)
+    (vertex : Vertex target) :
+    pullMapLensAux (g ∘ₗ f) tree target htarget vertex =
+      pullMapLens f tree
+        (pullMapLens g (M.mapLens f tree)
+          (castEquiv
+            (htarget.trans (M.mapLens_comp g f tree)) vertex)) := by
+  induction vertex generalizing tree with
+  | @root target =>
+      rw [pullMapLensAux, cast_root, pullMapLens_root, pullMapLens_root]
+  | @child target direction next ih =>
+      let mappedDirection := M.castDirection htarget direction
+      let compositeDirection :=
+        M.pullDirection (g ∘ₗ f) tree mappedDirection
+      let combinedEq := htarget.trans (M.mapLens_comp g f tree)
+      let transportedDirection := M.castDirection combinedEq direction
+      let sequentialDirection := M.castDirection
+        (M.mapLens_comp g f tree) mappedDirection
+      have hsequential : sequentialDirection = transportedDirection := by
+        apply eq_of_heq
+        exact (cast_heq _ mappedDirection).trans
+          ((cast_heq _ direction).trans
+            (cast_heq _ direction).symm)
+      let gDirection :=
+        M.pullDirection g (M.mapLens f tree) transportedDirection
+      let fDirection := M.pullDirection f tree gDirection
+      have hdirection : compositeDirection = fDirection := by
+        calc
+          compositeDirection =
+              M.pullDirection f tree
+                (M.pullDirection g (M.mapLens f tree)
+                  sequentialDirection) :=
+            M.pullDirection_comp g f tree mappedDirection
+          _ = fDirection := by rw [hsequential]
+      rw [pullMapLensAux, cast_child, pullMapLens_child,
+        pullMapLens_child, Vertex.child.injEq]
+      refine ⟨hdirection, ?_⟩
+      let leftChildEq := (M.children_castDirection htarget direction).trans
+        (M.children_mapLens (g ∘ₗ f) tree mappedDirection)
+      let compositeChild := M.children tree compositeDirection
+      let sequentialChild := M.children tree fDirection
+      have hchildren : compositeChild = sequentialChild :=
+        congrArg (M.children tree) hdirection
+      let ambientChildEq := M.children_castDirection combinedEq direction
+      let gChildEq :=
+        M.children_mapLens g (M.mapLens f tree) transportedDirection
+      let fChildEq := M.children_mapLens f tree gDirection
+      let canonicalVertex :
+          Vertex (M.mapLens g (M.mapLens f compositeChild)) :=
+        castEquiv
+          (leftChildEq.trans (M.mapLens_comp g f compositeChild)) next
+      let actualGChild := M.children (M.mapLens f tree) gDirection
+      let actualVertex : Vertex (M.mapLens g actualGChild) :=
+        castEquiv gChildEq (castEquiv ambientChildEq next)
+      have hgChildren : M.mapLens f compositeChild = actualGChild := by
+        calc
+          M.mapLens f compositeChild = M.mapLens f sequentialChild :=
+            congrArg (M.mapLens f) hchildren
+          _ = actualGChild := fChildEq.symm
+      have hvertices : canonicalVertex ≍ actualVertex := by
+        have hcanonical : canonicalVertex ≍ next := by
+          unfold canonicalVertex castEquiv
+          exact cast_heq _ next
+        have hactual : actualVertex ≍ next := by
+          have hinner : castEquiv ambientChildEq next ≍ next := by
+            unfold castEquiv
+            exact cast_heq (congrArg Vertex ambientChildEq) next
+          have houter : actualVertex ≍ castEquiv ambientChildEq next := by
+            unfold actualVertex castEquiv
+            exact cast_heq (congrArg Vertex gChildEq)
+              (cast (congrArg Vertex ambientChildEq) next)
+          exact houter.trans hinner
+        exact hcanonical.trans hactual.symm
+      have hgResults :
+          pullMapLens g (M.mapLens f compositeChild) canonicalVertex ≍
+            pullMapLens g actualGChild actualVertex :=
+        PolyFun.Logic.dependent_apply_heq
+          (fun source : M Q => pullMapLens g source)
+          hgChildren hvertices
+      have hfInputs :
+          pullMapLens g (M.mapLens f compositeChild) canonicalVertex ≍
+            castEquiv fChildEq
+              (pullMapLens g actualGChild actualVertex) :=
+        hgResults.trans (by
+          unfold castEquiv
+          exact (cast_heq (congrArg Vertex fChildEq)
+            (pullMapLens g actualGChild actualVertex)).symm)
+      have hresults :
+          pullMapLens f compositeChild
+              (pullMapLens g (M.mapLens f compositeChild) canonicalVertex) ≍
+            pullMapLens f sequentialChild
+              (castEquiv fChildEq
+                (pullMapLens g actualGChild actualVertex)) :=
+        PolyFun.Logic.dependent_apply_heq
+          (fun source : M P => pullMapLens f source)
+          hchildren hfInputs
+      have hrecursive := ih compositeChild leftChildEq
+      exact (heq_of_eq hrecursive).trans hresults
+
 theorem pullMapLens_comp {R : PFunctor.{uA₃, uB₃}}
     (g : Lens Q R) (f : Lens P Q) (tree : M P)
     (vertex : Vertex (M.mapLens (g ∘ₗ f) tree)) :
     pullMapLens (g ∘ₗ f) tree vertex =
       pullMapLens f tree
         (pullMapLens g (M.mapLens f tree)
-          (cast (congrArg Vertex (M.mapLens_comp g f tree)) vertex)) := by
-  induction hdepth : depth vertex using Nat.strong_induction_on generalizing tree with
-  | h n ih =>
-      cases vertex with
-      | root =>
-          rw [cast_root (M.mapLens_comp g f tree)]
-          rw [pullMapLens_root, pullMapLens_root, pullMapLens_root]
-      | child direction next =>
-          rw [pullMapLens_child]
-          rw [cast_child (M.mapLens_comp g f tree)]
-          rw [pullMapLens_child, pullMapLens_child]
-          rw [Vertex.child.injEq]
-          refine ⟨M.pullDirection_comp g f tree direction, ?_⟩
-          let compositeDirection :=
-            M.pullDirection (g ∘ₗ f) tree direction
-          let transportedDirection :=
-            M.castDirection (M.mapLens_comp g f tree) direction
-          let gDirection :=
-            M.pullDirection g (M.mapLens f tree) transportedDirection
-          let fDirection := M.pullDirection f tree gDirection
-          have hdirection : compositeDirection = fDirection :=
-            M.pullDirection_comp g f tree direction
-          let compositeChild := M.children tree compositeDirection
-          let sequentialChild := M.children tree fDirection
-          have hchildren : compositeChild = sequentialChild :=
-            congrArg (M.children tree) hdirection
-          let compositeChildEq :=
-            M.children_mapLens (g ∘ₗ f) tree direction
-          let fChildEq :=
-            M.children_mapLens f tree gDirection
-          let ambientChildEq :=
-            M.children_castDirection (M.mapLens_comp g f tree) direction
-          let gChildEq :=
-            M.children_mapLens g (M.mapLens f tree) transportedDirection
-          let canonicalVertex :
-              Vertex (M.mapLens g (M.mapLens f compositeChild)) :=
-            cast (congrArg Vertex (M.mapLens_comp g f compositeChild))
-              (cast (congrArg Vertex compositeChildEq) next)
-          let actualGChild :=
-            M.children (M.mapLens f tree) gDirection
-          let actualVertex : Vertex (M.mapLens g actualGChild) :=
-            cast (congrArg Vertex gChildEq)
-              (cast (congrArg Vertex ambientChildEq) next)
-          have hgChildren : M.mapLens f compositeChild = actualGChild := by
-            calc
-              M.mapLens f compositeChild =
-                  M.mapLens f sequentialChild := congrArg (M.mapLens f) hchildren
-              _ = actualGChild := fChildEq.symm
-          have hvertices : canonicalVertex ≍ actualVertex := by
-            exact
-              ((cast_heq _
-                (cast (congrArg Vertex compositeChildEq) next)).trans
-                (cast_heq (congrArg Vertex compositeChildEq) next)).trans
-              (((cast_heq _
-                (cast (congrArg Vertex ambientChildEq) next)).trans
-                (cast_heq (congrArg Vertex ambientChildEq) next)).symm)
-          have hgResults :
-              pullMapLens g (M.mapLens f compositeChild) canonicalVertex ≍
-                pullMapLens g actualGChild actualVertex :=
-            dependent_apply_heq
-              (fun source : M Q => pullMapLens g source)
-              hgChildren hvertices
-          have hfInputs :
-              pullMapLens g (M.mapLens f compositeChild) canonicalVertex ≍
-                cast (congrArg Vertex fChildEq)
-                  (pullMapLens g actualGChild actualVertex) :=
-            hgResults.trans (cast_heq _ _).symm
-          have hresults :
-              pullMapLens f compositeChild
-                  (pullMapLens g (M.mapLens f compositeChild)
-                    canonicalVertex) ≍
-                pullMapLens f sequentialChild
-                  (cast (congrArg Vertex fChildEq)
-                    (pullMapLens g actualGChild actualVertex)) :=
-            dependent_apply_heq
-              (fun source : M P => pullMapLens f source)
-              hchildren hfInputs
-          have hrecursive := ih
-            (depth (cast (congrArg Vertex compositeChildEq) next)) (by
-              calc
-                depth (cast (congrArg Vertex compositeChildEq) next) =
-                    depth next := depth_cast compositeChildEq next
-                _ < depth next + 1 := Nat.lt_succ_self _
-                _ = n := hdepth)
-            compositeChild
-            (cast (congrArg Vertex compositeChildEq) next) rfl
-          exact (heq_of_eq hrecursive).trans hresults
+          (castEquiv (M.mapLens_comp g f tree) vertex)) :=
+  pullMapLensAux_comp g f tree (M.mapLens (g ∘ₗ f) tree) rfl vertex
 
 end Vertex
 end M

--- a/PolyFun/PFunctor/M/Vertex.lean
+++ b/PolyFun/PFunctor/M/Vertex.lean
@@ -196,6 +196,24 @@ namespace Vertex
 def castEquiv {t t' : M P} (h : t = t') : Vertex t ≃ Vertex t' :=
   _root_.Equiv.cast (congrArg Vertex h)
 
+/-- Successive vertex transports compose to transport along the composite tree
+equality. -/
+@[simp]
+theorem castEquiv_trans {t t' t'' : M P} (h : t = t') (h' : t' = t'')
+    (vertex : Vertex t) :
+    castEquiv h' (castEquiv h vertex) = castEquiv (h.trans h') vertex := by
+  subst t'
+  subst t''
+  rfl
+
+/-- Transporting a vertex forward and then back is the identity. -/
+@[simp 1100]
+theorem castEquiv_symm_apply {t t' : M P} (h : t = t')
+    (vertex : Vertex t) :
+    castEquiv h.symm (castEquiv h vertex) = vertex := by
+  subst t'
+  rfl
+
 /-- The rooted subtree selected by a finite vertex. -/
 def subtree : {t : M P} → Vertex t → M P
   | _, .root t => t
@@ -427,7 +445,7 @@ theorem IsPrefix.trans {t : M P} {first second third : Vertex t}
   refine ⟨append middle last', ?_⟩
   have hround :
       castEquiv hsub.symm last' = last := by
-    simp [last', castEquiv]
+    simp [last']
   calc
     append first (append middle last') =
         append (append first middle)

--- a/PolyFun/PFunctor/M/Vertex.lean
+++ b/PolyFun/PFunctor/M/Vertex.lean
@@ -149,6 +149,52 @@ theorem children_castDirection {tree tree' : M P} (h : tree = tree')
   subst h
   rfl
 
+private theorem dependent_apply_heq {A : Sort uA}
+    {B : A → Sort uB} {C : A → Sort uB₂}
+    (function : (a : A) → B a → C a)
+    {a a' : A} (ha : a = a') {b : B a} {b' : B a'} (hb : b ≍ b') :
+    function a b ≍ function a' b' := by
+  subst a'
+  cases hb
+  rfl
+
+/-- Pulling a root direction through a composite lens is the same as pulling
+it through the two lenses successively. -/
+theorem pullDirection_comp {R : PFunctor.{uA₃, uB₃}}
+    (g : Lens Q R) (f : Lens P Q) (tree : M P)
+    (direction : R.B (M.head (M.mapLens (g ∘ₗ f) tree))) :
+    M.pullDirection (g ∘ₗ f) tree direction =
+      M.pullDirection f tree
+        (M.pullDirection g (M.mapLens f tree)
+          (M.castDirection (M.mapLens_comp g f tree) direction)) := by
+  unfold M.pullDirection M.castDirection
+  apply eq_of_heq
+  change f.toFunB (M.head tree)
+      (g.toFunB (f.toFunA (M.head tree)) (cast _ direction)) ≍
+    f.toFunB (M.head tree)
+      (cast _ (g.toFunB (M.head (M.mapLens f tree))
+        (cast _ (cast _ direction))))
+  apply heq_of_eq
+  apply congrArg (f.toFunB (M.head tree))
+  apply eq_of_heq
+  let leftInput := cast
+    (congrArg R.B (M.head_mapLens (g ∘ₗ f) tree)) direction
+  let rightInput := cast
+    (congrArg R.B (M.head_mapLens g (M.mapLens f tree)))
+      (cast
+        (congrArg (fun current => R.B (M.head current))
+          (M.mapLens_comp g f tree)) direction)
+  have hinputs : leftInput ≍ rightInput :=
+    (cast_heq _ direction).trans
+      ((cast_heq _ (cast _ direction)).trans
+        (cast_heq _ direction)).symm
+  have houtputs :
+      g.toFunB (f.toFunA (M.head tree)) leftInput ≍
+        g.toFunB (M.head (M.mapLens f tree)) rightInput :=
+    dependent_apply_heq g.toFunB
+      (M.head_mapLens f tree).symm hinputs
+  exact houtputs.trans (cast_heq _ _).symm
+
 /-- A finite rooted vertex of an M-type tree. -/
 inductive Vertex : (t : M P) → Type (max uA uB) where
   /-- The root vertex. -/
@@ -535,6 +581,147 @@ theorem subtree_pullMapLens (l : Lens P Q) (tree : M P)
                 (M.children tree sourceDirection)
                 (cast (congrArg Vertex childEq) next) rfl
             _ = subtree next := subtree_cast childEq next
+
+/-- Pulling finite vertices through the identity lens is the dependent
+identity transport induced by `M.mapLens_id`. -/
+@[simp]
+theorem pullMapLens_id (tree : M P)
+    (vertex : Vertex (M.mapLens (Lens.id P) tree)) :
+    pullMapLens (Lens.id P) tree vertex =
+      cast (congrArg Vertex (M.mapLens_id tree)) vertex := by
+  induction hdepth : depth vertex using Nat.strong_induction_on generalizing tree with
+  | h n ih =>
+      cases vertex with
+      | root =>
+          rw [pullMapLens_root]
+          exact (cast_root (M.mapLens_id tree)).symm
+      | child direction next =>
+          let sourceDirection := M.pullDirection (Lens.id P) tree direction
+          let targetDirection := M.castDirection (M.mapLens_id tree) direction
+          let childEq := M.children_mapLens (Lens.id P) tree direction
+          have hsource : sourceDirection ≍ direction := by
+            unfold sourceDirection M.pullDirection
+            exact cast_heq
+              (congrArg P.B (M.head_mapLens (Lens.id P) tree)) direction
+          have htarget : targetDirection ≍ direction := by
+            unfold targetDirection M.castDirection
+            exact cast_heq
+              (congrArg (fun current => P.B (M.head current))
+                (M.mapLens_id tree)) direction
+          have hdirection : sourceDirection = targetDirection :=
+            eq_of_heq (hsource.trans htarget.symm)
+          rw [pullMapLens_child, cast_child (M.mapLens_id tree)]
+          rw [Vertex.child.injEq]
+          refine ⟨hdirection, ?_⟩
+          have hrecursive := ih
+            (depth (cast (congrArg Vertex childEq) next)) (by
+              calc
+                depth (cast (congrArg Vertex childEq) next) = depth next :=
+                  depth_cast childEq next
+                _ < depth next + 1 := Nat.lt_succ_self _
+                _ = n := hdepth)
+            (M.children tree sourceDirection)
+            (cast (congrArg Vertex childEq) next) rfl
+          exact (heq_of_eq hrecursive).trans
+            ((cast_heq _ (cast (congrArg Vertex childEq) next)).trans
+              ((cast_heq (congrArg Vertex childEq) next).trans
+                (cast_heq _ next).symm))
+
+/-- Pulling a finite vertex through a composite lens agrees with pulling it
+through the two lenses successively. -/
+theorem pullMapLens_comp {R : PFunctor.{uA₃, uB₃}}
+    (g : Lens Q R) (f : Lens P Q) (tree : M P)
+    (vertex : Vertex (M.mapLens (g ∘ₗ f) tree)) :
+    pullMapLens (g ∘ₗ f) tree vertex =
+      pullMapLens f tree
+        (pullMapLens g (M.mapLens f tree)
+          (cast (congrArg Vertex (M.mapLens_comp g f tree)) vertex)) := by
+  induction hdepth : depth vertex using Nat.strong_induction_on generalizing tree with
+  | h n ih =>
+      cases vertex with
+      | root =>
+          rw [cast_root (M.mapLens_comp g f tree)]
+          rw [pullMapLens_root, pullMapLens_root, pullMapLens_root]
+      | child direction next =>
+          rw [pullMapLens_child]
+          rw [cast_child (M.mapLens_comp g f tree)]
+          rw [pullMapLens_child, pullMapLens_child]
+          rw [Vertex.child.injEq]
+          refine ⟨M.pullDirection_comp g f tree direction, ?_⟩
+          let compositeDirection :=
+            M.pullDirection (g ∘ₗ f) tree direction
+          let transportedDirection :=
+            M.castDirection (M.mapLens_comp g f tree) direction
+          let gDirection :=
+            M.pullDirection g (M.mapLens f tree) transportedDirection
+          let fDirection := M.pullDirection f tree gDirection
+          have hdirection : compositeDirection = fDirection :=
+            M.pullDirection_comp g f tree direction
+          let compositeChild := M.children tree compositeDirection
+          let sequentialChild := M.children tree fDirection
+          have hchildren : compositeChild = sequentialChild :=
+            congrArg (M.children tree) hdirection
+          let compositeChildEq :=
+            M.children_mapLens (g ∘ₗ f) tree direction
+          let fChildEq :=
+            M.children_mapLens f tree gDirection
+          let ambientChildEq :=
+            M.children_castDirection (M.mapLens_comp g f tree) direction
+          let gChildEq :=
+            M.children_mapLens g (M.mapLens f tree) transportedDirection
+          let canonicalVertex :
+              Vertex (M.mapLens g (M.mapLens f compositeChild)) :=
+            cast (congrArg Vertex (M.mapLens_comp g f compositeChild))
+              (cast (congrArg Vertex compositeChildEq) next)
+          let actualGChild :=
+            M.children (M.mapLens f tree) gDirection
+          let actualVertex : Vertex (M.mapLens g actualGChild) :=
+            cast (congrArg Vertex gChildEq)
+              (cast (congrArg Vertex ambientChildEq) next)
+          have hgChildren : M.mapLens f compositeChild = actualGChild := by
+            calc
+              M.mapLens f compositeChild =
+                  M.mapLens f sequentialChild := congrArg (M.mapLens f) hchildren
+              _ = actualGChild := fChildEq.symm
+          have hvertices : canonicalVertex ≍ actualVertex := by
+            exact
+              ((cast_heq _
+                (cast (congrArg Vertex compositeChildEq) next)).trans
+                (cast_heq (congrArg Vertex compositeChildEq) next)).trans
+              (((cast_heq _
+                (cast (congrArg Vertex ambientChildEq) next)).trans
+                (cast_heq (congrArg Vertex ambientChildEq) next)).symm)
+          have hgResults :
+              pullMapLens g (M.mapLens f compositeChild) canonicalVertex ≍
+                pullMapLens g actualGChild actualVertex :=
+            dependent_apply_heq
+              (fun source : M Q => pullMapLens g source)
+              hgChildren hvertices
+          have hfInputs :
+              pullMapLens g (M.mapLens f compositeChild) canonicalVertex ≍
+                cast (congrArg Vertex fChildEq)
+                  (pullMapLens g actualGChild actualVertex) :=
+            hgResults.trans (cast_heq _ _).symm
+          have hresults :
+              pullMapLens f compositeChild
+                  (pullMapLens g (M.mapLens f compositeChild)
+                    canonicalVertex) ≍
+                pullMapLens f sequentialChild
+                  (cast (congrArg Vertex fChildEq)
+                    (pullMapLens g actualGChild actualVertex)) :=
+            dependent_apply_heq
+              (fun source : M P => pullMapLens f source)
+              hchildren hfInputs
+          have hrecursive := ih
+            (depth (cast (congrArg Vertex compositeChildEq) next)) (by
+              calc
+                depth (cast (congrArg Vertex compositeChildEq) next) =
+                    depth next := depth_cast compositeChildEq next
+                _ < depth next + 1 := Nat.lt_succ_self _
+                _ = n := hdepth)
+            compositeChild
+            (cast (congrArg Vertex compositeChildEq) next) rfl
+          exact (heq_of_eq hrecursive).trans hresults
 
 end Vertex
 end M

--- a/PolyFun/PFunctor/M/Vertex.lean
+++ b/PolyFun/PFunctor/M/Vertex.lean
@@ -473,6 +473,17 @@ theorem cast_child {t t' : M P} (h : t = t')
   rfl
 
 @[simp]
+theorem castEquiv_child {t t' : M P} (h : t = t')
+    (direction : P.B (M.head t))
+    (next : Vertex (M.children t direction)) :
+    castEquiv h (.child direction next) =
+      .child (M.castDirection h direction)
+        (cast (congrArg Vertex
+          (M.children_castDirection h direction)) next) := by
+  change cast (congrArg Vertex h) (.child direction next) = _
+  exact cast_child h direction next
+
+@[simp]
 theorem castEquiv_rfl {t : M P} (vertex : Vertex t) :
     castEquiv rfl vertex = vertex :=
   rfl
@@ -581,6 +592,179 @@ theorem subtree_pullMapLens (l : Lens P Q) (tree : M P)
                 (M.children tree sourceDirection)
                 (cast (congrArg Vertex childEq) next) rfl
             _ = subtree next := subtree_cast childEq next
+
+private theorem append_congr {tree : M P}
+    {initial initial' : Vertex tree} (hinitial : initial = initial')
+    {suffix : Vertex (subtree initial)}
+    {suffix' : Vertex (subtree initial')} (hsuffix : suffix ≍ suffix') :
+    append initial suffix = append initial' suffix' := by
+  subst initial'
+  cases hsuffix
+  rfl
+
+private theorem cast_append {tree tree' : M P} (h : tree = tree')
+    (initial : Vertex tree) (suffix : Vertex (subtree initial)) :
+    cast (congrArg Vertex h) (append initial suffix) =
+      append (cast (congrArg Vertex h) initial)
+        (cast (congrArg Vertex (subtree_cast h initial).symm) suffix) := by
+  subst h
+  rfl
+
+/-- Pulling a mapped finite path commutes with concatenation. The explicit
+transport puts the target suffix in the mapped copy of the selected source
+subtree. -/
+theorem pullMapLens_append (l : Lens P Q) (tree : M P)
+    (initial : Vertex (M.mapLens l tree))
+    (suffix : Vertex (subtree initial)) :
+    pullMapLens l tree (append initial suffix) =
+      append (pullMapLens l tree initial)
+        (pullMapLens l (subtree (pullMapLens l tree initial))
+          (castEquiv (subtree_pullMapLens l tree initial).symm suffix)) := by
+  change pullMapLens l tree (append initial suffix) =
+    append (pullMapLens l tree initial)
+      (pullMapLens l (subtree (pullMapLens l tree initial))
+        (cast (congrArg Vertex
+          (subtree_pullMapLens l tree initial).symm) suffix))
+  induction hdepth : depth initial using Nat.strong_induction_on generalizing tree with
+  | h n ih =>
+      cases initial with
+      | root =>
+          have hpulled :
+              pullMapLens l tree (.root (M.mapLens l tree)) =
+                .root tree := pullMapLens_root l tree
+          have hsource :
+              subtree (pullMapLens l tree (.root (M.mapLens l tree))) =
+                tree := by rw [hpulled, subtree_root]
+          have hinput :
+              cast (congrArg Vertex
+                  (subtree_pullMapLens l tree
+                    (.root (M.mapLens l tree))).symm) suffix ≍
+                suffix := cast_heq _ suffix
+          have hsuffix :
+              pullMapLens l
+                  (subtree (pullMapLens l tree
+                    (.root (M.mapLens l tree))))
+                  (cast (congrArg Vertex
+                    (subtree_pullMapLens l tree
+                      (.root (M.mapLens l tree))).symm) suffix) ≍
+                pullMapLens l tree suffix :=
+            dependent_apply_heq
+              (fun source : M P => pullMapLens l source) hsource hinput
+          calc
+            pullMapLens l tree
+                (append (.root (M.mapLens l tree)) suffix) =
+                pullMapLens l tree suffix := by rw [append_root]
+            _ = append (pullMapLens l tree (.root (M.mapLens l tree)))
+                (pullMapLens l
+                  (subtree (pullMapLens l tree
+                    (.root (M.mapLens l tree))))
+                  (cast (congrArg Vertex
+                    (subtree_pullMapLens l tree
+                      (.root (M.mapLens l tree))).symm) suffix)) := by
+              symm
+              calc
+                append (pullMapLens l tree (.root (M.mapLens l tree)))
+                    (pullMapLens l
+                      (subtree (pullMapLens l tree
+                        (.root (M.mapLens l tree))))
+                      (cast (congrArg Vertex
+                        (subtree_pullMapLens l tree
+                          (.root (M.mapLens l tree))).symm) suffix)) =
+                    append (.root tree) (pullMapLens l tree suffix) :=
+                  append_congr hpulled hsuffix
+                _ = pullMapLens l tree suffix := append_root _ _
+      | child direction next =>
+          simp only [subtree_child] at suffix
+          let sourceDirection := M.pullDirection l tree direction
+          let childEq := M.children_mapLens l tree direction
+          let sourceChild := M.children tree sourceDirection
+          let next' : Vertex (M.mapLens l sourceChild) :=
+            cast (congrArg Vertex childEq) next
+          let subtreeEq : subtree next' = subtree next :=
+            subtree_cast childEq next
+          let suffix' : Vertex (subtree next') :=
+            cast (congrArg Vertex subtreeEq.symm) suffix
+          have hlt : depth next' < n := by
+            calc
+              depth next' = depth next := depth_cast childEq next
+              _ < depth next + 1 := Nat.lt_succ_self _
+              _ = n := hdepth
+          have hrecursive := ih (depth next') hlt sourceChild next' suffix' rfl
+          let pulledNext := pullMapLens l sourceChild next'
+          let recursiveSuffix :=
+            pullMapLens l (subtree pulledNext)
+              (cast (congrArg Vertex
+                (subtree_pullMapLens l sourceChild next').symm) suffix')
+          have hleftInput :
+              cast (congrArg Vertex childEq) (append next suffix) =
+                append next' suffix' := by
+            exact cast_append childEq next suffix
+          have hleft :
+              pullMapLens l tree
+                  (append (.child direction next) suffix) =
+                .child sourceDirection
+                  (pullMapLens l sourceChild (append next' suffix')) := by
+            rw [append_child, pullMapLens_child]
+            exact congrArg (Vertex.child sourceDirection)
+              (congrArg (pullMapLens l sourceChild) hleftInput)
+          have hpulled :
+              pullMapLens l tree (.child direction next) =
+                .child sourceDirection pulledNext := by
+            exact pullMapLens_child l tree direction next
+          have hsource :
+              subtree (pullMapLens l tree (.child direction next)) =
+                subtree pulledNext := by
+            rw [hpulled, subtree_child]
+          have hinput :
+              cast (congrArg Vertex
+                    (subtree_pullMapLens l tree (.child direction next)).symm)
+                  suffix ≍
+                cast (congrArg Vertex
+                  (subtree_pullMapLens l sourceChild next').symm)
+                  suffix' := by
+            exact (cast_heq _ suffix).trans
+              (((cast_heq (congrArg Vertex subtreeEq.symm) suffix).symm).trans
+                (cast_heq _ suffix').symm)
+          have hsuffix :
+              pullMapLens l
+                  (subtree (pullMapLens l tree (.child direction next)))
+                  (cast (congrArg Vertex
+                    (subtree_pullMapLens l tree (.child direction next)).symm)
+                    suffix) ≍
+                recursiveSuffix := by
+            exact dependent_apply_heq
+              (fun source : M P => pullMapLens l source) hsource hinput
+          have hright :
+              append (pullMapLens l tree (.child direction next))
+                  (pullMapLens l
+                    (subtree (pullMapLens l tree (.child direction next)))
+                    (cast (congrArg Vertex
+                      (subtree_pullMapLens l tree (.child direction next)).symm)
+                      suffix)) =
+                .child sourceDirection (append pulledNext recursiveSuffix) := by
+            calc
+              append (pullMapLens l tree (.child direction next))
+                  (pullMapLens l
+                    (subtree (pullMapLens l tree (.child direction next)))
+                    (cast (congrArg Vertex
+                      (subtree_pullMapLens l tree (.child direction next)).symm)
+                      suffix)) =
+                  append (.child sourceDirection pulledNext) recursiveSuffix :=
+                append_congr hpulled hsuffix
+              _ = .child sourceDirection (append pulledNext recursiveSuffix) :=
+                append_child _ _ _
+          calc
+            pullMapLens l tree (append (.child direction next) suffix) =
+                .child sourceDirection
+                  (pullMapLens l sourceChild (append next' suffix')) := hleft
+            _ = .child sourceDirection (append pulledNext recursiveSuffix) :=
+              congrArg (Vertex.child sourceDirection) hrecursive
+            _ = append (pullMapLens l tree (.child direction next))
+                (pullMapLens l
+                  (subtree (pullMapLens l tree (.child direction next)))
+                  (cast (congrArg Vertex
+                    (subtree_pullMapLens l tree (.child direction next)).symm)
+                    suffix)) := hright.symm
 
 /-- Pulling finite vertices through the identity lens is the dependent
 identity transport induced by `M.mapLens_id`. -/

--- a/PolyFun/PFunctor/M/Vertex.lean
+++ b/PolyFun/PFunctor/M/Vertex.lean
@@ -25,7 +25,7 @@ map concatenates finite vertices.
 
 @[expose] public section
 
-universe uA uB uA₂ uB₂ uA₃ uB₃
+universe uA uB uA₂ uB₂ uA₃ uB₃ v
 
 namespace PFunctor
 namespace M
@@ -109,6 +109,28 @@ theorem mapLens_comp {R : PFunctor.{uA₃, uB₃}} (g : Lens Q R)
       exact M.dest_corec _ _
     rw [hmapped, hsource]
     rfl
+
+/-- Mapping commutes with M-type corecursion by mapping each coalgebra step. -/
+theorem mapLens_corec {α : Type v} (l : Lens P Q) (step : α → P α)
+    (seed : α) :
+    mapLens l (M.corec step seed) =
+      M.corec (fun state => Lens.mapObj l (step state)) seed := by
+  change M.corec (fun tree => Lens.mapObj l (M.dest tree))
+      (M.corec step seed) =
+    M.corec (fun state => Lens.mapObj l (step state)) seed
+  refine M.corec_eq_corec
+    (fun tree => Lens.mapObj l (M.dest tree))
+    (fun state => Lens.mapObj l (step state))
+    (fun tree state => tree = M.corec step state)
+    (M.corec step seed) seed rfl ?_
+  rintro tree state rfl
+  rcases hstep : step state with ⟨shape, children⟩
+  refine ⟨l.toFunA shape,
+    fun direction => M.corec step (children (l.toFunB shape direction)),
+    fun direction => children (l.toFunB shape direction), ?_, ?_, fun _ => rfl⟩
+  · rw [M.dest_corec_apply, hstep]
+    rfl
+  · rfl
 
 /-- A finite rooted vertex of an M-type tree. -/
 inductive Vertex : (t : M P) → Type (max uA uB) where

--- a/PolyFunTest/PFunctor/MVertex.lean
+++ b/PolyFunTest/PFunctor/MVertex.lean
@@ -209,6 +209,21 @@ example (P : PFunctor.{uA, uB}) {tree tree' : M P}
           (M.children_castDirection h direction) next) :=
   M.Vertex.cast_child h direction next
 
+/-- Vertex transport composes without exposing the underlying dependent
+cast. -/
+example (P : PFunctor.{uA, uB}) {tree tree' tree'' : M P}
+    (h : tree = tree') (h' : tree' = tree'')
+    (vertex : M.Vertex tree) :
+    M.Vertex.castEquiv h' (M.Vertex.castEquiv h vertex) =
+      M.Vertex.castEquiv (h.trans h') vertex := by
+  simp
+
+/-- Forward and backward vertex transports cancel. -/
+example (P : PFunctor.{uA, uB}) {tree tree' : M P}
+    (h : tree = tree') (vertex : M.Vertex tree) :
+    M.Vertex.castEquiv h.symm (M.Vertex.castEquiv h vertex) = vertex := by
+  simp
+
 /-- Contravariant vertex transport is itself functorial across fully
 independent polynomial universes. -/
 example (P : PFunctor.{uA, uB}) (Q : PFunctor.{uA₂, uB₂})

--- a/PolyFunTest/PFunctor/MVertex.lean
+++ b/PolyFunTest/PFunctor/MVertex.lean
@@ -83,29 +83,75 @@ abbrev natBinaryP : PFunctor := ⟨Nat, fun _ => Bool⟩
 def reverseBranchLens : Lens binaryP natBinaryP :=
   (fun label => if label then 1 else 0) ⇆ (fun _ branch => !branch)
 
-def mappedFalse : M.Vertex (M.mapLens reverseBranchLens binaryTree) :=
+/-- A one-edge prefix in the mapped tree. -/
+def mappedPrefix : M.Vertex (M.mapLens reverseBranchLens binaryTree) :=
   .child false (.root _)
+
+/-- A one-edge suffix below `mappedPrefix`. -/
+def mappedSuffix : M.Vertex (M.Vertex.subtree mappedPrefix) :=
+  .child true (.root _)
 
 /-- Pulling target branch `false` really selects source branch `true`. -/
 example :
-    match M.Vertex.pullMapLens reverseBranchLens binaryTree mappedFalse with
+    match M.Vertex.pullMapLens reverseBranchLens binaryTree mappedPrefix with
     | .root _ => False
     | .child direction _ => direction = true := by
-  rw [M.Vertex.pullMapLens.eq_def]
+  unfold mappedPrefix
+  rw [M.Vertex.pullMapLens_child]
+  rfl
+
+def pulledMappedPrefix : M.Vertex binaryTree :=
+  M.Vertex.pullMapLens reverseBranchLens binaryTree mappedPrefix
+
+def pulledMappedSuffix : M.Vertex (M.Vertex.subtree pulledMappedPrefix) :=
+  M.Vertex.pullMapLens reverseBranchLens
+    (M.Vertex.subtree pulledMappedPrefix)
+    (M.Vertex.castEquiv
+      (M.Vertex.subtree_pullMapLens
+        reverseBranchLens binaryTree mappedPrefix).symm mappedSuffix)
+
+/-- The concrete concatenation law keeps the reversed prefix before the
+reversed suffix. -/
+example :
+    M.Vertex.pullMapLens reverseBranchLens binaryTree
+        (M.Vertex.append mappedPrefix mappedSuffix) =
+      M.Vertex.append pulledMappedPrefix pulledMappedSuffix :=
+  M.Vertex.pullMapLens_append reverseBranchLens binaryTree
+    mappedPrefix mappedSuffix
+
+example :
+    match pulledMappedPrefix with
+    | .child direction _ => direction = true
+    | _ => False := by
+  unfold pulledMappedPrefix mappedPrefix
+  rw [M.Vertex.pullMapLens_child]
+  rfl
+
+def mappedChildSuffix : M.Vertex
+    (M.mapLens reverseBranchLens (M.children binaryTree true)) :=
+  .child true (.root _)
+
+example :
+    match M.Vertex.pullMapLens reverseBranchLens
+        (M.children binaryTree true) mappedChildSuffix with
+    | .child direction _ => direction = false
+    | _ => False := by
+  unfold mappedChildSuffix
+  rw [M.Vertex.pullMapLens_child]
   rfl
 
 /-- The transported path preserves its length and selects a mapped copy of
 the exact target subtree. -/
 example : M.Vertex.depth
-    (M.Vertex.pullMapLens reverseBranchLens binaryTree mappedFalse) = 1 := by
+    (M.Vertex.pullMapLens reverseBranchLens binaryTree mappedPrefix) = 1 := by
   rw [M.Vertex.depth_pullMapLens]
   rfl
 
 example : M.mapLens reverseBranchLens
       (M.Vertex.subtree
-        (M.Vertex.pullMapLens reverseBranchLens binaryTree mappedFalse)) =
-    M.Vertex.subtree mappedFalse :=
-  M.Vertex.subtree_pullMapLens reverseBranchLens binaryTree mappedFalse
+        (M.Vertex.pullMapLens reverseBranchLens binaryTree mappedPrefix)) =
+    M.Vertex.subtree mappedPrefix :=
+  M.Vertex.subtree_pullMapLens reverseBranchLens binaryTree mappedPrefix
 
 /-- Root-only behavior remains stable for a nullary signature. -/
 abbrev nullaryP : PFunctor := ⟨Unit, fun _ => Empty⟩
@@ -137,6 +183,20 @@ example (P : PFunctor.{uA, uB}) (Q : PFunctor.{uA₂, uB₂})
     (l : Lens P Q) (tree : M P) :
     M.Vertex (M.mapLens l tree) → M.Vertex tree :=
   M.Vertex.pullMapLens l tree
+
+/-- Pulling mapped vertices preserves prefix-then-suffix concatenation across
+independent source and target polynomial universes. -/
+example (P : PFunctor.{uA, uB}) (Q : PFunctor.{uA₂, uB₂})
+    (l : Lens P Q) (tree : M P)
+    (initial : M.Vertex (M.mapLens l tree))
+    (suffix : M.Vertex (M.Vertex.subtree initial)) :
+    M.Vertex.pullMapLens l tree (M.Vertex.append initial suffix) =
+      M.Vertex.append (M.Vertex.pullMapLens l tree initial)
+        (M.Vertex.pullMapLens l
+          (M.Vertex.subtree (M.Vertex.pullMapLens l tree initial))
+          (M.Vertex.castEquiv
+            (M.Vertex.subtree_pullMapLens l tree initial).symm suffix)) :=
+  M.Vertex.pullMapLens_append l tree initial suffix
 
 /-- Transport preserves the explicit root/child structure of a finite
 vertex, including the dependent child subtree. -/

--- a/PolyFunTest/PFunctor/MVertex.lean
+++ b/PolyFunTest/PFunctor/MVertex.lean
@@ -203,10 +203,10 @@ vertex, including the dependent child subtree. -/
 example (P : PFunctor.{uA, uB}) {tree tree' : M P}
     (h : tree = tree') (direction : P.B (M.head tree))
     (next : M.Vertex (M.children tree direction)) :
-    cast (congrArg M.Vertex h) (.child direction next) =
+    M.Vertex.castEquiv h (.child direction next) =
       .child (M.castDirection h direction)
-        (cast (congrArg M.Vertex
-          (M.children_castDirection h direction)) next) :=
+        (M.Vertex.castEquiv
+          (M.children_castDirection h direction) next) :=
   M.Vertex.cast_child h direction next
 
 /-- Contravariant vertex transport is itself functorial across fully
@@ -217,13 +217,13 @@ example (P : PFunctor.{uA, uB}) (Q : PFunctor.{uA₂, uB₂})
     M.Vertex.pullMapLens (g ∘ₗ f) tree vertex =
       M.Vertex.pullMapLens f tree
         (M.Vertex.pullMapLens g (M.mapLens f tree)
-          (cast (congrArg M.Vertex (M.mapLens_comp g f tree)) vertex)) :=
+          (M.Vertex.castEquiv (M.mapLens_comp g f tree) vertex)) :=
   M.Vertex.pullMapLens_comp g f tree vertex
 
 example (P : PFunctor.{uA, uB}) (tree : M P)
     (vertex : M.Vertex (M.mapLens (Lens.id P) tree)) :
     M.Vertex.pullMapLens (Lens.id P) tree vertex =
-      cast (congrArg M.Vertex (M.mapLens_id tree)) vertex :=
+      M.Vertex.castEquiv (M.mapLens_id tree) vertex :=
   M.Vertex.pullMapLens_id tree vertex
 
 end MVertexTest

--- a/PolyFunTest/PFunctor/MVertex.lean
+++ b/PolyFunTest/PFunctor/MVertex.lean
@@ -149,5 +149,22 @@ example (P : PFunctor.{uA, uB}) {tree tree' : M P}
           (M.children_castDirection h direction)) next) :=
   M.Vertex.cast_child h direction next
 
+/-- Contravariant vertex transport is itself functorial across fully
+independent polynomial universes. -/
+example (P : PFunctor.{uA, uB}) (Q : PFunctor.{uA₂, uB₂})
+    (R : PFunctor.{uA₃, uB₃}) (f : Lens P Q) (g : Lens Q R)
+    (tree : M P) (vertex : M.Vertex (M.mapLens (g ∘ₗ f) tree)) :
+    M.Vertex.pullMapLens (g ∘ₗ f) tree vertex =
+      M.Vertex.pullMapLens f tree
+        (M.Vertex.pullMapLens g (M.mapLens f tree)
+          (cast (congrArg M.Vertex (M.mapLens_comp g f tree)) vertex)) :=
+  M.Vertex.pullMapLens_comp g f tree vertex
+
+example (P : PFunctor.{uA, uB}) (tree : M P)
+    (vertex : M.Vertex (M.mapLens (Lens.id P) tree)) :
+    M.Vertex.pullMapLens (Lens.id P) tree vertex =
+      cast (congrArg M.Vertex (M.mapLens_id tree)) vertex :=
+  M.Vertex.pullMapLens_id tree vertex
+
 end MVertexTest
 end PFunctor

--- a/PolyFunTest/PFunctor/MVertex.lean
+++ b/PolyFunTest/PFunctor/MVertex.lean
@@ -1,0 +1,134 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+module
+
+public import PolyFun.PFunctor.M.Vertex
+
+/-!
+# Regression tests for finite M-type vertices
+
+These examples make path order and the backward direction of a lens
+observable.  They also exercise roots, canonical splitting, concatenation,
+and independent position/direction universes.
+-/
+
+@[expose] public section
+
+universe uA uB uA₂ uB₂ uA₃ uB₃
+
+namespace PFunctor
+namespace MVertexTest
+
+/-- A binary signature whose node labels and directions are both bits. -/
+abbrev binaryP : PFunctor := ⟨Bool, fun _ => Bool⟩
+
+/-- The state records the most recently selected branch. -/
+def binaryStep (history : List Bool) : binaryP (List Bool) :=
+  ⟨history.head?.getD false, fun direction => direction :: history⟩
+
+def binaryTreeAt (history : List Bool) : M binaryP :=
+  M.corec binaryStep history
+
+def binaryTree : M binaryP :=
+  binaryTreeAt []
+
+theorem head_binaryTreeAt (history : List Bool) :
+    M.head (binaryTreeAt history) = history.head?.getD false :=
+  congrArg Sigma.fst (M.dest_corec_apply binaryStep history)
+
+theorem children_binaryTreeAt (history : List Bool) (direction : Bool) :
+    M.children (binaryTreeAt history) direction =
+      binaryTreeAt (direction :: history) := by
+  have h := M.dest_corec_apply binaryStep history
+  have hA := congrArg Sigma.fst h
+  have hB := (Sigma.ext_iff.mp h).2
+  cases hA
+  exact congrFun (eq_of_heq hB) direction
+
+/-- A path that first selects `true`, then `false`. -/
+def depthTwo : M.Vertex binaryTree :=
+  .child true (.child false (.root _))
+
+example : M.Vertex.depth depthTwo = 2 :=
+  rfl
+
+/-- Subtree selection follows the directions in outer-to-inner order. -/
+example : M.head (M.Vertex.subtree depthTwo) = false := by
+  change M.head
+    (M.children (M.children (binaryTreeAt []) true) false) = false
+  rw [children_binaryTreeAt, children_binaryTreeAt, head_binaryTreeAt]
+  rfl
+
+/-- Splitting after one edge produces a one-edge prefix and residual. -/
+example : M.Vertex.depth (M.Vertex.splitAt 1 depthTwo).1 = 1 := by
+  rw [M.Vertex.depth_splitAt_fst]
+  decide
+
+example : M.Vertex.depth (M.Vertex.splitAt 1 depthTwo).2 = 1 := by
+  rw [M.Vertex.depth_splitAt_snd]
+  decide
+
+/-- Recombination pins the orientation of prefix followed by residual. -/
+example : M.Vertex.append (M.Vertex.splitAt 1 depthTwo).1
+    (M.Vertex.splitAt 1 depthTwo).2 = depthTwo :=
+  M.Vertex.append_splitAt 1 depthTwo
+
+/-- A target signature with natural-number node labels. -/
+abbrev natBinaryP : PFunctor := ⟨Nat, fun _ => Bool⟩
+
+/-- Map node labels to `0`/`1` and reverse target branches on the way back. -/
+def reverseBranchLens : Lens binaryP natBinaryP :=
+  (fun label => if label then 1 else 0) ⇆ (fun _ branch => !branch)
+
+def mappedFalse : M.Vertex (M.mapLens reverseBranchLens binaryTree) :=
+  .child false (.root _)
+
+/-- Pulling target branch `false` really selects source branch `true`. -/
+example :
+    match M.Vertex.pullMapLens reverseBranchLens binaryTree mappedFalse with
+    | .root _ => False
+    | .child direction _ => direction = true := by
+  rw [M.Vertex.pullMapLens.eq_def]
+  rfl
+
+/-- The transported path preserves its length and selects a mapped copy of
+the exact target subtree. -/
+example : M.Vertex.depth
+    (M.Vertex.pullMapLens reverseBranchLens binaryTree mappedFalse) = 1 := by
+  rw [M.Vertex.depth_pullMapLens]
+  rfl
+
+example : M.mapLens reverseBranchLens
+      (M.Vertex.subtree
+        (M.Vertex.pullMapLens reverseBranchLens binaryTree mappedFalse)) =
+    M.Vertex.subtree mappedFalse :=
+  M.Vertex.subtree_pullMapLens reverseBranchLens binaryTree mappedFalse
+
+/-- Root-only behavior remains stable for a nullary signature. -/
+abbrev nullaryP : PFunctor := ⟨Unit, fun _ => Empty⟩
+
+def nullaryTree : M nullaryP :=
+  M.corec (fun _ : Unit => ⟨(), Empty.elim⟩) ()
+
+example : M.Vertex.splitAt 7 (.root nullaryTree) =
+    ⟨.root nullaryTree, .root nullaryTree⟩ := by
+  rfl
+
+/-- Tree mapping leaves all three polynomial universe pairs independent. -/
+example (P : PFunctor.{uA, uB}) (Q : PFunctor.{uA₂, uB₂})
+    (R : PFunctor.{uA₃, uB₃}) (f : Lens P Q) (g : Lens Q R)
+    (tree : M P) :
+    M.mapLens (g ∘ₗ f) tree = M.mapLens g (M.mapLens f tree) :=
+  M.mapLens_comp g f tree
+
+/-- Vertex transport likewise does not couple source and target universes. -/
+example (P : PFunctor.{uA, uB}) (Q : PFunctor.{uA₂, uB₂})
+    (l : Lens P Q) (tree : M P) :
+    M.Vertex (M.mapLens l tree) → M.Vertex tree :=
+  M.Vertex.pullMapLens l tree
+
+end MVertexTest
+end PFunctor

--- a/PolyFunTest/PFunctor/MVertex.lean
+++ b/PolyFunTest/PFunctor/MVertex.lean
@@ -124,6 +124,14 @@ example (P : PFunctor.{uA, uB}) (Q : PFunctor.{uA₂, uB₂})
     M.mapLens (g ∘ₗ f) tree = M.mapLens g (M.mapLens f tree) :=
   M.mapLens_comp g f tree
 
+/-- Lens mapping fuses with an independently universe-polymorphic coalgebra. -/
+example {α : Type uA₃} (P : PFunctor.{uA, uB})
+    (Q : PFunctor.{uA₂, uB₂}) (l : Lens P Q) (step : α → P α)
+    (seed : α) :
+    M.mapLens l (M.corec step seed) =
+      M.corec (fun state => Lens.mapObj l (step state)) seed :=
+  M.mapLens_corec l step seed
+
 /-- Vertex transport likewise does not couple source and target universes. -/
 example (P : PFunctor.{uA, uB}) (Q : PFunctor.{uA₂, uB₂})
     (l : Lens P Q) (tree : M P) :

--- a/PolyFunTest/PFunctor/MVertex.lean
+++ b/PolyFunTest/PFunctor/MVertex.lean
@@ -138,5 +138,16 @@ example (P : PFunctor.{uA, uB}) (Q : PFunctor.{uA₂, uB₂})
     M.Vertex (M.mapLens l tree) → M.Vertex tree :=
   M.Vertex.pullMapLens l tree
 
+/-- Transport preserves the explicit root/child structure of a finite
+vertex, including the dependent child subtree. -/
+example (P : PFunctor.{uA, uB}) {tree tree' : M P}
+    (h : tree = tree') (direction : P.B (M.head tree))
+    (next : M.Vertex (M.children tree direction)) :
+    cast (congrArg M.Vertex h) (.child direction next) =
+      .child (M.castDirection h direction)
+        (cast (congrArg M.Vertex
+          (M.children_castDirection h direction)) next) :=
+  M.Vertex.cast_child h direction next
+
 end MVertexTest
 end PFunctor

--- a/docs/wiki/pfunctor.md
+++ b/docs/wiki/pfunctor.md
@@ -47,7 +47,7 @@ McBride 2010 / Dagand-McBride 2014 (displayed algebras / ornaments).
 | [`PolyFun/PFunctor/Basic.lean`](../../PolyFun/PFunctor/Basic.lean) | `PFunctor` core, `Obj`, sum / product / sigma / pi / tensor / composition, `Lens`, `selfMonomial`, ring-style `0` / `1` / `+` / `*`. |
 | [`PolyFun/PFunctor/Equiv/Basic.lean`](../../PolyFun/PFunctor/Equiv/Basic.lean) | Equivalences `P ≃ₚ Q` and canonical equivalences for sums, products, sigma / pi, tensor, composition, universe lifts. |
 | [`PolyFun/PFunctor/M.lean`](../../PolyFun/PFunctor/M.lean) | Extensions to Mathlib's `PFunctor.M` (M-type / final coalgebra) used downstream. |
-| [`PolyFun/PFunctor/M/Vertex.lean`](../../PolyFun/PFunctor/M/Vertex.lean) | Finite rooted vertices of an M-type tree: subtree selection, concatenation, canonical depth splitting, prefixes, dependent transport, and contravariant path mapping along lenses. |
+| [`PolyFun/PFunctor/M/Vertex.lean`](../../PolyFun/PFunctor/M/Vertex.lean) | Finite rooted vertices of an M-type tree: subtree selection, concatenation, canonical depth splitting, prefixes, dependent transport, and contravariant path mapping along lenses. This is the coinductive counterpart of `FreeM.Cursor`; the selected subtree is computed rather than stored as a second index so that vertices directly form the cofree polynomial's direction family. |
 | [`PolyFun/PFunctor/Bound.lean`](../../PolyFun/PFunctor/Bound.lean) | Roll bounds for `FreeM` (budget-based termination predicate). |
 
 ### Lenses and charts
@@ -130,7 +130,7 @@ displayed families, roll bounds) on top of the upstream type.
 | File | Purpose |
 |------|---------|
 | [`PolyFun/PFunctor/Cofree.lean`](../../PolyFun/PFunctor/Cofree.lean) | `CofreeC` (cofree comonad on a `PFunctor`), built from `PFunctor.M` of the `constProd` polynomial. The dual of `FreeM`. |
-| [`PolyFun/PFunctor/M/Vertex.lean`](../../PolyFun/PFunctor/M/Vertex.lean) | `M.Vertex t`, the finite path calculus selecting rooted subtrees of a potentially infinite `t : M P`; this supplies the direction type needed by the polynomial presentation of the cofree construction. |
+| [`PolyFun/PFunctor/M/Vertex.lean`](../../PolyFun/PFunctor/M/Vertex.lean) | `M.Vertex t`, the finite path calculus selecting rooted subtrees of a potentially infinite `t : M P`; unlike the doubly indexed `FreeM.Cursor`, the residual is the `subtree` projection, which is the indexing choice needed for the cofree polynomial's direction type. |
 | [`PolyFun/PFunctor/Trace.lean`](../../PolyFun/PFunctor/Trace.lean) | Polynomial-trace machinery shared between `PFunctor` and downstream layers. |
 
 ### Control helpers

--- a/docs/wiki/pfunctor.md
+++ b/docs/wiki/pfunctor.md
@@ -47,6 +47,7 @@ McBride 2010 / Dagand-McBride 2014 (displayed algebras / ornaments).
 | [`PolyFun/PFunctor/Basic.lean`](../../PolyFun/PFunctor/Basic.lean) | `PFunctor` core, `Obj`, sum / product / sigma / pi / tensor / composition, `Lens`, `selfMonomial`, ring-style `0` / `1` / `+` / `*`. |
 | [`PolyFun/PFunctor/Equiv/Basic.lean`](../../PolyFun/PFunctor/Equiv/Basic.lean) | Equivalences `P ≃ₚ Q` and canonical equivalences for sums, products, sigma / pi, tensor, composition, universe lifts. |
 | [`PolyFun/PFunctor/M.lean`](../../PolyFun/PFunctor/M.lean) | Extensions to Mathlib's `PFunctor.M` (M-type / final coalgebra) used downstream. |
+| [`PolyFun/PFunctor/M/Vertex.lean`](../../PolyFun/PFunctor/M/Vertex.lean) | Finite rooted vertices of an M-type tree: subtree selection, concatenation, canonical depth splitting, prefixes, dependent transport, and contravariant path mapping along lenses. |
 | [`PolyFun/PFunctor/Bound.lean`](../../PolyFun/PFunctor/Bound.lean) | Roll bounds for `FreeM` (budget-based termination predicate). |
 
 ### Lenses and charts
@@ -129,6 +130,7 @@ displayed families, roll bounds) on top of the upstream type.
 | File | Purpose |
 |------|---------|
 | [`PolyFun/PFunctor/Cofree.lean`](../../PolyFun/PFunctor/Cofree.lean) | `CofreeC` (cofree comonad on a `PFunctor`), built from `PFunctor.M` of the `constProd` polynomial. The dual of `FreeM`. |
+| [`PolyFun/PFunctor/M/Vertex.lean`](../../PolyFun/PFunctor/M/Vertex.lean) | `M.Vertex t`, the finite path calculus selecting rooted subtrees of a potentially infinite `t : M P`; this supplies the direction type needed by the polynomial presentation of the cofree construction. |
 | [`PolyFun/PFunctor/Trace.lean`](../../PolyFun/PFunctor/Trace.lean) | Polynomial-trace machinery shared between `PFunctor` and downstream layers. |
 
 ### Control helpers

--- a/docs/wiki/repo-map.md
+++ b/docs/wiki/repo-map.md
@@ -40,6 +40,7 @@ recorded in [`AGENTS.md`](../../AGENTS.md):
 PFunctor/{Basic, Bound, M, Equiv, Chart, Lens}
   -> PFunctor/{Cofree, Trace}
   -> PFunctor/Resumption
+Logic/HEq + PFunctor/{M, Lens/Basic} -> PFunctor/M/Vertex
 PFunctor/Free/Basic
   -> PFunctor/Free/Displayed
   -> PFunctor/Free/{Path, Displayed/Decoration}


### PR DESCRIPTION
## Context

The cofree polynomial has potentially infinite behavior trees as positions
and finite rooted vertices as directions. Mathlib provides the final-coalgebra
M-type `M P`; this PR adds the finite path calculus needed by the cofree
substitution comonoid in #61.

## What this PR adds

### Mapping M-types along lenses

- `M.mapLens`, defined by corecursion through `Lens.mapObj (M.dest tree)`.
- root and child computation laws, identity and composition, and fusion with
  `M.corec`.
- independent source, intermediate, and target universe pairs.

### Finite rooted vertices

- `M.Vertex tree`: the root or a finite sequence of child directions.
- `subtree`, `depth`, `append`, `splitAt`, `descend`, and prefix structure.
- `castEquiv` as the public dependent-transport boundary, with composition,
  cancellation, depth, subtree, root, and child laws.

### Contravariant transport

- `M.Vertex.pullMapLens`, pulling vertices of `M.mapLens l tree` back to
  vertices of `tree`.
- preservation of roots, depth, selected subtrees, concatenation, identity,
  and lens composition.
- equality-carrying structural recursion in `pullMapLensAux`, avoiding
  well-founded recursion and repeated transport boilerplate.

### Generic support

- the axiom-free Sort-level `PolyFun.Logic.dependent_apply_heq` lemma lives at
  its generic owner in `PolyFun.Logic.HEq`.

## Review outcome

The definitions have the required variance: node positions map forward,
target child directions pull back, and finite vertices consequently transport
contravariantly. `append` is outer-prefix followed by residual suffix;
`subtree_append`, `append_assoc`, and `pullMapLens_append` preserve that order.
The identity and composition laws account for the unavoidable equalities of
coinductively defined ambient trees.

The single-indexed `Vertex tree` design is deliberate. It computes the
residual using `subtree`, making it directly usable as the direction family
of `CofreeP`; `castEquiv` localizes the resulting dependent transports. This
is the coinductive counterpart of `FreeM.Cursor`, with
`append`/`depth`/`subtree` corresponding to
`comp`/`length`/`residual`.

No mathematical, abstraction-boundary, universe, executable-behavior, or
trust-boundary blocker was found.

## Falsifiable coverage

Producer tests cover branch-reversing lens transport, multi-edge path order,
subtree and depth preservation, split/recombine, append compatibility,
identity and composition across independent universes, and transport
composition/cancellation.

## Validation on the rebased head

- targeted source and producer-test build
- `./scripts/validate.sh --lint --test`
- `lake exe lint-style`
- generated-import and documentation-integrity checks
- `git diff --check` and trust scan
- principal laws depend only on the expected `propext`, `Classical.choice`,
  and `Quot.sound`; `dependent_apply_heq` is axiom-free

## Stack

- Base: current `main`, including merged #54 and #55.
- This is now the oldest open PR in the pattern-runs-on-matter train.
- Next: #61, which constructs the cofree polynomial substitution comonoid.
