### PR TITLE
Add dependent occurrence lookup and selected fork filtering

### DIFF
--- a/PolyFun/PFunctor/Free/Cursor/Fork.lean
+++ b/PolyFun/PFunctor/Free/Cursor/Fork.lean
@@ -51,6 +51,14 @@ def ofCompletion {target : P.A} {program : FreeM P α} {n : Nat}
   completion := completion
   path_eq := rfl
 
+@[simp] theorem ofCompletion_occurrence {target : P.A} {program : FreeM P α} {n : Nat}
+    {occ : Occurrence target program n} (completion : occ.Completion) :
+    (ofCompletion completion).occurrence = occ := rfl
+
+@[simp] theorem ofCompletion_completion {target : P.A} {program : FreeM P α} {n : Nat}
+    {occ : Occurrence target program n} (completion : occ.Completion) :
+    (ofCompletion completion).completion = completion := rfl
+
 /-- Locate the root occurrence of a path. -/
 def here {target : P.A}
     (next : P.B target → FreeM P α) (answer : P.B target)
@@ -306,6 +314,38 @@ def secondOutput (selected : SelectedForkView target program κ index) : α :=
 def outputs (selected : SelectedForkView target program κ index) : α × α :=
   (selected.firstOutput, selected.secondOutput)
 
+@[simp] theorem firstOutput_mk (label : κ)
+    (view : ForkView target program (index label)) :
+    firstOutput (⟨label, view⟩ : SelectedForkView target program κ index) =
+      output program view.firstPath := rfl
+
+@[simp] theorem secondOutput_mk (label : κ)
+    (view : ForkView target program (index label)) :
+    secondOutput (⟨label, view⟩ : SelectedForkView target program κ index) =
+      output program view.secondPath := rfl
+
+@[simp] theorem outputs_mk (label : κ)
+    (view : ForkView target program (index label)) :
+    outputs (⟨label, view⟩ : SelectedForkView target program κ index) =
+      (output program view.firstPath, output program view.secondPath) := rfl
+
+/-- Retain a selected fork only when it belongs to a fixed selector fiber,
+transporting its dependent view to that fiber. -/
+def forLabel [DecidableEq κ] (label : κ)
+    (selected : SelectedForkView target program κ index) :
+    Option (ForkView target program (index label)) :=
+  if h : selected.label = label then some (h ▸ selected.view) else none
+
+@[simp] theorem forLabel_mk_self [DecidableEq κ] (label : κ)
+    (view : ForkView target program (index label)) :
+    forLabel label (⟨label, view⟩ : SelectedForkView target program κ index) = some view := by
+  simp [forLabel]
+
+@[simp] theorem forLabel_mk_of_ne [DecidableEq κ] {label other : κ}
+    (hne : other ≠ label) (view : ForkView target program (index other)) :
+    forLabel label (⟨other, view⟩ : SelectedForkView target program κ index) = none := by
+  simp [forLabel, hne]
+
 end SelectedForkView
 
 /-- Dynamically select an occurrence from the first output and fork its
@@ -350,6 +390,16 @@ def filterMapLocateAndForkAt [DecidableEq P.A] {β : Type*}
   FreeM.map (fun view? => view?.bind observe)
     (locateAndForkAt target program n)
 
+/-- Dynamically select an occurrence and retain its label and typed fork view,
+discarding selected views rejected by a pure optional classifier. -/
+def filterMapLocateAndForkSelected [DecidableEq P.A] {κ β : Type*}
+    (target : P.A) (program : FreeM P α)
+    (select : α → Option κ) (index : κ → Nat)
+    (observe : SelectedForkView target program κ index → Option β) :
+    FreeM P (Option β) :=
+  FreeM.map (fun selected? => selected?.bind observe)
+    (locateAndForkSelected target program select index)
+
 /-- Mapping an observation after dynamic fork selection fuses into the
 path-dependent observer. -/
 theorem map_locateAndForkBy [DecidableEq P.A] {κ β γ : Type*}
@@ -377,6 +427,32 @@ theorem map_locateAndForkBy [DecidableEq P.A] {κ β γ : Type*}
       rfl
     · simp only [hlocate]
       rw [FreeM.bind_pure_comp, ← FreeM.comp_map]
+
+/-- The selected-filter presentation is the dynamic observer presentation
+with the selector label and typed view packaged before classification. -/
+theorem filterMapLocateAndForkSelected_eq_filterMapLocateAndForkBy
+    [DecidableEq P.A] {κ β : Type*}
+    (target : P.A) (program : FreeM P α)
+    (select : α → Option κ) (index : κ → Nat)
+    (observe : SelectedForkView target program κ index → Option β) :
+    filterMapLocateAndForkSelected target program select index observe =
+      filterMapLocateAndForkBy target program select index
+        (fun label view => observe ⟨label, view⟩) := by
+  unfold filterMapLocateAndForkSelected locateAndForkSelected
+  rw [map_locateAndForkBy]
+  unfold filterMapLocateAndForkBy
+  rw [map_locateAndForkBy]
+  apply congrArg (FreeM.bind (withPath program))
+  funext path
+  rcases select (output program path) with _ | label
+  · simp
+  · rcases hlocate : locateAt? target program path (index label) with _ | located
+    · simp only [hlocate]
+      rfl
+    · simp only [hlocate]
+      apply congrArg (fun f => FreeM.map f located.fork)
+      funext view
+      rfl
 
 /-- Eliminate a dynamically selected optional fork into its first path and
 one independently sampled completion. -/

--- a/PolyFun/PFunctor/Free/Cursor/Occurrence.lean
+++ b/PolyFun/PFunctor/Free/Cursor/Occurrence.lean
@@ -142,6 +142,18 @@ structure Completion (occ : Occurrence target program n) where
 def Completion.path {occ : Occurrence target program n} (completion : Completion occ) :
     Path program := occ.plug completion.answer completion.suffix
 
+/-- Looking up the focused occurrence on a completion's erased trace returns
+the answer stored by that completion. -/
+@[simp] theorem getAt?_trace_completion_path [DecidableEq P.A]
+    (occ : Occurrence target program n) (completion : Completion occ) :
+    PFunctor.TraceList.getAt? (Path.trace program completion.path) target n =
+      some completion.answer := by
+  rw [Completion.path, trace_plug]
+  simpa only [before_count] using
+    (PFunctor.TraceList.getAt?_append_self_occurrences
+      occ.before (Path.trace (occ.resume completion.answer) completion.suffix)
+        target completion.answer)
+
 /-- Execute the focused query and its residual, retaining the typed completion. -/
 def complete (occ : Occurrence target program n) : FreeM P (Completion occ) :=
   FreeM.liftBind target fun answer =>

--- a/PolyFun/PFunctor/Free/Cursor/Occurrence.lean
+++ b/PolyFun/PFunctor/Free/Cursor/Occurrence.lean
@@ -142,6 +142,10 @@ structure Completion (occ : Occurrence target program n) where
 def Completion.path {occ : Occurrence target program n} (completion : Completion occ) :
     Path program := occ.plug completion.answer completion.suffix
 
+@[simp] theorem Completion.path_mk (occ : Occurrence target program n)
+    (answer : P.B target) (suffix : Path (occ.resume answer)) :
+    Completion.path (occ := occ) ⟨answer, suffix⟩ = occ.plug answer suffix := rfl
+
 /-- Looking up the focused occurrence on a completion's erased trace returns
 the answer stored by that completion. -/
 @[simp] theorem getAt?_trace_completion_path [DecidableEq P.A]
@@ -196,6 +200,22 @@ def firstAnswer (view : ForkView target program n) : P.B target :=
 def secondAnswer (view : ForkView target program n) : P.B target :=
   view.second.answer
 
+@[simp] theorem firstPath_mk (occurrence : Occurrence target program n)
+    (first second : occurrence.Completion) :
+    firstPath ({ occurrence, first, second } : ForkView target program n) = first.path := rfl
+
+@[simp] theorem secondPath_mk (occurrence : Occurrence target program n)
+    (first second : occurrence.Completion) :
+    secondPath ({ occurrence, first, second } : ForkView target program n) = second.path := rfl
+
+@[simp] theorem firstAnswer_mk (occurrence : Occurrence target program n)
+    (first second : occurrence.Completion) :
+    firstAnswer ({ occurrence, first, second } : ForkView target program n) = first.answer := rfl
+
+@[simp] theorem secondAnswer_mk (occurrence : Occurrence target program n)
+    (first second : occurrence.Completion) :
+    secondAnswer ({ occurrence, first, second } : ForkView target program n) = second.answer := rfl
+
 /-- Extend both completions by one earlier occurrence of the target. -/
 def prependSame {next : P.B target → FreeM P α} (answer : P.B target) {n : Nat}
     (view : ForkView target (next answer) n) :
@@ -237,6 +257,14 @@ def complete : Split target program n → FreeM P (Path program)
   | .missing path => pure path
   | .found occurrence => occurrence.completePath
 
+omit [DecidableEq P.A] in
+@[simp] theorem complete_missing (path : Path program) :
+    complete (.missing path : Split target program n) = pure path := rfl
+
+omit [DecidableEq P.A] in
+@[simp] theorem complete_found (occurrence : Occurrence target program n) :
+    complete (.found occurrence) = occurrence.completePath := rfl
+
 /-- Independently complete a found occurrence twice. A certified missing
 split has no occurrence to fork and therefore returns `none`. -/
 def completeFork : Split target program n →
@@ -251,6 +279,10 @@ def completeFork : Split target program n →
               first := ⟨firstAnswer, firstSuffix⟩
               second := ⟨secondAnswer, secondSuffix⟩ })
               (withPath (occurrence.resume secondAnswer))
+
+omit [DecidableEq P.A] in
+@[simp] theorem completeFork_missing (path : Path program) :
+    completeFork (.missing path : Split target program n) = pure none := rfl
 
 omit [DecidableEq P.A] in
 /-- On a found occurrence, `completeFork` is two independent executions of

--- a/PolyFun/PFunctor/Trace.lean
+++ b/PolyFun/PFunctor/Trace.lean
@@ -78,6 +78,66 @@ def occurrences {P : PFunctor.{uA, uB}} [DecidableEq P.A]
     (target : P.A) (events : TraceList P) : Nat :=
   events.countP fun (event : P.Idx) => event.1 = target
 
+/-- The answer carried by the `n`-th event at `target`, if that occurrence exists. -/
+def getAt? {P : PFunctor.{uA, uB}} [DecidableEq P.A]
+    (events : TraceList P) (target : P.A) : Nat → Option (P.B target)
+  | n =>
+      match events, n with
+      | [], _ => none
+      | ⟨a, answer⟩ :: tail, 0 =>
+          if h : a = target then some (h ▸ answer) else getAt? tail target 0
+      | ⟨a, _⟩ :: tail, n + 1 =>
+          if a = target then getAt? tail target n else getAt? tail target (n + 1)
+
+@[simp] theorem getAt?_nil {P : PFunctor.{uA, uB}} [DecidableEq P.A]
+    (target : P.A) (n : Nat) :
+    getAt? ([] : TraceList P) target n = none := rfl
+
+@[simp] theorem getAt?_cons_self_zero {P : PFunctor.{uA, uB}} [DecidableEq P.A]
+    (target : P.A) (answer : P.B target) (tail : TraceList P) :
+    getAt? ((show P.Idx from ⟨target, answer⟩) :: tail) target 0 = some answer := by
+  simp [getAt?]
+
+@[simp] theorem getAt?_cons_self_succ {P : PFunctor.{uA, uB}} [DecidableEq P.A]
+    (target : P.A) (answer : P.B target) (tail : TraceList P) (n : Nat) :
+    getAt? ((show P.Idx from ⟨target, answer⟩) :: tail) target (n + 1) =
+      getAt? tail target n := by
+  simp [getAt?]
+
+@[simp] theorem getAt?_cons_of_ne {P : PFunctor.{uA, uB}} [DecidableEq P.A]
+    {a target : P.A} (hne : a ≠ target) (answer : P.B a) (tail : TraceList P) (n : Nat) :
+    getAt? ((show P.Idx from ⟨a, answer⟩) :: tail) target n = getAt? tail target n := by
+  cases n <;> simp [getAt?, hne]
+
+/-- A dependent trace lookup succeeds exactly for the counted occurrences. -/
+@[simp] theorem getAt?_isSome_iff_lt_occurrences
+    {P : PFunctor.{uA, uB}} [DecidableEq P.A]
+    (events : TraceList P) (target : P.A) (n : Nat) :
+    (getAt? events target n).isSome ↔ n < occurrences target events := by
+  induction events generalizing n with
+  | nil => simp [occurrences]
+  | cons event tail ih =>
+      rcases event with ⟨a, answer⟩
+      by_cases h : a = target
+      · subst a
+        cases n <;> simp [occurrences, ih]
+      · simp [occurrences, h, ih]
+
+/-- The event following a prefix is found at the prefix's occurrence count. -/
+theorem getAt?_append_self_occurrences
+    {P : PFunctor.{uA, uB}} [DecidableEq P.A]
+    (before after : TraceList P) (target : P.A) (answer : P.B target) :
+    getAt? (List.append before ((show P.Idx from ⟨target, answer⟩) :: after)) target
+      (occurrences target before) = some answer := by
+  induction before with
+  | nil => simp [occurrences]
+  | cons event before ih =>
+      rcases event with ⟨a, prefixAnswer⟩
+      by_cases h : a = target
+      · subst a
+        simpa [occurrences] using ih
+      · simpa [occurrences, h] using ih
+
 end TraceList
 
 /--

--- a/PolyFunTest/PFunctor/FreeCursorOccurrenceExamples.lean
+++ b/PolyFunTest/PFunctor/FreeCursorOccurrenceExamples.lean
@@ -82,6 +82,10 @@ example : nestedFork.firstAnswer = false := rfl
 
 example : nestedFork.secondAnswer = true := rfl
 
+example : PFunctor.TraceList.getAt? (Path.trace nestedProgram nestedFork.first.path)
+    ExampleOp.target 0 = some nestedFork.first.answer := by
+  exact Occurrence.getAt?_trace_completion_path nestedOccurrence nestedFork.first
+
 example : output nestedProgram nestedFork.firstPath = 101 := rfl
 
 example : output nestedProgram nestedFork.secondPath = 211 := rfl


### PR DESCRIPTION
## Summary

- add dependent trace lookup that preserves occurrence indices and answer types
- add projection and simplification lemmas for occurrence completions and fork views
- add selected-fork filtering for dynamically chosen occurrence fibers
- include a focused occurrence lookup example

## Testing

- lake build
- lake test
- lake lint
- git diff --check