### PR TITLE
Upstream dependent trace and free-tree root predicates

### DIFF
--- a/PolyFun/PFunctor/Basic.lean
+++ b/PolyFun/PFunctor/Basic.lean
@@ -91,15 +91,20 @@ instance search, keeping transitions over `univ` as ergonomic as bare functions.
 def univ : PFunctor.{u + 1, u} :=
   ⟨Type u, fun T => T⟩
 
-section ofFn
+section ofFamily
 
-/-- Construct a polynomial functor from just a function `B`, with `A` derived implicitly. -/
-@[simps]
-def ofFn {A : Type uA₁} (B : (a : A) → Type uB) : PFunctor.{uA₁, uB} where
+/-- Construct a polynomial functor from a dependent family of directions.
+
+The family's domain remains the position type, so this constructor is useful
+when an API keeps the position type explicit and passes only its direction
+family. It is the generic polynomial-functor form of interfaces such as an
+oracle specification `Query → Type`. -/
+@[reducible, simps]
+def ofFamily {A : Type uA₁} (B : (a : A) → Type uB) : PFunctor.{uA₁, uB} where
   A := A
   B := B
 
-end ofFn
+end ofFamily
 
 section Coprod
 instance {a} : IsEmpty (B 1 a) := inferInstanceAs (IsEmpty PEmpty)

--- a/PolyFun/PFunctor/Free/Basic.lean
+++ b/PolyFun/PFunctor/Free/Basic.lean
@@ -37,6 +37,32 @@ namespace FreeM
 
 variable {P : PFunctor.{uA, uB}} {α β γ : Type v}
 
+/-- Test only the root of a free polynomial tree.
+
+A leaf demands `leafPred` of its result, while an internal node demands
+`positionPred` of its exposed position. This deliberately does not recurse
+into the continuations; callers can quantify over paths or cursors when they
+need a whole-tree property. -/
+def RootSatisfies (positionPred : P.A → Prop) (leafPred : α → Prop) :
+    FreeM P α → Prop
+  | .pure result => leafPred result
+  | .liftBind position _ => positionPred position
+
+@[simp]
+theorem rootSatisfies_pure (positionPred : P.A → Prop) (leafPred : α → Prop)
+    (result : α) :
+    RootSatisfies positionPred leafPred (pure result : FreeM P α) =
+      leafPred result :=
+  rfl
+
+@[simp]
+theorem rootSatisfies_liftBind (positionPred : P.A → Prop) (leafPred : α → Prop)
+    (position : P.A) (next : P.B position → FreeM P α) :
+    RootSatisfies positionPred leafPred
+        ((FreeM.lift (P := P) position).bind next) =
+      positionPred position :=
+  rfl
+
 /-- Forward direction of the equivalence with `P.W` when the leaf type is empty: every `pure`
 case is unreachable, and every `liftBind` is reinterpreted as a W-node. -/
 def toW [IsEmpty α] : FreeM P α → P.W

--- a/PolyFun/PFunctor/Trace.lean
+++ b/PolyFun/PFunctor/Trace.lean
@@ -73,6 +73,29 @@ in turn is reducibly `List (Idx P)`.  This is the universal carrier for
 
 namespace TraceList
 
+/-- Every event in a trace carries a direction allowed at its position.
+
+The allowed directions remain fiber-indexed: checking an event `⟨a, b⟩`
+uses `allowed a`, so no equality casts or decidable equality on positions are
+needed. -/
+def DirectionsWithin {P : PFunctor.{uA, uB}}
+    (allowed : (a : P.A) → Set (P.B a)) (events : TraceList P) : Prop :=
+  ∀ event ∈ events, event.2 ∈ allowed event.1
+
+@[simp]
+theorem directionsWithin_nil {P : PFunctor.{uA, uB}}
+    (allowed : (a : P.A) → Set (P.B a)) :
+    DirectionsWithin allowed ([] : TraceList P) :=
+  fun _ event_mem => absurd event_mem List.not_mem_nil
+
+@[simp]
+theorem directionsWithin_cons {P : PFunctor.{uA, uB}}
+    (allowed : (a : P.A) → Set (P.B a)) (event : P.Idx)
+    (events : TraceList P) :
+    DirectionsWithin allowed (event :: events) ↔
+      event.2 ∈ allowed event.1 ∧ DirectionsWithin allowed events :=
+  List.forall_mem_cons
+
 /-- Number of events at a given position in an erased execution trace. -/
 def occurrences {P : PFunctor.{uA, uB}} [DecidableEq P.A]
     (target : P.A) (events : TraceList P) : Nat :=

--- a/PolyFunTest/PFunctor/TraceAndRootPredicates.lean
+++ b/PolyFunTest/PFunctor/TraceAndRootPredicates.lean
@@ -1,0 +1,57 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+module
+
+public import PolyFun.PFunctor.Free.Cursor
+public import PolyFun.PFunctor.Trace
+
+/-! # Producer tests for dependent trace and free-tree root predicates -/
+
+@[expose] public section
+
+universe uA uB v
+
+namespace PFunctor.PredicateExamples
+
+variable {P : PFunctor.{uA, uB}} {α : Type v}
+
+/-- A direction family reconstructs its polynomial while keeping both
+universes independent. -/
+example {A : Type uA} (B : A → Type uB) :
+    (PFunctor.ofFamily B).A = A ∧
+      (∀ a, (PFunctor.ofFamily B).B a = B a) := by
+  simp
+
+/-- The trace predicate accepts genuinely dependent direction fibers without
+requiring decidable equality on positions. -/
+example (allowed : (a : P.A) → Set (P.B a)) (a : P.A) (b : P.B a)
+    (tail : TraceList P) :
+    TraceList.DirectionsWithin allowed (⟨a, b⟩ :: tail) ↔
+      b ∈ allowed a ∧ TraceList.DirectionsWithin allowed tail := by
+  simp
+
+/-- Root satisfaction distinguishes leaves from exposed positions. -/
+example (positionPred : P.A → Prop) (leafPred : α → Prop) (result : α) :
+    FreeM.RootSatisfies positionPred leafPred (pure result : FreeM P α) =
+      leafPred result := rfl
+
+example (positionPred : P.A → Prop) (leafPred : α → Prop)
+    (position : P.A) (next : P.B position → FreeM P α) :
+    FreeM.RootSatisfies positionPred leafPred
+        ((FreeM.lift (P := P) position).bind next) =
+      positionPred position := rfl
+
+/-- A cursor descent changes the selected residual but introduces no separate
+cursor-level satisfaction semantics. -/
+example (positionPred : P.A → Prop) (leafPred : α → Prop)
+    {position : P.A} {next : P.B position → FreeM P α}
+    (direction : P.B position) (tail : FreeM.Cursor (next direction)) :
+    FreeM.RootSatisfies positionPred leafPred
+        (FreeM.Cursor.down direction tail).residual ↔
+      FreeM.RootSatisfies positionPred leafPred tail.residual := by
+  simp
+
+end PFunctor.PredicateExamples


### PR DESCRIPTION
## Summary

- rename `PFunctor.ofFn` to `PFunctor.ofFamily`, documenting the direction-family view used by interfaces such as `OracleSpec`
- keep `ofFamily` reducible, so replacing a literal `{ A := A, B := B }` construction preserves projection reduction at instance transparency
- add `PFunctor.TraceList.DirectionsWithin` with `nil`/`cons` simp laws, preserving dependent direction fibers without `DecidableEq` on positions
- add `PFunctor.FreeM.RootSatisfies` at the free-tree layer, with universe-polymorphic constructor laws stated in simp-normal form
- add producer tests covering independent universes, dependent traces, leaf/node behavior, and cursor residual descent

## Motivation

[VCVio#490](https://github.com/Verified-zkEVM/VCVio/pull/490) introduced equivalent helpers locally while reformulating traversal predicates using `FreeM.Cursor`. The trace filter is generic PolyFun functionality, while the cursor predicate actually depends only on the selected `FreeM` residual root. This PR puts each definition at its lowest correct abstraction layer and gives it domain-accurate naming.

`OracleSpec ι = ι → Type` is not a second polynomial representation: it is precisely a dependent direction family whose domain is the exposed position type. `PFunctor.ofFamily` is the generic constructor for that view; no additional `PFunctor.Family` wrapper is needed.

The reducibility annotation is part of this constructor's contract. Without it, an API that previously returned the literal PFunctor structure gains a semireducible layer, and projections such as `spec.toPFunctor.A` may stop reducing at the transparency level used by typeclass synthesis and tactics.

## Downstream canary

A local patch of VCVio#490 removes `TraceList.WithinOn` and `FreeM.Cursor.Sat`, rewrites traversal using `DirectionsWithin` and `RootSatisfies c.residual`, and defines `OracleSpec.toPFunctor spec := PFunctor.ofFamily spec`.

It also narrows symbolic-registry key normalization to the reducible abstraction wrappers. This avoids a Lean 4.32 `whnfEasyCases` panic caused by preprocessing arbitrary user programs.

On VCVio's pinned Lean 4.32 stack, `VCVio.OracleComp.Traversal`, `VCVio.CryptoFoundations.ReplayFork`, all program-logic regression examples, and the complete `Examples` library (2,966 jobs) pass. The previous `SimpleTwoServerPIR` panic is gone.

## Validation

Pinned Lean `v4.32.0`:

- `lake build PolyFunTest.PFunctor.TraceAndRootPredicates`
- `lake lint`
- `LAKE_ARTIFACT_CACHE=false ./scripts/validate.sh --test`

The full library build (8,811 jobs), umbrella-import check, documentation integrity, and complete `PolyFunTest` library pass. GitHub Actions also reruns these checks on the amended head.