### PR TITLE
feat(pfunctor): prove the cofree polynomial universal property

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,9 @@ PFunctor/Comonoid → PFunctor/Comonoid/Category
 PFunctor/{Cofree, Comonoid, M/Vertex}
   → PFunctor/Cofree/Polynomial
 
+PFunctor/{Cofree/Polynomial, Comonoid/Category}
+  → PFunctor/Cofree/Universal
+
 PFunctor/{Lens, Cofree, M} + Control/Coalgebra
   → PFunctor/Dynamical/{Basic, Safety, Combinators, Run, Speedup, Trajectory}
   → PFunctor/Dynamical/{Behavior, Simulation, RunN, DynComputation, IOMachine}

--- a/PolyFun.lean
+++ b/PolyFun.lean
@@ -117,6 +117,7 @@ import PolyFun.PFunctor.Category
 import PolyFun.PFunctor.Chart.Basic
 import PolyFun.PFunctor.Cofree
 import PolyFun.PFunctor.Cofree.Polynomial
+import PolyFun.PFunctor.Cofree.Universal
 import PolyFun.PFunctor.Comonoid
 import PolyFun.PFunctor.Comonoid.Category
 import PolyFun.PFunctor.Dynamical.Basic

--- a/PolyFun/PFunctor/Cofree/Universal.lean
+++ b/PolyFun/PFunctor/Cofree/Universal.lean
@@ -1,0 +1,821 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+module
+
+public import PolyFun.PFunctor.Cofree.Polynomial
+public import PolyFun.PFunctor.Comonoid.Category
+
+/-!
+# The universal property of the cofree polynomial comonoid
+
+For a polynomial `P`, the cofree comonoid `CofreeP.comonoid P` is right
+adjoint to the carrier-forgetful functor from polynomial comonoids.  Concretely,
+a lens from a comonoid carrier to `P` extends uniquely to a retrofunctor into
+the cofree comonoid.
+
+This file packages the adjunction at the hom-set level.  It does not install a
+bundled `CategoryTheory.Adjunction`: `PFunctor` currently has overlapping lens
+and chart category instances, whereas the concrete hom-set equivalence is
+unambiguous and is the API needed by downstream dynamical systems. Generic
+coiteration remains universe-polymorphic; only the retrofunctor packaging uses
+the common-maximum universe boundary currently required by `Comonoid.Hom`.
+-/
+
+@[expose] public section
+
+universe uA uB uA₂ uB₂ uCA uCB
+
+namespace PFunctor
+namespace CofreeP
+
+variable {P : PFunctor.{uA, uB}}
+
+/-! ## Cogeneration and coiteration -/
+
+/-- The one-layer projection from the cofree polynomial to its generator.
+It exposes the root position and pulls a generator direction back to the
+corresponding depth-one vertex.  This is `ε_P^{(1)}` in Spivak--Niu. -/
+def cogenerator (P : PFunctor.{uA, uB}) : Lens (CofreeP P) P where
+  toFunA := M.head
+  toFunB tree direction :=
+    .child direction (.root (M.children tree direction))
+
+@[simp]
+theorem cogenerator_toFunA (tree : M P) :
+    (cogenerator P).toFunA tree = M.head tree :=
+  rfl
+
+@[simp]
+theorem cogenerator_toFunB (tree : M P)
+    (direction : P.B ((cogenerator P).toFunA tree)) :
+    (cogenerator P).toFunB tree direction =
+      .child direction (.root (M.children tree direction)) :=
+  rfl
+
+/-- The cofree generator projection is natural with respect to a generating
+lens, across independent source and target generator universes. -/
+@[simp]
+theorem cogenerator_comp_map {Q : PFunctor.{uA₂, uB₂}}
+    (lens : Lens P Q) :
+    cogenerator Q ∘ₗ map lens = lens ∘ₗ cogenerator P := by
+  let hA : ∀ tree,
+      (cogenerator Q ∘ₗ map lens).toFunA tree =
+        (lens ∘ₗ cogenerator P).toFunA tree :=
+    M.head_mapLens lens
+  refine Lens.ext _ _ hA ?_
+  intro tree
+  have hhead := M.head_mapLens lens tree
+  cases hhead
+  have hproof : hA tree = rfl := Subsingleton.elim _ _
+  rw [hproof]
+  funext direction
+  dsimp only [Lens.comp, cogenerator, map]
+  change M.Vertex.pullMapLens lens tree
+      (.child direction
+        (.root (M.children (M.mapLens lens tree) direction))) =
+    .child (lens.toFunB (M.head tree) direction)
+      (.root (M.children tree
+        (lens.toFunB (M.head tree) direction)))
+  rw [M.Vertex.pullMapLens_child,
+    M.Vertex.cast_root (M.children_mapLens lens tree direction),
+    M.Vertex.pullMapLens_root]
+  rfl
+
+/-! ## The outgoing category of the cofree comonoid -/
+
+/-- The categorical identity of a cofree tree is its root vertex. -/
+@[simp]
+theorem comonoid_identity (tree : M P) :
+    Comonoid.identity (comonoid P) tree = .root tree :=
+  rfl
+
+/-- The categorical target of a cofree vertex is its selected subtree. -/
+@[simp]
+theorem comonoid_target (tree : M P) (vertex : M.Vertex tree) :
+    Comonoid.target (comonoid P) tree vertex =
+      M.Vertex.subtree vertex :=
+  rfl
+
+/-- Categorical composition in the cofree comonoid is finite-vertex
+concatenation, in outer-then-inner path order. -/
+@[simp]
+theorem comonoid_compose (tree : M P) (first : M.Vertex tree)
+    (second : M.Vertex (M.Vertex.subtree first)) :
+    Comonoid.compose (comonoid P) tree first second =
+      M.Vertex.append first second :=
+  rfl
+
+variable (C : Comonoid.{uCA, uCB})
+
+/-- The cofree tree generated from an object of `C` by repeatedly applying
+the chosen generator lens. -/
+def unfoldShape (lens : Lens C.carrier P) (object : C.carrier.A) : M P :=
+  M.corec
+    (fun current =>
+      ⟨lens.toFunA current, fun direction =>
+        Comonoid.target C current (lens.toFunB current direction)⟩)
+    object
+
+/-- One-step unfolding of the coiterated shape. -/
+theorem dest_unfoldShape (lens : Lens C.carrier P)
+    (object : C.carrier.A) :
+    M.dest (unfoldShape C lens object) =
+      ⟨lens.toFunA object, fun direction =>
+        unfoldShape C lens
+          (Comonoid.target C object
+            (lens.toFunB object direction))⟩ := by
+  simpa only [unfoldShape] using
+    M.dest_corec_apply
+      (fun current =>
+        ⟨lens.toFunA current, fun direction =>
+          Comonoid.target C current (lens.toFunB current direction)⟩)
+      object
+
+/-- The root position of a coiterated tree is the position exposed by the
+generator lens. -/
+theorem head_unfoldShape (lens : Lens C.carrier P) (object : C.carrier.A) :
+    M.head (unfoldShape C lens object) = lens.toFunA object :=
+  congrArg Sigma.fst (dest_unfoldShape C lens object)
+
+/-- Pull a root direction of a coiterated tree back to the corresponding
+outgoing arrow of `C`. -/
+def unfoldRootDirection (lens : Lens C.carrier P)
+    (object : C.carrier.A)
+    (direction : P.B (M.head (unfoldShape C lens object))) :
+    C.carrier.B object :=
+  lens.toFunB object
+    (cast (congrArg P.B (head_unfoldShape C lens object)) direction)
+
+/-- Selecting a child of a coiterated tree continues coiteration from the
+target of the pulled-back arrow. -/
+theorem children_unfoldShape (lens : Lens C.carrier P)
+    (object : C.carrier.A)
+    (direction : P.B (M.head (unfoldShape C lens object))) :
+    M.children (unfoldShape C lens object) direction =
+      unfoldShape C lens
+        (Comonoid.target C object
+          (unfoldRootDirection C lens object direction)) := by
+  have h := M.dest_corec_apply
+    (fun current =>
+      ⟨lens.toFunA current, fun currentDirection =>
+        Comonoid.target C current
+          (lens.toFunB current currentDirection)⟩)
+    object
+  have hA := congrArg Sigma.fst h
+  have hB := (Sigma.ext_iff.mp h).2
+  cases hA
+  exact congrFun (eq_of_heq hB) direction
+
+/-- Pull a finite vertex of a coiterated tree back to the composite outgoing
+arrow of `C` represented by that path. -/
+def unfoldDirection (lens : Lens C.carrier P) :
+    (object : C.carrier.A) →
+      M.Vertex (unfoldShape C lens object) → C.carrier.B object
+  | object, .root _ => Comonoid.identity C object
+  | object, .child direction next =>
+      let first := unfoldRootDirection C lens object direction
+      let childEq := children_unfoldShape C lens object direction
+      Comonoid.compose C object first
+        (unfoldDirection lens
+          (Comonoid.target C object first)
+          (cast (congrArg M.Vertex childEq) next))
+termination_by _ vertex => M.Vertex.depth vertex
+decreasing_by
+  calc
+    M.Vertex.depth (cast (congrArg M.Vertex childEq) next) =
+        M.Vertex.depth next := M.Vertex.depth_cast childEq next
+    _ < M.Vertex.depth (.child direction next) := Nat.lt_succ_self _
+
+@[simp]
+theorem unfoldDirection_root (lens : Lens C.carrier P)
+    (object : C.carrier.A) :
+    unfoldDirection C lens object (.root (unfoldShape C lens object)) =
+      Comonoid.identity C object := by
+  rw [unfoldDirection.eq_def]
+
+private theorem unfoldDirection_child (lens : Lens C.carrier P)
+    (object : C.carrier.A)
+    (direction : P.B (M.head (unfoldShape C lens object)))
+    (next : M.Vertex
+      (M.children (unfoldShape C lens object) direction)) :
+    unfoldDirection C lens object (.child direction next) =
+      Comonoid.compose C object
+        (unfoldRootDirection C lens object direction)
+        (unfoldDirection C lens
+          (Comonoid.target C object
+            (unfoldRootDirection C lens object direction))
+          (cast (congrArg M.Vertex
+            (children_unfoldShape C lens object direction)) next)) := by
+  rw [unfoldDirection.eq_def]
+
+private theorem unfoldDirection_heq (lens : Lens C.carrier P)
+    {object object' : C.carrier.A} (hobject : object = object')
+    {vertex : M.Vertex (unfoldShape C lens object)}
+    {vertex' : M.Vertex (unfoldShape C lens object')}
+    (hvertex : vertex ≍ vertex') :
+    unfoldDirection C lens object vertex ≍
+      unfoldDirection C lens object' vertex' := by
+  subst object'
+  cases hvertex
+  rfl
+
+private theorem unfoldDirection_cast_object (lens : Lens C.carrier P)
+    {object object' : C.carrier.A} (hobject : object = object')
+    (vertex : M.Vertex (unfoldShape C lens object)) :
+    unfoldDirection C lens object'
+        (cast (congrArg M.Vertex
+          (congrArg (unfoldShape C lens) hobject)) vertex) =
+      cast (congrArg C.carrier.B hobject)
+        (unfoldDirection C lens object vertex) := by
+  subst object'
+  rfl
+
+/-- The subtree selected by a coiterated vertex is the coiteration started at
+the target of the corresponding composite arrow. -/
+theorem subtree_unfoldShape (lens : Lens C.carrier P) :
+    (object : C.carrier.A) →
+      (vertex : M.Vertex (unfoldShape C lens object)) →
+      M.Vertex.subtree vertex =
+        unfoldShape C lens
+          (Comonoid.target C object
+            (unfoldDirection C lens object vertex))
+  | object, .root _ => by
+      rw [unfoldDirection_root, Comonoid.target_identity]
+      rfl
+  | object, .child direction next => by
+      let first := unfoldRootDirection C lens object direction
+      let childEq := children_unfoldShape C lens object direction
+      let next' := cast (congrArg M.Vertex childEq) next
+      let rest := unfoldDirection C lens
+        (Comonoid.target C object first) next'
+      have ih := subtree_unfoldShape lens
+        (Comonoid.target C object first) next'
+      have hsub : M.Vertex.subtree next' = M.Vertex.subtree next :=
+        M.Vertex.subtree_cast childEq next
+      rw [unfoldDirection_child]
+      change M.Vertex.subtree next =
+        unfoldShape C lens
+          (Comonoid.target C object
+            (Comonoid.compose C object first rest))
+      calc
+        M.Vertex.subtree next = M.Vertex.subtree next' := hsub.symm
+        _ = unfoldShape C lens
+            (Comonoid.target C
+              (Comonoid.target C object first) rest) := ih
+        _ = unfoldShape C lens
+            (Comonoid.target C object
+              (Comonoid.compose C object first rest)) := by
+          rw [Comonoid.target_compose]
+termination_by _ vertex => M.Vertex.depth vertex
+decreasing_by
+  calc
+    M.Vertex.depth next' = M.Vertex.depth next :=
+      M.Vertex.depth_cast childEq next
+    _ < M.Vertex.depth (.child direction next) := Nat.lt_succ_self _
+
+private theorem vertex_cast_append {tree tree' : M P} (h : tree = tree')
+    (initial : M.Vertex tree)
+    (suffix : M.Vertex (M.Vertex.subtree initial)) :
+    cast (congrArg M.Vertex h) (M.Vertex.append initial suffix) =
+      M.Vertex.append (cast (congrArg M.Vertex h) initial)
+        (cast (congrArg M.Vertex
+          (M.Vertex.subtree_cast h initial).symm) suffix) := by
+  subst tree'
+  rfl
+
+private theorem compose_heq (object : C.carrier.A)
+    {first first' : C.carrier.B object} (hfirst : first ≍ first')
+    {second : C.carrier.B (Comonoid.target C object first)}
+    {second' : C.carrier.B (Comonoid.target C object first')}
+    (hsecond : second ≍ second') :
+    Comonoid.compose C object first second =
+      Comonoid.compose C object first' second' := by
+  cases hfirst
+  cases hsecond
+  rfl
+
+/-- Pulling back a concatenated cofree vertex composes the arrows represented
+by its prefix and suffix, in outer-then-inner path order. The suffix is
+transported from the selected subtree to the propositionally equal coiterated
+tree at the prefix target. -/
+private theorem unfoldDirection_append (lens : Lens C.carrier P) :
+    (object : C.carrier.A) →
+      (initial : M.Vertex (unfoldShape C lens object)) →
+      (suffix : M.Vertex (M.Vertex.subtree initial)) →
+      unfoldDirection C lens object (M.Vertex.append initial suffix) =
+        Comonoid.compose C object
+          (unfoldDirection C lens object initial)
+          (unfoldDirection C lens
+            (Comonoid.target C object
+              (unfoldDirection C lens object initial))
+            (cast (congrArg M.Vertex
+              (subtree_unfoldShape C lens object initial)) suffix))
+  | object, .root _, suffix => by
+      let actualDirection := unfoldDirection C lens object
+        (.root (unfoldShape C lens object))
+      let actualTarget := Comonoid.target C object actualDirection
+      let actualVertex := cast (congrArg M.Vertex
+        (subtree_unfoldShape C lens object
+          (.root (unfoldShape C lens object)))) suffix
+      let identityTarget :=
+        Comonoid.target C object (Comonoid.identity C object)
+      let canonicalVertex := cast (congrArg M.Vertex
+        (congrArg (unfoldShape C lens)
+          (Comonoid.target_identity C object).symm)) suffix
+      have hdirection : actualDirection = Comonoid.identity C object :=
+        unfoldDirection_root C lens object
+      have htarget : actualTarget = identityTarget :=
+        congrArg (Comonoid.target C object) hdirection
+      have hvertex : actualVertex ≍ canonicalVertex :=
+        (cast_heq _ suffix).trans (cast_heq _ suffix).symm
+      have htail :
+          unfoldDirection C lens actualTarget actualVertex ≍
+            unfoldDirection C lens identityTarget canonicalVertex :=
+        unfoldDirection_heq C lens htarget hvertex
+      have hcanonical :
+          unfoldDirection C lens identityTarget canonicalVertex =
+            cast (congrArg C.carrier.B
+              (Comonoid.target_identity C object).symm)
+              (unfoldDirection C lens object suffix) :=
+        unfoldDirection_cast_object C lens
+          (Comonoid.target_identity C object).symm suffix
+      have hcompose :
+          Comonoid.compose C object actualDirection
+              (unfoldDirection C lens actualTarget actualVertex) =
+            Comonoid.compose C object (Comonoid.identity C object)
+              (unfoldDirection C lens identityTarget canonicalVertex) :=
+        compose_heq C object (heq_of_eq hdirection) htail
+      simp only [M.Vertex.append_root]
+      exact (hcompose.trans (by
+        rw [hcanonical]
+        exact Comonoid.identity_compose C object
+          (unfoldDirection C lens object suffix))).symm
+  | object, .child direction next, suffix => by
+      let first := unfoldRootDirection C lens object direction
+      let childEq :
+          M.children (unfoldShape C lens object) direction =
+            unfoldShape C lens (Comonoid.target C object first) := by
+        simpa only [first] using
+          children_unfoldShape C lens object direction
+      let next' := cast (congrArg M.Vertex childEq) next
+      let subtreeEq := M.Vertex.subtree_cast childEq next
+      let suffix' := cast (congrArg M.Vertex subtreeEq.symm) suffix
+      let rest := unfoldDirection C lens
+        (Comonoid.target C object first) next'
+      let final := Comonoid.target C
+        (Comonoid.target C object first) rest
+      let finalVertex := cast (congrArg M.Vertex
+        (subtree_unfoldShape C lens
+          (Comonoid.target C object first) next')) suffix'
+      have ih := unfoldDirection_append lens
+        (Comonoid.target C object first) next' suffix'
+      let compositeTarget :=
+        Comonoid.target C object (Comonoid.compose C object first rest)
+      let compositeSubtreeEq :
+          M.Vertex.subtree (.child direction next) =
+            unfoldShape C lens compositeTarget := by
+        simpa only [unfoldDirection_child] using
+          subtree_unfoldShape C lens object (.child direction next)
+      let compositeVertex :=
+        cast (congrArg M.Vertex compositeSubtreeEq) suffix
+      have htarget : compositeTarget = final :=
+        Comonoid.target_compose C object first rest
+      have hvertices : compositeVertex ≍ finalVertex := by
+        have hcomposite : compositeVertex ≍ suffix :=
+          cast_heq _ suffix
+        have hfinal : finalVertex ≍ suffix' :=
+          cast_heq _ suffix'
+        have hsuffix : suffix' ≍ suffix :=
+          cast_heq _ suffix
+        exact hcomposite.trans (hfinal.trans hsuffix).symm
+      have harrows :
+          unfoldDirection C lens compositeTarget compositeVertex ≍
+            unfoldDirection C lens final finalVertex :=
+        unfoldDirection_heq C lens htarget hvertices
+      have htail :
+          unfoldDirection C lens compositeTarget compositeVertex =
+            cast (congrArg C.carrier.B htarget.symm)
+              (unfoldDirection C lens final finalVertex) := by
+        apply eq_of_heq
+        exact harrows.trans
+          (cast_heq (congrArg C.carrier.B htarget.symm)
+            (unfoldDirection C lens final finalVertex)).symm
+      have hnormalized :
+          unfoldDirection C lens object
+              (M.Vertex.append (.child direction next) suffix) =
+            Comonoid.compose C object
+              (Comonoid.compose C object first rest)
+              (unfoldDirection C lens compositeTarget compositeVertex) := by
+        calc
+          unfoldDirection C lens object
+              (M.Vertex.append (.child direction next) suffix) =
+              Comonoid.compose C object first
+                (unfoldDirection C lens
+                  (Comonoid.target C object first)
+                  (cast (congrArg M.Vertex childEq)
+                    (M.Vertex.append next suffix))) := by
+            rw [M.Vertex.append_child, unfoldDirection_child]
+          _ = Comonoid.compose C object first
+                (Comonoid.compose C (Comonoid.target C object first) rest
+                  (unfoldDirection C lens final finalVertex)) := by
+            rw [vertex_cast_append childEq next suffix, ih]
+          _ = Comonoid.compose C object
+                (Comonoid.compose C object first rest)
+                (cast (congrArg C.carrier.B htarget.symm)
+                  (unfoldDirection C lens final finalVertex)) :=
+            (Comonoid.compose_assoc C object first rest
+              (unfoldDirection C lens final finalVertex)).symm
+          _ = Comonoid.compose C object
+                (Comonoid.compose C object first rest)
+                (unfoldDirection C lens compositeTarget compositeVertex) := by
+            rw [htail]
+      let actualDirection :=
+        unfoldDirection C lens object (.child direction next)
+      let actualTarget := Comonoid.target C object actualDirection
+      let actualVertex := cast (congrArg M.Vertex
+        (subtree_unfoldShape C lens object (.child direction next))) suffix
+      have hdirection :
+          actualDirection = Comonoid.compose C object first rest := by
+        simpa only [actualDirection, first, rest, next', childEq] using
+          unfoldDirection_child C lens object direction next
+      have hactualTarget : actualTarget = compositeTarget :=
+        congrArg (Comonoid.target C object) hdirection
+      have hactualVertex : actualVertex ≍ compositeVertex := by
+        exact (cast_heq _ suffix).trans (cast_heq _ suffix).symm
+      have hactualTail :
+          unfoldDirection C lens actualTarget actualVertex ≍
+            unfoldDirection C lens compositeTarget compositeVertex :=
+        unfoldDirection_heq C lens hactualTarget hactualVertex
+      calc
+        unfoldDirection C lens object
+            (M.Vertex.append (.child direction next) suffix) =
+            Comonoid.compose C object
+              (Comonoid.compose C object first rest)
+              (unfoldDirection C lens compositeTarget compositeVertex) :=
+          hnormalized
+        _ = Comonoid.compose C object actualDirection
+              (unfoldDirection C lens actualTarget actualVertex) :=
+          compose_heq C object (heq_of_eq hdirection.symm) hactualTail.symm
+  termination_by _ initial _ => M.Vertex.depth initial
+  decreasing_by
+    calc
+      M.Vertex.depth next' = M.Vertex.depth next :=
+        M.Vertex.depth_cast childEq next
+      _ < M.Vertex.depth (.child direction next) := Nat.lt_succ_self _
+
+/-- The carrier lens obtained by coiteration. -/
+def unfoldLens (lens : Lens C.carrier P) :
+    Lens C.carrier (CofreeP P) where
+  toFunA := unfoldShape C lens
+  toFunB := unfoldDirection C lens
+
+@[simp]
+theorem unfoldLens_toFunA (lens : Lens C.carrier P)
+    (object : C.carrier.A) :
+    (unfoldLens C lens).toFunA object = unfoldShape C lens object :=
+  rfl
+
+@[simp]
+theorem unfoldLens_toFunB (lens : Lens C.carrier P)
+    (object : C.carrier.A)
+    (vertex : M.Vertex ((unfoldLens C lens).toFunA object)) :
+    (unfoldLens C lens).toFunB object vertex =
+      unfoldDirection C lens object vertex :=
+  rfl
+
+/-! ## Universal extension and restriction -/
+
+/-- Restrict a retrofunctor into the cofree comonoid to its one-layer
+generator lens. -/
+def restrict
+    (C : Comonoid.{max uA uB, max uA uB})
+    (hom : Comonoid.Hom C (comonoid P)) : Lens C.carrier P :=
+  cogenerator P ∘ₗ hom.toLens
+
+/-- Extend a generator lens uniquely along the cofree polynomial comonoid at
+the level of retrofunctor data. -/
+def extend
+    (C : Comonoid.{max uA uB, max uA uB})
+    (lens : Lens C.carrier P) : Comonoid.Hom C (comonoid P) :=
+  Comonoid.Hom.ofCategoryLaws (unfoldLens C lens)
+    (fun object => by
+      change unfoldDirection C lens object
+          (.root (unfoldShape C lens object)) =
+        Comonoid.identity C object
+      exact unfoldDirection_root C lens object)
+    (fun object vertex => by
+      change unfoldShape C lens
+          (Comonoid.target C object
+            (unfoldDirection C lens object vertex)) =
+        M.Vertex.subtree vertex
+      exact (subtree_unfoldShape C lens object vertex).symm)
+    (fun object initial suffix => by
+      change unfoldDirection C lens object
+          (M.Vertex.append initial suffix) =
+        Comonoid.compose C object
+          (unfoldDirection C lens object initial)
+          (unfoldDirection C lens
+            (Comonoid.target C object
+              (unfoldDirection C lens object initial))
+            (cast (congrArg M.Vertex
+              (subtree_unfoldShape C lens object initial)) suffix))
+      exact unfoldDirection_append C lens object initial suffix)
+
+@[simp]
+theorem extend_toLens
+    (C : Comonoid.{max uA uB, max uA uB})
+    (lens : Lens C.carrier P) :
+    (extend C lens).toLens = unfoldLens C lens :=
+  rfl
+
+/-- Coiteration is split by the one-layer cogenerator. -/
+@[simp]
+theorem cogenerator_comp_unfoldLens (lens : Lens C.carrier P) :
+    cogenerator P ∘ₗ unfoldLens C lens = lens := by
+  let hA : ∀ object,
+      (cogenerator P ∘ₗ unfoldLens C lens).toFunA object =
+        lens.toFunA object :=
+    head_unfoldShape C lens
+  refine Lens.ext _ _ hA ?_
+  intro object
+  have hhead := head_unfoldShape C lens object
+  cases hhead
+  have hproof : hA object = rfl := Subsingleton.elim _ _
+  rw [hproof]
+  funext direction
+  dsimp only [Lens.comp, unfoldLens, cogenerator]
+  change unfoldDirection C lens object
+      (.child direction
+        (.root (M.children (unfoldShape C lens object) direction))) =
+    lens.toFunB object direction
+  rw [unfoldDirection_child,
+    M.Vertex.cast_root (children_unfoldShape C lens object direction),
+    unfoldDirection_root,
+    Comonoid.compose_identity_right]
+  rfl
+
+/-- Restricting a cofree extension recovers its generator lens. -/
+@[simp]
+theorem restrict_extend
+    (C : Comonoid.{max uA uB, max uA uB})
+    (lens : Lens C.carrier P) :
+    restrict C (extend C lens) = lens :=
+  cogenerator_comp_unfoldLens C lens
+
+private theorem hom_target_oneLayer
+    (C : Comonoid.{max uA uB, max uA uB})
+    (hom : Comonoid.Hom C (comonoid P))
+    (object : C.carrier.A)
+    (direction : P.B (M.head (hom.toLens.toFunA object))) :
+    hom.toLens.toFunA
+        (Comonoid.target C object
+          (hom.toLens.toFunB object
+            (.child direction
+              (.root (M.children
+                (hom.toLens.toFunA object) direction))))) =
+      M.children (hom.toLens.toFunA object) direction := by
+  simpa only [comonoid_target, M.Vertex.subtree_child,
+    M.Vertex.subtree_root] using
+    hom.map_target object
+      (.child direction
+        (.root (M.children (hom.toLens.toFunA object) direction)))
+
+/-- The object map of a retrofunctor into the cofree comonoid is the
+coiteration of its restriction to one-layer generators. -/
+theorem unfoldShape_restrict
+    (C : Comonoid.{max uA uB, max uA uB})
+    (hom : Comonoid.Hom C (comonoid P))
+    (object : C.carrier.A) :
+    unfoldShape C (restrict C hom) object = hom.toLens.toFunA object := by
+  conv_rhs => rw [← M.corec_dest (hom.toLens.toFunA object)]
+  refine M.corec_eq_corec
+    (fun current =>
+      ⟨(restrict C hom).toFunA current, fun direction =>
+        Comonoid.target C current
+          ((restrict C hom).toFunB current direction)⟩)
+    M.dest
+    (fun source tree => hom.toLens.toFunA source = tree)
+    object (hom.toLens.toFunA object) rfl ?_
+  rintro source _ rfl
+  let tree := hom.toLens.toFunA source
+  refine ⟨M.head tree,
+    fun direction =>
+      Comonoid.target C source
+        ((restrict C hom).toFunB source direction),
+    fun direction => M.children tree direction, ?_, ?_, ?_⟩
+  · rfl
+  · rfl
+  · intro direction
+    exact hom_target_oneLayer C hom source direction
+
+private theorem homDirection_heq
+    (C : Comonoid.{max uA uB, max uA uB})
+    (hom : Comonoid.Hom C (comonoid P))
+    {object object' : C.carrier.A} (hobject : object = object')
+    {vertex : M.Vertex (hom.toLens.toFunA object)}
+    {vertex' : M.Vertex (hom.toLens.toFunA object')}
+    (hvertex : vertex ≍ vertex') :
+    hom.toLens.toFunB object vertex ≍
+      hom.toLens.toFunB object' vertex' := by
+  subst object'
+  cases hvertex
+  rfl
+
+/-- Pulling a coiterated vertex back through the restricted generator lens
+recovers the original retrofunctor's pullback of the corresponding vertex. -/
+private theorem unfoldDirection_restrict
+    (C : Comonoid.{max uA uB, max uA uB})
+    (hom : Comonoid.Hom C (comonoid P)) :
+    (object : C.carrier.A) →
+      (vertex : M.Vertex (unfoldShape C (restrict C hom) object)) →
+      unfoldDirection C (restrict C hom) object vertex =
+        hom.toLens.toFunB object
+          (cast (congrArg M.Vertex
+            (unfoldShape_restrict C hom object)) vertex)
+  | object, .root _ => by
+      have hcast :
+          cast (congrArg M.Vertex
+              (unfoldShape_restrict C hom object))
+              (.root (unfoldShape C (restrict C hom) object)) =
+            .root (hom.toLens.toFunA object) :=
+        M.Vertex.cast_root (unfoldShape_restrict C hom object)
+      calc
+        unfoldDirection C (restrict C hom) object
+            (.root (unfoldShape C (restrict C hom) object)) =
+            Comonoid.identity C object :=
+          unfoldDirection_root C (restrict C hom) object
+        _ = hom.toLens.toFunB object
+              (.root (hom.toLens.toFunA object)) := by
+          simpa only [comonoid_identity] using
+            (hom.map_identity object).symm
+        _ = hom.toLens.toFunB object
+              (cast (congrArg M.Vertex
+                (unfoldShape_restrict C hom object))
+                (.root (unfoldShape C (restrict C hom) object))) :=
+          congrArg (hom.toLens.toFunB object) hcast.symm
+  | object, .child direction next => by
+      let shapeEq := unfoldShape_restrict C hom object
+      let mappedDirection := M.castDirection shapeEq direction
+      let mappedNext := cast (congrArg M.Vertex
+        (M.children_castDirection shapeEq direction)) next
+      let firstVertex : M.Vertex (hom.toLens.toFunA object) :=
+        .child mappedDirection
+          (.root (M.children (hom.toLens.toFunA object) mappedDirection))
+      let rootDirection :=
+        unfoldRootDirection C (restrict C hom) object direction
+      let first := hom.toLens.toFunB object firstVertex
+      have hfirst : rootDirection = first := by
+        rfl
+      let childEq := children_unfoldShape C (restrict C hom) object direction
+      let nativeNext := cast (congrArg M.Vertex childEq) next
+      let nextObject := Comonoid.target C object rootDirection
+      let rest := unfoldDirection C (restrict C hom) nextObject nativeNext
+      have ih := unfoldDirection_restrict
+        (C := C) hom nextObject nativeNext
+      let ihVertex := cast (congrArg M.Vertex
+        (unfoldShape_restrict C hom nextObject)) nativeNext
+      let homNext := cast (congrArg M.Vertex
+        (hom.map_target object firstVertex).symm) mappedNext
+      let homNextObject := Comonoid.target C object first
+      have hnextObject : nextObject = homNextObject :=
+        congrArg (Comonoid.target C object) hfirst
+      have hvertices : ihVertex ≍ homNext := by
+        have hih : ihVertex ≍ nativeNext := cast_heq _ nativeNext
+        have hnative : nativeNext ≍ next := cast_heq _ next
+        have hmapped : mappedNext ≍ next := cast_heq _ next
+        have hhom : homNext ≍ mappedNext := cast_heq _ mappedNext
+        exact (hih.trans hnative).trans (hhom.trans hmapped).symm
+      have hhomDirections :
+          hom.toLens.toFunB nextObject ihVertex ≍
+            hom.toLens.toFunB homNextObject homNext :=
+        homDirection_heq C hom hnextObject hvertices
+      have hrest : rest ≍ hom.toLens.toFunB homNextObject homNext :=
+        (heq_of_eq ih).trans hhomDirections
+      have hcompose :
+          Comonoid.compose C object rootDirection rest =
+            Comonoid.compose C object first
+              (hom.toLens.toFunB homNextObject homNext) :=
+        compose_heq C object (heq_of_eq hfirst) hrest
+      have hmap :
+          hom.toLens.toFunB object
+              (M.Vertex.append firstVertex mappedNext) =
+            Comonoid.compose C object first
+              (hom.toLens.toFunB homNextObject homNext) := by
+        let rawNext := cast (congrArg (comonoid P).carrier.B
+          (hom.map_target object firstVertex).symm) mappedNext
+        have hraw :
+            hom.toLens.toFunB object
+                (M.Vertex.append firstVertex mappedNext) =
+              Comonoid.compose C object
+                (hom.toLens.toFunB object firstVertex)
+                (hom.toLens.toFunB
+                  (Comonoid.target C object
+                    (hom.toLens.toFunB object firstVertex)) rawNext) := by
+          simpa only [comonoid_compose, rawNext] using
+            hom.map_compose object firstVertex mappedNext
+        have hrawVertices : rawNext ≍ homNext :=
+          (cast_heq _ mappedNext).trans (cast_heq _ mappedNext).symm
+        have hrawDirections :
+            hom.toLens.toFunB
+                (Comonoid.target C object
+                  (hom.toLens.toFunB object firstVertex)) rawNext ≍
+              hom.toLens.toFunB homNextObject homNext :=
+          homDirection_heq C hom rfl hrawVertices
+        exact hraw.trans
+          (compose_heq C object (heq_of_eq rfl) hrawDirections)
+      have hmappedVertex :
+          cast (congrArg M.Vertex shapeEq)
+              (.child direction next) =
+            M.Vertex.append firstVertex mappedNext := by
+        rw [M.Vertex.cast_child]
+        rfl
+      calc
+        unfoldDirection C (restrict C hom) object
+            (.child direction next) =
+            Comonoid.compose C object rootDirection rest := by
+          rw [unfoldDirection_child]
+        _ = Comonoid.compose C object first
+              (hom.toLens.toFunB homNextObject homNext) := hcompose
+        _ = hom.toLens.toFunB object
+              (M.Vertex.append firstVertex mappedNext) := hmap.symm
+        _ = hom.toLens.toFunB object
+              (cast (congrArg M.Vertex shapeEq)
+                (.child direction next)) := by
+          exact congrArg (hom.toLens.toFunB object) hmappedVertex.symm
+  termination_by _ vertex => M.Vertex.depth vertex
+  decreasing_by
+    calc
+      M.Vertex.depth nativeNext = M.Vertex.depth next :=
+        M.Vertex.depth_cast childEq next
+      _ < M.Vertex.depth (.child direction next) := Nat.lt_succ_self _
+
+/-- Extending the restriction of a retrofunctor into the cofree polynomial
+comonoid recovers the original retrofunctor. -/
+@[simp]
+theorem extend_restrict
+    (C : Comonoid.{max uA uB, max uA uB})
+    (hom : Comonoid.Hom C (comonoid P)) :
+    extend C (restrict C hom) = hom := by
+  apply Comonoid.Hom.ext
+  let hA : ∀ object,
+      (extend C (restrict C hom)).toLens.toFunA object =
+        hom.toLens.toFunA object :=
+    unfoldShape_restrict C hom
+  refine Lens.ext _ _ hA ?_
+  intro object
+  apply eq_of_heq
+  have hraw :
+      (extend C (restrict C hom)).toLens.toFunB object ≍
+        hom.toLens.toFunB object := by
+    apply Function.hfunext (congrArg M.Vertex (hA object))
+    intro vertex vertex' hvertex
+    have hcast :
+        cast (congrArg M.Vertex (hA object)) vertex = vertex' :=
+      (cast_eq_iff_heq).2 hvertex
+    subst vertex'
+    apply heq_of_eq
+    exact unfoldDirection_restrict C hom object vertex
+  have htransport :
+      (hA object ▸ hom.toLens.toFunB object) ≍
+        hom.toLens.toFunB object :=
+    eqRec_heq_self _ _
+  exact hraw.trans htransport.symm
+
+/-- The cofree polynomial comonoid's universal property as an equivalence
+between retrofunctors into it and lenses into its generator polynomial. -/
+def homEquiv
+    (C : Comonoid.{max uA uB, max uA uB}) :
+    Comonoid.Hom C (comonoid P) ≃ Lens C.carrier P where
+  toFun := restrict C
+  invFun := extend C
+  left_inv := extend_restrict C
+  right_inv := restrict_extend C
+
+/-- The cofree hom-set equivalence is natural in its source comonoid. -/
+theorem homEquiv_natural_left
+    {C₁ C₂ : Comonoid.{max uA uB, max uA uB}}
+    (pre : Comonoid.Hom C₁ C₂)
+    (hom : Comonoid.Hom C₂ (comonoid P)) :
+    homEquiv (P := P) C₁ (pre.comp hom) =
+      homEquiv (P := P) C₂ hom ∘ₗ pre.toLens := by
+  change cogenerator P ∘ₗ (hom.toLens ∘ₗ pre.toLens) =
+    (cogenerator P ∘ₗ hom.toLens) ∘ₗ pre.toLens
+  exact (Lens.comp_assoc (cogenerator P) hom.toLens pre.toLens).symm
+
+/-- The cofree hom-set equivalence is natural in its generator polynomial. -/
+theorem homEquiv_natural_right
+    {Q : PFunctor.{uA, uB}}
+    (C : Comonoid.{max uA uB, max uA uB})
+    (lens : Lens P Q)
+    (hom : Comonoid.Hom C (comonoid P)) :
+    homEquiv (P := Q) C (hom.comp (mapHom lens)) =
+      lens ∘ₗ homEquiv (P := P) C hom := by
+  change cogenerator Q ∘ₗ (map lens ∘ₗ hom.toLens) =
+    lens ∘ₗ (cogenerator P ∘ₗ hom.toLens)
+  rw [← Lens.comp_assoc, cogenerator_comp_map, Lens.comp_assoc]
+
+end CofreeP
+end PFunctor

--- a/PolyFun/PFunctor/Cofree/Universal.lean
+++ b/PolyFun/PFunctor/Cofree/Universal.lean
@@ -181,11 +181,11 @@ def unfoldDirection (lens : Lens C.carrier P) :
       Comonoid.compose C object first
         (unfoldDirection lens
           (Comonoid.target C object first)
-          (cast (congrArg M.Vertex childEq) next))
+          (M.Vertex.castEquiv childEq next))
 termination_by _ vertex => M.Vertex.depth vertex
 decreasing_by
   calc
-    M.Vertex.depth (cast (congrArg M.Vertex childEq) next) =
+    M.Vertex.depth (M.Vertex.castEquiv childEq next) =
         M.Vertex.depth next := M.Vertex.depth_cast childEq next
     _ < M.Vertex.depth (.child direction next) := Nat.lt_succ_self _
 
@@ -209,8 +209,8 @@ theorem unfoldDirection_child (lens : Lens C.carrier P)
         (unfoldDirection C lens
           (Comonoid.target C object
             (unfoldRootDirection C lens object direction))
-          (cast (congrArg M.Vertex
-            (children_unfoldShape C lens object direction)) next)) := by
+          (M.Vertex.castEquiv
+            (children_unfoldShape C lens object direction) next)) := by
   rw [unfoldDirection.eq_def]
 
 private theorem unfoldDirection_heq (lens : Lens C.carrier P)
@@ -228,8 +228,8 @@ private theorem unfoldDirection_cast_object (lens : Lens C.carrier P)
     {object object' : C.carrier.A} (hobject : object = object')
     (vertex : M.Vertex (unfoldShape C lens object)) :
     unfoldDirection C lens object'
-        (cast (congrArg M.Vertex
-          (congrArg (unfoldShape C lens) hobject)) vertex) =
+        (M.Vertex.castEquiv
+          (congrArg (unfoldShape C lens) hobject) vertex) =
       cast (congrArg C.carrier.B hobject)
         (unfoldDirection C lens object vertex) := by
   subst object'
@@ -250,7 +250,7 @@ theorem subtree_unfoldShape (lens : Lens C.carrier P) :
   | object, .child direction next => by
       let first := unfoldRootDirection C lens object direction
       let childEq := children_unfoldShape C lens object direction
-      let next' := cast (congrArg M.Vertex childEq) next
+      let next' := M.Vertex.castEquiv childEq next
       let rest := unfoldDirection C lens
         (Comonoid.target C object first) next'
       have ih := subtree_unfoldShape lens
@@ -281,10 +281,10 @@ decreasing_by
 private theorem vertex_cast_append {tree tree' : M P} (h : tree = tree')
     (initial : M.Vertex tree)
     (suffix : M.Vertex (M.Vertex.subtree initial)) :
-    cast (congrArg M.Vertex h) (M.Vertex.append initial suffix) =
-      M.Vertex.append (cast (congrArg M.Vertex h) initial)
-        (cast (congrArg M.Vertex
-          (M.Vertex.subtree_cast h initial).symm) suffix) := by
+    M.Vertex.castEquiv h (M.Vertex.append initial suffix) =
+      M.Vertex.append (M.Vertex.castEquiv h initial)
+        (M.Vertex.castEquiv
+          (M.Vertex.subtree_cast h initial).symm suffix) := by
   subst tree'
   rfl
 
@@ -313,20 +313,20 @@ theorem unfoldDirection_append (lens : Lens C.carrier P) :
           (unfoldDirection C lens
             (Comonoid.target C object
               (unfoldDirection C lens object initial))
-            (cast (congrArg M.Vertex
-              (subtree_unfoldShape C lens object initial)) suffix))
+            (M.Vertex.castEquiv
+              (subtree_unfoldShape C lens object initial) suffix))
   | object, .root _, suffix => by
       let actualDirection := unfoldDirection C lens object
         (.root (unfoldShape C lens object))
       let actualTarget := Comonoid.target C object actualDirection
-      let actualVertex := cast (congrArg M.Vertex
+      let actualVertex := M.Vertex.castEquiv
         (subtree_unfoldShape C lens object
-          (.root (unfoldShape C lens object)))) suffix
+          (.root (unfoldShape C lens object))) suffix
       let identityTarget :=
         Comonoid.target C object (Comonoid.identity C object)
-      let canonicalVertex := cast (congrArg M.Vertex
+      let canonicalVertex := M.Vertex.castEquiv
         (congrArg (unfoldShape C lens)
-          (Comonoid.target_identity C object).symm)) suffix
+          (Comonoid.target_identity C object).symm) suffix
       have hdirection : actualDirection = Comonoid.identity C object :=
         unfoldDirection_root C lens object
       have htarget : actualTarget = identityTarget :=
@@ -362,16 +362,16 @@ theorem unfoldDirection_append (lens : Lens C.carrier P) :
             unfoldShape C lens (Comonoid.target C object first) := by
         simpa only [first] using
           children_unfoldShape C lens object direction
-      let next' := cast (congrArg M.Vertex childEq) next
+      let next' := M.Vertex.castEquiv childEq next
       let subtreeEq := M.Vertex.subtree_cast childEq next
-      let suffix' := cast (congrArg M.Vertex subtreeEq.symm) suffix
+      let suffix' := M.Vertex.castEquiv subtreeEq.symm suffix
       let rest := unfoldDirection C lens
         (Comonoid.target C object first) next'
       let final := Comonoid.target C
         (Comonoid.target C object first) rest
-      let finalVertex := cast (congrArg M.Vertex
+      let finalVertex := M.Vertex.castEquiv
         (subtree_unfoldShape C lens
-          (Comonoid.target C object first) next')) suffix'
+          (Comonoid.target C object first) next') suffix'
       have ih := unfoldDirection_append lens
         (Comonoid.target C object first) next' suffix'
       let compositeTarget :=
@@ -381,17 +381,24 @@ theorem unfoldDirection_append (lens : Lens C.carrier P) :
             unfoldShape C lens compositeTarget := by
         simpa only [unfoldDirection_child] using
           subtree_unfoldShape C lens object (.child direction next)
-      let compositeVertex :=
-        cast (congrArg M.Vertex compositeSubtreeEq) suffix
+      let compositeVertex := M.Vertex.castEquiv compositeSubtreeEq suffix
       have htarget : compositeTarget = final :=
         Comonoid.target_compose C object first rest
       have hvertices : compositeVertex ≍ finalVertex := by
         have hcomposite : compositeVertex ≍ suffix :=
-          cast_heq _ suffix
+          by
+            unfold compositeVertex M.Vertex.castEquiv
+            exact cast_heq (congrArg M.Vertex compositeSubtreeEq) suffix
         have hfinal : finalVertex ≍ suffix' :=
-          cast_heq _ suffix'
+          by
+            unfold finalVertex M.Vertex.castEquiv
+            exact cast_heq (congrArg M.Vertex
+              (subtree_unfoldShape C lens
+                (Comonoid.target C object first) next')) suffix'
         have hsuffix : suffix' ≍ suffix :=
-          cast_heq _ suffix
+          by
+            unfold suffix' M.Vertex.castEquiv
+            exact cast_heq (congrArg M.Vertex subtreeEq.symm) suffix
         exact hcomposite.trans (hfinal.trans hsuffix).symm
       have harrows :
           unfoldDirection C lens compositeTarget compositeVertex ≍
@@ -417,7 +424,7 @@ theorem unfoldDirection_append (lens : Lens C.carrier P) :
               Comonoid.compose C object first
                 (unfoldDirection C lens
                   (Comonoid.target C object first)
-                  (cast (congrArg M.Vertex childEq)
+                  (M.Vertex.castEquiv childEq
                     (M.Vertex.append next suffix))) := by
             rw [M.Vertex.append_child, unfoldDirection_child]
           _ = Comonoid.compose C object first
@@ -437,8 +444,8 @@ theorem unfoldDirection_append (lens : Lens C.carrier P) :
       let actualDirection :=
         unfoldDirection C lens object (.child direction next)
       let actualTarget := Comonoid.target C object actualDirection
-      let actualVertex := cast (congrArg M.Vertex
-        (subtree_unfoldShape C lens object (.child direction next))) suffix
+      let actualVertex := M.Vertex.castEquiv
+        (subtree_unfoldShape C lens object (.child direction next)) suffix
       have hdirection :
           actualDirection = Comonoid.compose C object first rest := by
         simpa only [actualDirection, first, rest, next', childEq] using
@@ -522,8 +529,8 @@ def extend
           (unfoldDirection C lens
             (Comonoid.target C object
               (unfoldDirection C lens object initial))
-            (cast (congrArg M.Vertex
-              (subtree_unfoldShape C lens object initial)) suffix))
+            (M.Vertex.castEquiv
+              (subtree_unfoldShape C lens object initial) suffix))
       exact unfoldDirection_append C lens object initial suffix)
 
 @[simp]
@@ -635,12 +642,12 @@ private theorem unfoldDirection_restrict
       (vertex : M.Vertex (unfoldShape C (restrict C hom) object)) →
       unfoldDirection C (restrict C hom) object vertex =
         hom.toLens.toFunB object
-          (cast (congrArg M.Vertex
-            (unfoldShape_restrict C hom object)) vertex)
+          (M.Vertex.castEquiv
+            (unfoldShape_restrict C hom object) vertex)
   | object, .root _ => by
       have hcast :
-          cast (congrArg M.Vertex
-              (unfoldShape_restrict C hom object))
+          M.Vertex.castEquiv
+            (unfoldShape_restrict C hom object)
               (.root (unfoldShape C (restrict C hom) object)) =
             .root (hom.toLens.toFunA object) :=
         M.Vertex.cast_root (unfoldShape_restrict C hom object)
@@ -654,15 +661,15 @@ private theorem unfoldDirection_restrict
           simpa only [comonoid_identity] using
             (hom.map_identity object).symm
         _ = hom.toLens.toFunB object
-              (cast (congrArg M.Vertex
-                (unfoldShape_restrict C hom object))
+              (M.Vertex.castEquiv
+                (unfoldShape_restrict C hom object)
                 (.root (unfoldShape C (restrict C hom) object))) :=
           congrArg (hom.toLens.toFunB object) hcast.symm
   | object, .child direction next => by
       let shapeEq := unfoldShape_restrict C hom object
       let mappedDirection := M.castDirection shapeEq direction
-      let mappedNext := cast (congrArg M.Vertex
-        (M.children_castDirection shapeEq direction)) next
+      let mappedNext := M.Vertex.castEquiv
+        (M.children_castDirection shapeEq direction) next
       let firstVertex : M.Vertex (hom.toLens.toFunA object) :=
         .child mappedDirection
           (.root (M.children (hom.toLens.toFunA object) mappedDirection))
@@ -672,23 +679,34 @@ private theorem unfoldDirection_restrict
       have hfirst : rootDirection = first := by
         rfl
       let childEq := children_unfoldShape C (restrict C hom) object direction
-      let nativeNext := cast (congrArg M.Vertex childEq) next
+      let nativeNext := M.Vertex.castEquiv childEq next
       let nextObject := Comonoid.target C object rootDirection
       let rest := unfoldDirection C (restrict C hom) nextObject nativeNext
       have ih := unfoldDirection_restrict
         (C := C) hom nextObject nativeNext
-      let ihVertex := cast (congrArg M.Vertex
-        (unfoldShape_restrict C hom nextObject)) nativeNext
-      let homNext := cast (congrArg M.Vertex
-        (hom.map_target object firstVertex).symm) mappedNext
+      let ihVertex := M.Vertex.castEquiv
+        (unfoldShape_restrict C hom nextObject) nativeNext
+      let homNext := M.Vertex.castEquiv
+        (hom.map_target object firstVertex).symm mappedNext
       let homNextObject := Comonoid.target C object first
       have hnextObject : nextObject = homNextObject :=
         congrArg (Comonoid.target C object) hfirst
       have hvertices : ihVertex ≍ homNext := by
-        have hih : ihVertex ≍ nativeNext := cast_heq _ nativeNext
-        have hnative : nativeNext ≍ next := cast_heq _ next
-        have hmapped : mappedNext ≍ next := cast_heq _ next
-        have hhom : homNext ≍ mappedNext := cast_heq _ mappedNext
+        have hih : ihVertex ≍ nativeNext := by
+          unfold ihVertex M.Vertex.castEquiv
+          exact cast_heq (congrArg M.Vertex
+            (unfoldShape_restrict C hom nextObject)) nativeNext
+        have hnative : nativeNext ≍ next := by
+          unfold nativeNext M.Vertex.castEquiv
+          exact cast_heq (congrArg M.Vertex childEq) next
+        have hmapped : mappedNext ≍ next := by
+          unfold mappedNext M.Vertex.castEquiv
+          exact cast_heq (congrArg M.Vertex
+            (M.children_castDirection shapeEq direction)) next
+        have hhom : homNext ≍ mappedNext := by
+          unfold homNext M.Vertex.castEquiv
+          exact cast_heq (congrArg M.Vertex
+            (hom.map_target object firstVertex).symm) mappedNext
         exact (hih.trans hnative).trans (hhom.trans hmapped).symm
       have hhomDirections :
           hom.toLens.toFunB nextObject ihVertex ≍
@@ -729,8 +747,7 @@ private theorem unfoldDirection_restrict
         exact hraw.trans
           (compose_heq C object (heq_of_eq rfl) hrawDirections)
       have hmappedVertex :
-          cast (congrArg M.Vertex shapeEq)
-              (.child direction next) =
+          M.Vertex.castEquiv shapeEq (.child direction next) =
             M.Vertex.append firstVertex mappedNext := by
         rw [M.Vertex.cast_child]
         rfl
@@ -744,8 +761,7 @@ private theorem unfoldDirection_restrict
         _ = hom.toLens.toFunB object
               (M.Vertex.append firstVertex mappedNext) := hmap.symm
         _ = hom.toLens.toFunB object
-              (cast (congrArg M.Vertex shapeEq)
-                (.child direction next)) := by
+              (M.Vertex.castEquiv shapeEq (.child direction next)) := by
           exact congrArg (hom.toLens.toFunB object) hmappedVertex.symm
   termination_by _ vertex => M.Vertex.depth vertex
   decreasing_by
@@ -775,7 +791,7 @@ theorem extend_restrict
     apply Function.hfunext (congrArg M.Vertex (hA object))
     intro vertex vertex' hvertex
     have hcast :
-        cast (congrArg M.Vertex (hA object)) vertex = vertex' :=
+        M.Vertex.castEquiv (hA object) vertex = vertex' :=
       (cast_eq_iff_heq).2 hvertex
     subst vertex'
     apply heq_of_eq

--- a/PolyFun/PFunctor/Cofree/Universal.lean
+++ b/PolyFun/PFunctor/Cofree/Universal.lean
@@ -196,7 +196,9 @@ theorem unfoldDirection_root (lens : Lens C.carrier P)
       Comonoid.identity C object := by
   rw [unfoldDirection.eq_def]
 
-private theorem unfoldDirection_child (lens : Lens C.carrier P)
+/-- Pulling back a child vertex first selects the root arrow and then composes
+it with the recursively pulled-back arrow in the selected subtree. -/
+theorem unfoldDirection_child (lens : Lens C.carrier P)
     (object : C.carrier.A)
     (direction : P.B (M.head (unfoldShape C lens object)))
     (next : M.Vertex
@@ -301,7 +303,7 @@ private theorem compose_heq (object : C.carrier.A)
 by its prefix and suffix, in outer-then-inner path order. The suffix is
 transported from the selected subtree to the propositionally equal coiterated
 tree at the prefix target. -/
-private theorem unfoldDirection_append (lens : Lens C.carrier P) :
+theorem unfoldDirection_append (lens : Lens C.carrier P) :
     (object : C.carrier.A) →
       (initial : M.Vertex (unfoldShape C lens object)) →
       (suffix : M.Vertex (M.Vertex.subtree initial)) →
@@ -795,7 +797,7 @@ def homEquiv
   right_inv := restrict_extend C
 
 /-- The cofree hom-set equivalence is natural in its source comonoid. -/
-theorem homEquiv_natural_left
+theorem homEquiv_naturality_left
     {C₁ C₂ : Comonoid.{max uA uB, max uA uB}}
     (pre : Comonoid.Hom C₁ C₂)
     (hom : Comonoid.Hom C₂ (comonoid P)) :
@@ -806,7 +808,7 @@ theorem homEquiv_natural_left
   exact (Lens.comp_assoc (cogenerator P) hom.toLens pre.toLens).symm
 
 /-- The cofree hom-set equivalence is natural in its generator polynomial. -/
-theorem homEquiv_natural_right
+theorem homEquiv_naturality_right
     {Q : PFunctor.{uA, uB}}
     (C : Comonoid.{max uA uB, max uA uB})
     (lens : Lens P Q)

--- a/PolyFunTest/PFunctor/CofreeUniversal.lean
+++ b/PolyFunTest/PFunctor/CofreeUniversal.lean
@@ -1,0 +1,272 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+module
+
+public import PolyFun.PFunctor.Cofree.Universal
+public import PolyFunTest.PFunctor.CofreePolynomial
+public import PolyFunTest.PFunctor.Comonoid.Category
+
+/-!
+# Regression tests for the cofree polynomial universal property
+
+The tests keep generic coiteration universe-independent, make coiterated
+branching observable on a three-state category, and use the non-thin Boolean
+list category to distinguish root, one-edge, and two-edge path pulls.  Both
+round trips and both naturality variables of the hom-set equivalence are
+exercised through exported declarations.
+-/
+
+@[expose] public section
+
+universe uA uB uCA uCB
+
+namespace PFunctor
+namespace CofreeUniversalTest
+
+open CofreePolynomialTest
+open ComonoidCategoryTest
+
+/-! ## Universe and cogenerator canaries -/
+
+/-- Generic coiteration keeps the comonoid and generator universe pairs
+independent. -/
+example (P : PFunctor.{uA, uB}) (C : Comonoid.{uCA, uCB})
+    (lens : Lens C.carrier P) : Lens C.carrier (CofreeP P) :=
+  CofreeP.unfoldLens C lens
+
+/-- The underlying cogenerator square retains the heterogeneous universe
+boundary of cofree mapping, even though `mapHom` later specializes it. -/
+example (P : PFunctor.{uA, uB}) (Q : PFunctor.{uCA, uCB})
+    (lens : Lens P Q) :
+    CofreeP.cogenerator Q ∘ₗ CofreeP.map lens =
+      lens ∘ₗ CofreeP.cogenerator P :=
+  CofreeP.cogenerator_comp_map lens
+
+/-- The semantic subtree equation is available at the same fully
+heterogeneous boundary. -/
+example (P : PFunctor.{uA, uB}) (C : Comonoid.{uCA, uCB})
+    (lens : Lens C.carrier P) (object : C.carrier.A)
+    (vertex : M.Vertex (CofreeP.unfoldShape C lens object)) :
+    M.Vertex.subtree vertex =
+      CofreeP.unfoldShape C lens
+        (Comonoid.target C object
+          (CofreeP.unfoldDirection C lens object vertex)) :=
+  CofreeP.subtree_unfoldShape C lens object vertex
+
+/-- Homomorphism packaging is localized to the homogeneous maximum occupied
+by `CofreeP P`. -/
+example (P : PFunctor.{uA, uB})
+    (C : Comonoid.{max uA uB, max uA uB})
+    (lens : Lens C.carrier P) :
+    Comonoid.Hom C (CofreeP.comonoid P) :=
+  CofreeP.extend C lens
+
+example (P : PFunctor.{uA, uB})
+    (C : Comonoid.{max uA uB, max uA uB}) :
+    Comonoid.Hom C (CofreeP.comonoid P) ≃ Lens C.carrier P :=
+  CofreeP.homEquiv C
+
+/-- The cogenerator exposes the root label. -/
+example : (CofreeP.cogenerator binaryP).toFunA binaryTree =
+    M.head binaryTree :=
+  rfl
+
+/-- Its backward map really selects the requested depth-one vertex. -/
+example : (CofreeP.cogenerator binaryP).toFunB binaryTree false =
+    .child false (.root (M.children binaryTree false)) :=
+  rfl
+
+/-! ## Observable three-state unfolding -/
+
+/-- A state-category generator whose two source branches enter states with
+different exposed labels. -/
+def branchingLens : Lens (stateComonoid ThreeState).carrier binaryP where
+  toFunA
+    | .source => false
+    | .middle => true
+    | .final => false
+  toFunB state direction :=
+    match state, direction with
+    | .source, false => .middle
+    | .source, true => .final
+    | .middle, false => .source
+    | .middle, true => .final
+    | .final, false => .source
+    | .final, true => .middle
+
+def branchingTree : M binaryP :=
+  CofreeP.unfoldShape (stateComonoid ThreeState) branchingLens .source
+
+example : M.head branchingTree = false := by
+  exact CofreeP.head_unfoldShape
+    (stateComonoid ThreeState) branchingLens .source
+
+/-- The `false` branch enters `middle`, whose label is observably `true`. -/
+example : M.head (M.children branchingTree false) = true := by
+  unfold branchingTree
+  rw [CofreeP.children_unfoldShape]
+  exact CofreeP.head_unfoldShape
+    (stateComonoid ThreeState) branchingLens .middle
+
+/-- The other branch enters `final`, whose label remains distinct. -/
+example : M.head (M.children branchingTree true) = false := by
+  unfold branchingTree
+  rw [CofreeP.children_unfoldShape]
+  exact CofreeP.head_unfoldShape
+    (stateComonoid ThreeState) branchingLens .final
+
+/-! ## Non-thin path-order model -/
+
+/-- Fix the otherwise unconstrained position universe of the test-local pure
+power comonoid. -/
+abbrev boolListComonoid : Comonoid.{0, 0} :=
+  listMonoidComonoid
+
+/-- Interpret a Boolean generator direction as the corresponding singleton
+arrow in the one-object Boolean-list category. -/
+def bitGenerator : Lens boolListComonoid.carrier binaryP :=
+  (fun _ => false) ⇆ (fun _ direction => [direction])
+
+def listExtension : Comonoid.Hom
+    boolListComonoid (CofreeP.comonoid binaryP) :=
+  CofreeP.extend boolListComonoid bitGenerator
+
+def listObject : boolListComonoid.carrier.A :=
+  PUnit.unit
+
+def listTree : M binaryP :=
+  listExtension.toLens.toFunA listObject
+
+def falseVertex : M.Vertex listTree :=
+  .child false (.root _)
+
+def innerTrueVertex : M.Vertex (M.Vertex.subtree falseVertex) :=
+  .child true (.root _)
+
+def falseThenTrueVertex : M.Vertex listTree :=
+  M.Vertex.append falseVertex innerTrueVertex
+
+/-- The concrete extension uses the generic coiterated shape. -/
+example : listTree =
+    CofreeP.unfoldShape boolListComonoid bitGenerator listObject :=
+  rfl
+
+/-- The root path is the identity arrow, hence the empty list. -/
+example : listExtension.toLens.toFunB listObject (.root listTree) = [] := by
+  calc
+    _ = Comonoid.identity boolListComonoid listObject := by
+      simpa [listTree] using listExtension.map_identity listObject
+    _ = [] := rfl
+
+/-- Every one-edge path pulls back to the corresponding singleton arrow. -/
+theorem listExtension_oneLayer (object : boolListComonoid.carrier.A)
+    (direction : Bool) :
+    listExtension.toLens.toFunB object
+        (.child direction (.root
+          (M.children (listExtension.toLens.toFunA object) direction))) =
+      [direction] := by
+  have h := congrArg
+    (fun lens : Lens boolListComonoid.carrier binaryP =>
+      lens.toFunB object direction)
+    (CofreeP.restrict_extend boolListComonoid bitGenerator)
+  change (CofreeP.restrict boolListComonoid listExtension).toFunB
+    object direction = [direction]
+  simpa [listExtension, bitGenerator] using h
+
+/-- A concrete one-edge path exposes the `false` singleton. -/
+example : listExtension.toLens.toFunB listObject falseVertex = [false] :=
+  listExtension_oneLayer listObject false
+
+/-- A two-edge path records both arrows in outer-then-inner order. -/
+example : listExtension.toLens.toFunB listObject falseThenTrueVertex =
+    [false, true] := by
+  have hmap := listExtension.map_compose
+    listObject falseVertex innerTrueVertex
+  let nextObject := Comonoid.target boolListComonoid listObject
+    (listExtension.toLens.toFunB listObject falseVertex)
+  let nextTrueVertex : M.Vertex
+      (listExtension.toLens.toFunA nextObject) :=
+    .child true (.root _)
+  have htree : M.Vertex.subtree falseVertex =
+      listExtension.toLens.toFunA nextObject :=
+    (listExtension.map_target listObject falseVertex).symm
+  have hraw : innerTrueVertex ≍ nextTrueVertex := by
+    cases htree
+    rfl
+  have htailAny (vertex : M.Vertex
+      (listExtension.toLens.toFunA nextObject))
+      (hvertex : vertex ≍ nextTrueVertex) :
+      listExtension.toLens.toFunB nextObject vertex = [true] := by
+    have hvertexEq : vertex = nextTrueVertex := eq_of_heq hvertex
+    rw [hvertexEq]
+    exact listExtension_oneLayer nextObject true
+  have hfirst :
+      listExtension.toLens.toFunB listObject falseVertex = [false] :=
+    listExtension_oneLayer listObject false
+  change listExtension.toLens.toFunB listObject
+    (M.Vertex.append falseVertex innerTrueVertex) = [false, true]
+  refine hmap.trans ?_
+  rw [hfirst]
+  change [false] ++ _ = [false] ++ [true]
+  congr 1
+  apply htailAny
+  exact (cast_heq _ innerTrueVertex).trans hraw
+
+/-! ## Universal-property round trips -/
+
+example : CofreeP.restrict boolListComonoid listExtension = bitGenerator := by
+  simp [listExtension]
+
+example (hom : Comonoid.Hom
+    boolListComonoid (CofreeP.comonoid binaryP)) :
+    CofreeP.extend boolListComonoid
+        (CofreeP.restrict boolListComonoid hom) = hom := by
+  simp
+
+example : (CofreeP.homEquiv boolListComonoid).symm
+      ((CofreeP.homEquiv boolListComonoid) listExtension) =
+    listExtension :=
+  (CofreeP.homEquiv boolListComonoid).symm_apply_apply _
+
+example : CofreeP.homEquiv boolListComonoid
+      ((CofreeP.homEquiv boolListComonoid).symm bitGenerator) =
+    bitGenerator :=
+  (CofreeP.homEquiv boolListComonoid).apply_symm_apply _
+
+/-- Extending the canonical cogenerator recovers the identity retrofunctor. -/
+example : CofreeP.extend (CofreeP.comonoid binaryP)
+      (CofreeP.cogenerator binaryP) =
+    Comonoid.Hom.id (CofreeP.comonoid binaryP) := by
+  simpa [CofreeP.restrict] using
+    CofreeP.extend_restrict
+      (C := CofreeP.comonoid binaryP)
+      (Comonoid.Hom.id (CofreeP.comonoid binaryP))
+
+/-! ## Naturality canaries -/
+
+/-- Source-side naturality is exercised with the nontrivial state projection
+retrofunctor. -/
+example :
+    CofreeP.homEquiv (stateComonoid (ThreeState × Bool))
+        (fstHom.comp
+          (CofreeP.extend (stateComonoid ThreeState) branchingLens)) =
+      CofreeP.homEquiv (stateComonoid ThreeState)
+          (CofreeP.extend (stateComonoid ThreeState) branchingLens) ∘ₗ
+        fstHom.toLens :=
+  CofreeP.homEquiv_natural_left fstHom
+    (CofreeP.extend (stateComonoid ThreeState) branchingLens)
+
+/-- Generator-side naturality is exercised with a branch-reversing lens. -/
+example :
+    CofreeP.homEquiv boolListComonoid
+        (listExtension.comp (CofreeP.mapHom reverseBranchLens)) =
+      reverseBranchLens ∘ₗ
+        CofreeP.homEquiv boolListComonoid listExtension :=
+  CofreeP.homEquiv_natural_right boolListComonoid
+    reverseBranchLens listExtension
+
+end CofreeUniversalTest
+end PFunctor

--- a/PolyFunTest/PFunctor/CofreeUniversal.lean
+++ b/PolyFunTest/PFunctor/CofreeUniversal.lean
@@ -256,7 +256,7 @@ example :
       CofreeP.homEquiv (stateComonoid ThreeState)
           (CofreeP.extend (stateComonoid ThreeState) branchingLens) ∘ₗ
         fstHom.toLens :=
-  CofreeP.homEquiv_natural_left fstHom
+  CofreeP.homEquiv_naturality_left fstHom
     (CofreeP.extend (stateComonoid ThreeState) branchingLens)
 
 /-- Generator-side naturality is exercised with a branch-reversing lens. -/
@@ -265,7 +265,7 @@ example :
         (listExtension.comp (CofreeP.mapHom reverseBranchLens)) =
       reverseBranchLens ∘ₗ
         CofreeP.homEquiv boolListComonoid listExtension :=
-  CofreeP.homEquiv_natural_right boolListComonoid
+  CofreeP.homEquiv_naturality_right boolListComonoid
     reverseBranchLens listExtension
 
 end CofreeUniversalTest

--- a/docs/reading/roadmap.md
+++ b/docs/reading/roadmap.md
@@ -20,7 +20,7 @@ Announced VCVio baseline: `2026-899.pdf` (ePrint 2026/899).
 | Ch 5 factorizations, adjunctions, (co)limits | **Done**: vertical–cartesian factorization and orthogonality (A3), trivial-interface adjunctions plus binary tensor gluing (A4/A5), and cartesian closure (A2); general (co)limits remain open |
 | Ch 6 ◁ theory (composites, coclosure, duoidal) | **Done**: direct composite-lens projections, `compNthMap`, δ/`twoStep`, full left Π-distributivity, ordering/interchange naturality and concrete duoidal coherence; coclosure/multiadjoint (A8) and the higher three-interchange diagram remain open |
 | Ch 7 comonoids = categories, retrofunctors | **Done (B1–B4 spine)**: `Comonoid`, `Comonoid.Hom`/`Cat♯`, state comonoids, `δ^(n)`, `Run_n`, and the `IOMachine` run/composition core; §7.3.3 quadruple (B5), all-bracketing canonicity, and representable-monoid equivalence remain open |
-| Ch 8 cofree comonoid, Cat♯ ⊣ Poly, bicomodules | Missing (raw material: `M p`, `M.corec`, `FreeM.Path`) |
+| Ch 8 cofree comonoid, Cat♯ ⊣ Poly, bicomodules | **C1/C2 done; C3 hom-set data done**: `M.Vertex`, `CofreeP.comonoid`, generic coiteration, and the natural hom-set equivalence; behavior mates, finite projections/Prop 8.49, lax monoidality, and bicomodules remain open |
 
 ## Reading units
 
@@ -253,19 +253,24 @@ canonical `FreeM` interpretation.
 
 ### Phase C — cofree comonoid and adjunctions (Ch 8.1–8.2)
 
-- **C1** `MPath p : M p → Type` (finite rooted paths; inductive over
-  coinductive) + `follow : (T : M p) → MPath p T → M p` (= `cod`, the
-  subtree at a path's end) + append/assoc lemmas. Bridge lemma: `M p` *is*
+- **C1 — done:** `M.Vertex t` (finite rooted paths; inductive over
+  coinductive) + `M.Vertex.subtree` (= `cod`, the subtree at a path's end) +
+  append/assoc lemmas. Bridge lemma: `M p` *is*
   `tree_p` (Ex 8.16 — terminal `p`-coalgebra); trimming projections
-  `ε_p^{(n)}` per Prop 8.18.
-- **C2** carrier `t_p := ⟨M p, MPath p⟩` (Prop 8.18); ε = root/nil,
-  δ = (follow, append); comonoid laws (Prop 8.33) derived from the
-  workhorse spec (8.32) `δ ⨟ (ε^{(ℓ)} ◁ ε^{(m)}) = ε^{(ℓ+m)}` (or by
-  direct path induction — decide by proof ergonomics). Instances:
+  `ε_p^{(n)}` per Prop 8.18 remain a separate finite-projection slice.
+- **C2 — done:** carrier `t_p := ⟨M p, M.Vertex⟩` (Prop 8.18); ε = root/nil,
+  δ = (follow, append); comonoid laws (Prop 8.33) proved by direct path
+  induction. The stronger workhorse spec (8.32)
+  `δ ⨟ (ε^{(ℓ)} ◁ ε^{(m)}) = ε^{(ℓ+m)}` remains with finite projections.
+  Still-open instances:
   `t_1 ≅ y`, `t_y ≅ y^ℕ` = (ℕ,0,+), `t_{By} ≅ B^ℕ y^ℕ` = B-streams
   (Example 8.38), `t_{By^A} ≅ B^{List A} y^{List A}` (Ex 8.40).
-- **C3** `U ⊣ 𝒯_₋` (Thm 8.45): `Lens c p ≃ Retrofunctor 𝒞 (𝒯_p)`; mate via
-  `M.corec`; uniqueness via M-finality; **Prop 8.49**:
+- **C3 — hom-set data done:** the universe-local form of `U ⊣ 𝒯_₋`
+  (Thm 8.45), `Lens c p ≃ Retrofunctor 𝒞 (𝒯_p)`, with mate via `M.corec`,
+  full dependent-path uniqueness, and naturality in both variables. It is
+  packaged as a concrete hom-set equivalence rather than a bundled
+  `CategoryTheory.Adjunction`, because bare `PFunctor` currently has
+  overlapping lens/chart category instances. Still open: **Prop 8.49**,
   `mate ⨟ ε_p^{(n)} = Run_n(φ)` — the mate packages every finite run.
   Functoriality `𝒯_φ` (§8.1.5) + `φ` cartesian ⟹ `𝒯_φ` cartesian
   (Prop 8.72); `𝒯_p` free on a graph (Prop 8.57); lax monoidality

--- a/docs/wiki/pfunctor.md
+++ b/docs/wiki/pfunctor.md
@@ -134,6 +134,7 @@ displayed families, roll bounds) on top of the upstream type.
 | [`PolyFun/PFunctor/Cofree.lean`](../../PolyFun/PFunctor/Cofree.lean) | `CofreeC` (cofree comonad on a `PFunctor`), built from `PFunctor.M` of the `constProd` polynomial. The dual of `FreeM`. |
 | [`PolyFun/PFunctor/M/Vertex.lean`](../../PolyFun/PFunctor/M/Vertex.lean) | `M.Vertex t`, the finite path calculus selecting rooted subtrees of a potentially infinite `t : M P`; unlike the doubly indexed `FreeM.Cursor`, the residual is the `subtree` projection, which is the indexing choice needed for the cofree polynomial's direction type. |
 | [`PolyFun/PFunctor/Cofree/Polynomial.lean`](../../PolyFun/PFunctor/Cofree/Polynomial.lean) | `CofreeP P`, whose positions are potentially infinite `P`-trees and whose directions are finite rooted vertices; its extension equivalence with `CofreeC P`, functorial action on lenses, and substitution-comonoid structure. Its carrier uses `max uA uB` for both polynomial universes because a vertex stores directions along an ambient `M P` tree. |
+| [`PolyFun/PFunctor/Cofree/Universal.lean`](../../PolyFun/PFunctor/Cofree/Universal.lean) | Generic coiteration and the cofree-comonoid universal property `Comonoid.Hom C (CofreeP.comonoid P) ≃ Lens C.carrier P`, with explicit naturality in both variables. The generic unfolding keeps the comonoid and generator universe pairs independent; the hom-set packaging specializes `C` to the homogeneous `max uA uB` universe pair required by the existing `Comonoid.Hom`. This is unbundled adjunction data, not a `CategoryTheory.Adjunction`. |
 | [`PolyFun/PFunctor/Trace.lean`](../../PolyFun/PFunctor/Trace.lean) | Polynomial-trace machinery shared between `PFunctor` and downstream layers. |
 
 ### Control helpers
@@ -165,7 +166,9 @@ provides the reusable monad / comonad / coalgebra plumbing. See
   universe pairs to agree. The current `CofreeP.mapHom` API ensures that by
   choosing a common generator universe pair, so both resulting comonoid
   universes are definitionally `max uA uB`; a future lift/equal-maximum API
-  could relax this specialization. PolyFun separately formalizes
+  could relax this specialization. `CofreeP.homEquiv` packages the cofree
+  universal property at the same fixed-maximum boundary, while its underlying
+  coiteration remains fully heterogeneous. PolyFun separately formalizes
   `LawfulMonad (FreeM P)` and `LawfulComonad (CofreeC F)`; those type-level
   structures are not the paper's polynomial module action
   `FreeP p ⊗ CofreeP q → FreeP (p ⊗ q)`. That module-action layer is a

--- a/docs/wiki/repo-map.md
+++ b/docs/wiki/repo-map.md
@@ -66,6 +66,9 @@ PFunctor/Comonoid -> PFunctor/Comonoid/Category
 PFunctor/{Cofree, Comonoid, M/Vertex}
   -> PFunctor/Cofree/Polynomial
 
+PFunctor/{Cofree/Polynomial, Comonoid/Category}
+  -> PFunctor/Cofree/Universal
+
 PFunctor/{Lens, Cofree, M} + Control/Coalgebra
   -> PFunctor/Dynamical/{Basic, Safety, Combinators, Run, Speedup, Trajectory}
   -> PFunctor/Dynamical/{Behavior, Simulation, RunN, DynComputation, IOMachine}


### PR DESCRIPTION
## Context

#63 extracts the category structure of a polynomial comonoid. This PR proves
the cofree universal property: homomorphisms from a polynomial comonoid `C`
into `CofreeP P` are exactly lenses from `C.carrier` to the generator `P`.

## What this adds

- `CofreeP.cogenerator`;
- generic `unfoldShape`, `unfoldDirection`, and `unfoldLens`;
- public child and append/composition equations;
- `CofreeP.extend` and `restrict` with both triangle laws;
- full uniqueness of the dependent backward maps on finite vertices;
- `CofreeP.homEquiv` and naturality in source and generator.

The result is explicit hom-set equivalence/adjunction data, not a global
`CategoryTheory.Adjunction`. Generic coiteration keeps four independent
universes; packaging through the existing homogeneous `Comonoid.Hom` uses the
documented common maximum.

## Stack

- Base: current `main` through merged #63.
- Previous: #63.
- Next: #67, dynamical-system cofree mates.

## Validation

After restacking onto merged #63:

- targeted source/test build: 749 jobs;
- full build: 8,829 jobs;
- full tests: 1,970 jobs;
- `./scripts/validate.sh --lint --test`;
- `lake exe lint-style`;
- imports/docs integrity and `git diff --check`;
- trust scan with no `sorry`, `admit`, `axiom`, or `unsafe`;
- principal universal-property/naturality axiom audit: only `propext`,
  `Classical.choice`, and `Quot.sound`.
