### PR TITLE
feat(interaction): compose dependent TypeTree chains

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,7 +231,7 @@ PFunctor/Dynamical + ITree/Basic → ITree/Unfold
 
 PFunctor/Free + Control → Interaction/Basic/{TypeTree, Node, Decoration,
                             Syntax, Shape, Interaction, Strategy,
-                            Append, Replicate, StateChain, Chain,
+                            Append, Replicate, StateChain, Chain, Chain/Append,
                             Telescope, Sampler, MonadDecoration,
                             BundledMonad, Ownership, TypeTreeFintype}
 

--- a/PolyFun.lean
+++ b/PolyFun.lean
@@ -47,6 +47,7 @@ import PolyFun.ITree.Unfold
 import PolyFun.Interaction.Basic.Append
 import PolyFun.Interaction.Basic.BundledMonad
 import PolyFun.Interaction.Basic.Chain
+import PolyFun.Interaction.Basic.Chain.Append
 import PolyFun.Interaction.Basic.Decoration
 import PolyFun.Interaction.Basic.Interaction
 import PolyFun.Interaction.Basic.MonadDecoration

--- a/PolyFun/Interaction/Basic/Chain.lean
+++ b/PolyFun/Interaction/Basic/Chain.lean
@@ -33,6 +33,8 @@ specialization.
 * `Chain.replicate` — constant rounds (recovers `TypeTree.replicate`).
 * `Chain.ofStateChain` — finite unfold of a stage-indexed coalgebra.
 * `Chain.ofStateMachine` — homogeneous-state specialization.
+* `Chain.outputFamily` / `Chain.strategyComp` — dependent state and strategy
+  composition along every round.
 
 ## Three composition mechanisms
 
@@ -205,6 +207,21 @@ def outputFamily
       PFunctor.FreeM.Path.liftAppend spec (fun tr₁ => toTypeTree n (cont tr₁))
         (fun tr₁ tr₂ => outputFamily Family n (cont tr₁) tr₂)
         tr
+
+/-- `outputFamily` ultimately evaluates the family at the unique zero-round
+chain. Intermediate chain indices describe the state threaded between rounds;
+after a complete path no rounds remain. -/
+theorem outputFamily_eq_terminal
+    (Family : {n : Nat} → Chain n → Type u) :
+    (n : Nat) → (c : Chain n) → (path : Path (toTypeTree n c)) →
+    outputFamily Family n c path = @Family 0 PUnit.unit
+  | 0, ⟨⟩, _ => rfl
+  | n + 1, ⟨spec, cont⟩, path => by
+      simp only [outputFamily]
+      rw [PFunctor.FreeM.Path.liftAppend_congr spec _ _ _
+        (fun first rest => outputFamily_eq_terminal Family n (cont first) rest)]
+      exact PFunctor.FreeM.Path.liftAppend_const (@Family 0 PUnit.unit)
+        spec _ path
 
 /-- Compose strategies along a chain with a path-dependent output family. The step
 function sees the current round tree packaged as the remaining chain, and returns the next

--- a/PolyFun/Interaction/Basic/Chain/Append.lean
+++ b/PolyFun/Interaction/Basic/Chain/Append.lean
@@ -1,0 +1,347 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+import PolyFun.Interaction.Basic.Chain
+
+/-!
+# Dependent concatenation of finite interaction chains
+
+This file composes two `TypeTree.Chain` values when the suffix chain may
+depend on the complete path through the prefix. The construction preserves the
+round boundary carried by `Chain`: a chain of `m` rounds followed by a chain of
+`n` rounds produces a chain of `m + n` rounds.
+
+`Chain.then` is the chain-level counterpart of `PFunctor.FreeM.append`.
+`toTypeTree_then` states that flattening commutes with concatenation. The API
+includes raw and flattened unit laws, a path equivalence with inverse split/join
+operations, `liftThen` for dependent output families, and `strategyCompThen`
+for strategies crossing the boundary. `toTypeTree_then_assoc` gives the typed
+three-stage reassociation law and exposes the unavoidable `Nat.add_assoc`
+transport between the two chain indices.
+
+Raw `Chain`-level associativity is intentionally not the public contract:
+it would identify continuation functions through the intensional details of
+round-count and path transports. `Chain` is a finite-approximant presentation,
+while `toTypeTree` is its operational interpretation; consumers therefore use
+the stable operational equality `toTypeTree_then_assoc`.
+-/
+
+universe u
+
+namespace Interaction
+namespace TypeTree
+namespace Chain
+
+/-- Transport a chain across an equality of its round count. -/
+def castRounds {m n : Nat} (h : m = n) (c : Chain m) : Chain n :=
+  h ▸ c
+
+@[simp]
+theorem castRounds_rfl {m : Nat} (c : Chain m) : castRounds rfl c = c :=
+  rfl
+
+@[simp]
+theorem castRounds_symm {m n : Nat} (h : m = n) (c : Chain m) :
+    castRounds h.symm (castRounds h c) = c := by
+  subst n
+  rfl
+
+theorem castRounds_trans {m n p : Nat} (h : m = n) (h' : n = p)
+    (c : Chain m) :
+    castRounds h' (castRounds h c) = castRounds (h.trans h') c := by
+  subst n
+  subst p
+  rfl
+
+/-- Transporting the round count does not change the flattened type tree. -/
+@[simp]
+theorem toTypeTree_castRounds {m n : Nat} (h : m = n) (c : Chain m) :
+    toTypeTree n (castRounds h c) = toTypeTree m c := by
+  subst n
+  rfl
+
+/-- Append a path-dependent `n`-round suffix to an `m`-round prefix chain. -/
+def «then» : {m n : Nat} → (c : Chain m) →
+    (Path (toTypeTree m c) → Chain n) → Chain (m + n)
+  | 0, n, _, k => castRounds (Nat.zero_add n).symm (k ⟨⟩)
+  | m + 1, n, ⟨tree, cont⟩, k =>
+      castRounds (Nat.succ_add m n).symm
+        ⟨tree, fun path =>
+          Chain.then (cont path) (fun tail =>
+            k (appendPath m ⟨tree, cont⟩ path tail))⟩
+
+/-- Flattening a concatenated chain is dependent type-tree append. -/
+theorem toTypeTree_then : {m n : Nat} → (c : Chain m) →
+    (k : Path (toTypeTree m c) → Chain n) →
+    toTypeTree (m + n) (Chain.then c k) =
+      (toTypeTree m c).append (fun path => toTypeTree n (k path))
+  | 0, n, ⟨⟩, k => by
+      simp only [Chain.then, toTypeTree_castRounds, toTypeTree_zero]
+      change toTypeTree n (k ⟨⟩) =
+        (fun path => toTypeTree n (k path)) ⟨⟩
+      rfl
+  | m + 1, n, ⟨tree, cont⟩, k => by
+      simp only [Chain.then, toTypeTree_castRounds, toTypeTree,
+        TypeTree.substMonoid_mult_toFunA]
+      rw [PFunctor.FreeM.Path.append_tree_assoc]
+      congr 1
+      funext path
+      rw [toTypeTree_then]
+      rfl
+
+/-! ## Unit laws -/
+
+/-- An empty prefix is a left unit for `Chain.then` already at the
+round-indexed presentation level. -/
+@[simp]
+theorem then_zero_left {n : Nat} (c : Chain 0)
+    (k : Path (toTypeTree 0 c) → Chain n) :
+    castRounds (Nat.zero_add n) (Chain.then c k) = k ⟨⟩ := by
+  cases c
+  exact castRounds_symm (Nat.zero_add n).symm (k ⟨⟩)
+
+/-- An empty suffix is a right unit for `Chain.then` already at the
+round-indexed presentation level. -/
+@[simp]
+theorem then_zero_right : {m : Nat} → (c : Chain m) →
+    (k : Path (toTypeTree m c) → Chain 0) →
+    Chain.then c k = c
+  | 0, ⟨⟩, k => by cases k ⟨⟩; rfl
+  | m + 1, ⟨tree, cont⟩, k => by
+      simp only [Chain.then, castRounds]
+      congr 1
+      funext path
+      exact then_zero_right (cont path) (fun tail =>
+        k (appendPath m ⟨tree, cont⟩ path tail))
+
+/-- An empty prefix is a left unit for `Chain.then` after flattening. -/
+@[simp]
+theorem toTypeTree_then_zero_left {n : Nat} (c : Chain 0)
+    (k : Path (toTypeTree 0 c) → Chain n) :
+    toTypeTree (0 + n) (Chain.then c k) = toTypeTree n (k ⟨⟩) := by
+  rw [toTypeTree_then]
+  rfl
+
+/-- An empty suffix is a right unit for `Chain.then` after flattening. -/
+theorem toTypeTree_then_zero_right {m : Nat} (c : Chain m)
+    (k : Path (toTypeTree m c) → Chain 0) :
+    toTypeTree m (Chain.then c k) = toTypeTree m c := by
+  rw [then_zero_right]
+
+/-! ## Paths across the concatenation boundary -/
+
+/-- Paths through a concatenated chain are equivalently a prefix path followed
+by a path through the selected suffix chain. -/
+def thenPathEquiv {m n : Nat} (c : Chain m)
+    (k : Path (toTypeTree m c) → Chain n) :
+    Path (toTypeTree (m + n) (Chain.then c k)) ≃
+      (path : Path (toTypeTree m c)) × Path (toTypeTree n (k path)) :=
+  (Equiv.cast (congrArg Path (toTypeTree_then c k))).trans
+    { toFun := PFunctor.FreeM.Path.split (toTypeTree m c)
+        (fun path => toTypeTree n (k path))
+      invFun := fun ⟨path, suffix⟩ =>
+        PFunctor.FreeM.Path.append (toTypeTree m c)
+          (fun path => toTypeTree n (k path)) path suffix
+      left_inv := PFunctor.FreeM.Path.append_split _ _
+      right_inv := by
+        rintro ⟨path, suffix⟩
+        exact PFunctor.FreeM.Path.split_append (toTypeTree m c)
+          (fun path => toTypeTree n (k path)) path suffix }
+
+/-- Split a path through `c.then k` at the prefix/suffix boundary. -/
+def splitThenPath {m n : Nat} (c : Chain m)
+    (k : Path (toTypeTree m c) → Chain n) :
+    Path (toTypeTree (m + n) (Chain.then c k)) →
+      (path : Path (toTypeTree m c)) × Path (toTypeTree n (k path)) :=
+  thenPathEquiv c k
+
+/-- Join a prefix path and selected suffix path into a path through `c.then k`. -/
+def appendThenPath {m n : Nat} (c : Chain m)
+    (k : Path (toTypeTree m c) → Chain n)
+    (path : Path (toTypeTree m c)) (suffix : Path (toTypeTree n (k path))) :
+    Path (toTypeTree (m + n) (Chain.then c k)) :=
+  (thenPathEquiv c k).symm ⟨path, suffix⟩
+
+@[simp, grind =]
+theorem splitThenPath_appendThenPath {m n : Nat} (c : Chain m)
+    (k : Path (toTypeTree m c) → Chain n)
+    (path : Path (toTypeTree m c)) (suffix : Path (toTypeTree n (k path))) :
+    splitThenPath c k (appendThenPath c k path suffix) = ⟨path, suffix⟩ :=
+  (thenPathEquiv c k).apply_symm_apply ⟨path, suffix⟩
+
+@[simp, grind =]
+theorem appendThenPath_splitThenPath {m n : Nat} (c : Chain m)
+    (k : Path (toTypeTree m c) → Chain n)
+    (path : Path (toTypeTree (m + n) (Chain.then c k))) :
+    appendThenPath c k (splitThenPath c k path).1
+      (splitThenPath c k path).2 = path :=
+  (thenPathEquiv c k).symm_apply_apply path
+
+/-- `appendThenPath` is the ordinary appended-tree path, transported back
+along `toTypeTree_then`. -/
+theorem appendThenPath_eq_cast_append {m n : Nat} (c : Chain m)
+    (k : Path (toTypeTree m c) → Chain n)
+    (path : Path (toTypeTree m c)) (suffix : Path (toTypeTree n (k path))) :
+    appendThenPath c k path suffix =
+      Equiv.cast (congrArg Path (toTypeTree_then c k)).symm
+        (PFunctor.FreeM.Path.append (toTypeTree m c)
+          (fun path => toTypeTree n (k path)) path suffix) :=
+  rfl
+
+/-! ## Dependent output families and strategies -/
+
+/-- Lift a family indexed separately by a prefix path and its selected suffix
+path to a family on paths through the concatenated chain. This is the
+chain-boundary counterpart of `PFunctor.FreeM.Path.liftAppend`. -/
+def liftThen {m n : Nat} (c : Chain m)
+    (k : Path (toTypeTree m c) → Chain n)
+    (Family : (path : Path (toTypeTree m c)) →
+      Path (toTypeTree n (k path)) → Type u)
+    (combined : Path (toTypeTree (m + n) (Chain.then c k))) : Type u :=
+  let pieces := splitThenPath c k combined
+  Family pieces.1 pieces.2
+
+/-- `liftThen` computes to the original family on a joined boundary path. -/
+@[simp]
+theorem liftThen_appendThenPath {m n : Nat} (c : Chain m)
+    (k : Path (toTypeTree m c) → Chain n)
+    (Family : (path : Path (toTypeTree m c)) →
+      Path (toTypeTree n (k path)) → Type u)
+    (path : Path (toTypeTree m c)) (suffix : Path (toTypeTree n (k path))) :
+    liftThen c k Family (appendThenPath c k path suffix) = Family path suffix := by
+  unfold liftThen
+  rw [splitThenPath_appendThenPath]
+
+/-- After transporting a concatenated-chain path along `toTypeTree_then`,
+`liftThen` is exactly the generic appended-tree family `Path.liftAppend`. -/
+theorem liftThen_eq_liftAppend_cast {m n : Nat} (c : Chain m)
+    (k : Path (toTypeTree m c) → Chain n)
+    (Family : (path : Path (toTypeTree m c)) →
+      Path (toTypeTree n (k path)) → Type u)
+    (combined : Path (toTypeTree (m + n) (Chain.then c k))) :
+    liftThen c k Family combined =
+      PFunctor.FreeM.Path.liftAppend (toTypeTree m c)
+        (fun path => toTypeTree n (k path)) Family
+        (Equiv.cast (congrArg Path (toTypeTree_then c k)) combined) := by
+  exact (PFunctor.FreeM.Path.liftAppend_split (toTypeTree m c)
+    (fun path => toTypeTree n (k path)) Family
+    (Equiv.cast (congrArg Path (toTypeTree_then c k)) combined)).symm
+
+/-- The intrinsic `Chain.outputFamily` of a concatenation agrees with the
+output family of the suffix selected by the recovered prefix path. -/
+theorem outputFamily_then
+    (Family : {rounds : Nat} → Chain rounds → Type u)
+    {m n : Nat} (c : Chain m)
+    (k : Path (toTypeTree m c) → Chain n)
+    (combined : Path (toTypeTree (m + n) (Chain.then c k))) :
+    outputFamily Family (m + n) (Chain.then c k) combined =
+      outputFamily Family n (k (splitThenPath c k combined).1)
+        (splitThenPath c k combined).2 := by
+  rw [outputFamily_eq_terminal, outputFamily_eq_terminal]
+
+/-- Compose strategies across a `Chain.then` boundary. The output family is
+indexed by the prefix/suffix path pair and exposed on the concatenated chain
+through `liftThen`. -/
+def strategyCompThen {monad : Type u → Type u} [Monad monad]
+    {m n : Nat} (c : Chain m)
+    (k : Path (toTypeTree m c) → Chain n)
+    {Mid : Path (toTypeTree m c) → Type u}
+    {Family : (path : Path (toTypeTree m c)) →
+      Path (toTypeTree n (k path)) → Type u}
+    (prefixStrategy : Strategy.Plain monad (toTypeTree m c) Mid)
+    (suffixStrategy : (path : Path (toTypeTree m c)) → Mid path →
+      monad (Strategy.Plain monad (toTypeTree n (k path)) (Family path))) :
+    monad (Strategy.Plain monad
+      (toTypeTree (m + n) (Chain.then c k)) (liftThen c k Family)) := by
+  let hSpec := toTypeTree_then c k
+  let composed := Strategy.comp (toTypeTree m c)
+    (fun path => toTypeTree n (k path)) prefixStrategy suffixStrategy
+  exact (fun strategy =>
+    Strategy.castSpec hSpec.symm
+      (fun combined => (liftThen_eq_liftAppend_cast c k Family combined).symm)
+      strategy) <$> composed
+
+/-! ## Three-stage coherence -/
+
+/-- Reassociate the round-count index of a three-stage chain. -/
+def reassoc {m n p : Nat} (c : Chain ((m + n) + p)) :
+    Chain (m + (n + p)) :=
+  castRounds (Nat.add_assoc m n p) c
+
+/-- Reassociating the round-count index does not change the flattened tree. -/
+@[simp]
+theorem toTypeTree_reassoc {m n p : Nat} (c : Chain ((m + n) + p)) :
+    toTypeTree (m + (n + p)) (reassoc c) = toTypeTree ((m + n) + p) c :=
+  toTypeTree_castRounds (Nat.add_assoc m n p) c
+
+/-- Rewrite the prefix tree of a dependent append across an equality, with
+the continuation path transported in the opposite direction. -/
+private theorem append_cast_prefix {s t : TypeTree} (h : s = t)
+    (k : Path s → TypeTree) :
+    s.append k =
+      t.append (fun path => k (Equiv.cast (congrArg Path h).symm path)) := by
+  subst t
+  rfl
+
+/-- Operational associativity of dependent chain concatenation. The two chain
+presentations have propositionally equal round counts; after `reassoc`, their
+flattened type trees agree. The third stage on the right is reindexed by the
+joined prefix and middle paths. -/
+theorem toTypeTree_then_assoc {m n p : Nat} (c : Chain m)
+    (k : Path (toTypeTree m c) → Chain n)
+    (l : Path (toTypeTree (m + n) (Chain.then c k)) → Chain p) :
+    toTypeTree (m + (n + p))
+        (reassoc (Chain.then (Chain.then c k) l)) =
+      toTypeTree (m + (n + p))
+        (Chain.then c (fun path =>
+          Chain.then (k path) (fun suffix =>
+            l (appendThenPath c k path suffix)))) := by
+  rw [toTypeTree_reassoc, toTypeTree_then]
+  calc
+    (toTypeTree (m + n) (Chain.then c k)).append
+          (fun path => toTypeTree p (l path)) =
+        ((toTypeTree m c).append (fun path => toTypeTree n (k path))).append
+          (fun path => toTypeTree p
+            (l (Equiv.cast (congrArg Path (toTypeTree_then c k)).symm path))) :=
+      append_cast_prefix (toTypeTree_then c k) _
+    _ = (toTypeTree m c).append (fun path =>
+          (toTypeTree n (k path)).append (fun suffix =>
+            toTypeTree p
+              (l (Equiv.cast (congrArg Path (toTypeTree_then c k)).symm
+                (PFunctor.FreeM.Path.append (toTypeTree m c)
+                  (fun path => toTypeTree n (k path)) path suffix))))) :=
+      PFunctor.FreeM.Path.append_tree_assoc _ _ _
+    _ = toTypeTree (m + (n + p))
+          (Chain.then c (fun path =>
+            Chain.then (k path) (fun suffix =>
+              l (appendThenPath c k path suffix)))) := by
+      symm
+      calc
+        toTypeTree (m + (n + p))
+              (Chain.then c (fun path =>
+                Chain.then (k path) (fun suffix =>
+                  l (appendThenPath c k path suffix)))) =
+            (toTypeTree m c).append (fun path =>
+              toTypeTree (n + p)
+                (Chain.then (k path) (fun suffix =>
+                  l (appendThenPath c k path suffix)))) :=
+          toTypeTree_then c _
+        _ = (toTypeTree m c).append (fun path =>
+              (toTypeTree n (k path)).append (fun suffix =>
+                toTypeTree p (l (appendThenPath c k path suffix)))) := by
+          congr 1
+          funext path
+          exact toTypeTree_then (k path) _
+        _ = (toTypeTree m c).append (fun path =>
+              (toTypeTree n (k path)).append (fun suffix =>
+                toTypeTree p
+                  (l (Equiv.cast (congrArg Path (toTypeTree_then c k)).symm
+                    (PFunctor.FreeM.Path.append (toTypeTree m c)
+                      (fun path => toTypeTree n (k path)) path suffix))))) := by
+          rfl
+
+end Chain
+end TypeTree
+end Interaction

--- a/PolyFun/Interaction/Basic/Strategy.lean
+++ b/PolyFun/Interaction/Basic/Strategy.lean
@@ -44,6 +44,31 @@ abbrev Strategy.Plain (m : Type u → Type u)
   StrategyOver (Strategy.syntax m) (PUnit.unit : PUnit.{u+1}) spec
     (Decoration.empty.{u, u} spec) Output
 
+/-- Transport a plain strategy across equality of its type tree and a
+pointwise identification of the correspondingly transported output family.
+
+The explicit family equality keeps dependent path transport localized here;
+callers do not need to unfold the `StrategyOver` representation. -/
+def Strategy.castSpec {m : Type u → Type u} {source target : TypeTree}
+    {Source : Path source → Type u} {Target : Path target → Type u}
+    (hSpec : source = target)
+    (hOutput : (path : Path target) →
+      Source (Equiv.cast (congrArg Path hSpec).symm path) = Target path)
+    (strategy : Strategy.Plain m source Source) :
+    Strategy.Plain m target Target := by
+  subst target
+  have hFamily : Source = Target := by
+    funext path
+    simpa using hOutput path
+  subst Target
+  exact strategy
+
+@[simp]
+theorem Strategy.castSpec_rfl {m : Type u → Type u} {spec : TypeTree}
+    {Output : Path spec → Type u} (strategy : Strategy.Plain m spec Output) :
+    Strategy.castSpec rfl (fun _ => rfl) strategy = strategy :=
+  rfl
+
 /-- One-step execution law for ordinary one-player strategies. -/
 def Strategy.interaction (m : Type u → Type u) [Monad m] :
     InteractionOver

--- a/PolyFunTest/Interaction/Basic/ChainAppendExamples.lean
+++ b/PolyFunTest/Interaction/Basic/ChainAppendExamples.lean
@@ -1,0 +1,175 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+import PolyFun.Interaction.Basic.Chain.Append
+
+/-!
+# Dependent chain-concatenation regression tests
+
+The three one-round stages below model a genuinely dependent three-stage
+pipeline. The middle move type depends on the prefix path, and the final move
+type depends on both the prefix and middle paths. The examples exercise raw
+and flattened units, boundary path and output-family transport, strategy
+composition, and typed three-stage reassociation.
+-/
+
+namespace Interaction
+namespace TypeTree
+namespace ChainAppendExamples
+
+private def prefixTree : TypeTree :=
+  .node Bool fun _ => .done
+
+private def prefixChain : Chain 1 :=
+  ⟨prefixTree, fun _ => ⟨⟩⟩
+
+private def middleTree (path : Path (Chain.toTypeTree 1 prefixChain)) : TypeTree :=
+  .node (Fin (bif path.1 then 2 else 3)) fun _ => .done
+
+private def middle (path : Path (Chain.toTypeTree 1 prefixChain)) : Chain 1 :=
+  ⟨middleTree path, fun _ => ⟨⟩⟩
+
+private def finalArity
+    (path : Path (Chain.toTypeTree (1 + 1) (Chain.then prefixChain middle))) : Nat :=
+  let pieces := Chain.splitThenPath prefixChain middle path
+  (bif pieces.1.1 then 10 else 20) + pieces.2.1.val + 1
+
+private def finalTree
+    (path : Path (Chain.toTypeTree (1 + 1) (Chain.then prefixChain middle))) : TypeTree :=
+  .node (Fin (finalArity path)) fun _ => .done
+
+private def final
+    (path : Path (Chain.toTypeTree (1 + 1) (Chain.then prefixChain middle))) : Chain 1 :=
+  ⟨finalTree path, fun _ => ⟨⟩⟩
+
+private def prefixPath : Path (Chain.toTypeTree 1 prefixChain) :=
+  ⟨true, ⟨⟩⟩
+
+private def middlePath : Path (Chain.toTypeTree 1 (middle prefixPath)) :=
+  ⟨(1 : Fin 2), ⟨⟩⟩
+
+private def combinedPath :
+    Path (Chain.toTypeTree (1 + 1) (Chain.then prefixChain middle)) :=
+  Chain.appendThenPath prefixChain middle prefixPath middlePath
+
+private def otherPrefixPath : Path (Chain.toTypeTree 1 prefixChain) :=
+  ⟨false, ⟨⟩⟩
+
+private def otherMiddlePath : Path (Chain.toTypeTree 1 (middle otherPrefixPath)) :=
+  ⟨(2 : Fin 3), ⟨⟩⟩
+
+private def otherCombinedPath :
+    Path (Chain.toTypeTree (1 + 1) (Chain.then prefixChain middle)) :=
+  Chain.appendThenPath prefixChain middle otherPrefixPath otherMiddlePath
+
+example : Chain.splitThenPath prefixChain middle combinedPath =
+    ⟨prefixPath, middlePath⟩ := by
+  simp [combinedPath]
+
+example : Chain.splitThenPath prefixChain middle otherCombinedPath =
+    ⟨otherPrefixPath, otherMiddlePath⟩ := by
+  simp [otherCombinedPath]
+
+example : finalArity combinedPath = 12 := rfl
+
+example : finalArity otherCombinedPath = 23 := rfl
+
+example : Chain.appendThenPath prefixChain middle
+      (Chain.splitThenPath prefixChain middle combinedPath).1
+      (Chain.splitThenPath prefixChain middle combinedPath).2 = combinedPath :=
+  Chain.appendThenPath_splitThenPath prefixChain middle combinedPath
+
+/-! ## Strategy composition across the chain boundary -/
+
+private def boundaryFamily
+    (path : Path (Chain.toTypeTree 1 prefixChain))
+    (suffix : Path (Chain.toTypeTree 1 (middle path))) : Type :=
+  Fin ((bif path.1 then 10 else 20) + suffix.1.val + 1)
+
+private def prefixStrategy :
+    Strategy.Plain Id (Chain.toTypeTree 1 prefixChain) (fun _ => PUnit) :=
+  ⟨true, ⟨⟩⟩
+
+private def suffixStrategy :
+    (path : Path (Chain.toTypeTree 1 prefixChain)) → PUnit →
+      Id (Strategy.Plain Id (Chain.toTypeTree 1 (middle path))
+        (boundaryFamily path))
+  | ⟨true, ⟨⟩⟩, _ => ⟨(1 : Fin 2), (0 : Fin 12)⟩
+  | ⟨false, ⟨⟩⟩, _ => ⟨(2 : Fin 3), (0 : Fin 23)⟩
+
+private def composedStrategy :
+    Strategy.Plain Id
+      (Chain.toTypeTree (1 + 1) (Chain.then prefixChain middle))
+      (Chain.liftThen prefixChain middle boundaryFamily) :=
+  Chain.strategyCompThen prefixChain middle prefixStrategy suffixStrategy
+
+/-- The chain-specific strategy combinator preserves the dependent prefix and
+suffix choices in the path returned by execution. -/
+example :
+    (Strategy.run
+      (Chain.toTypeTree (1 + 1) (Chain.then prefixChain middle))
+      composedStrategy).1 = combinedPath :=
+  rfl
+
+/-- The dependent output type computes through the joined boundary path. -/
+example :
+    (Strategy.run
+      (Chain.toTypeTree (1 + 1) (Chain.then prefixChain middle))
+      composedStrategy).2 = (0 : Fin 12) :=
+  rfl
+
+example :
+    Chain.liftThen prefixChain middle boundaryFamily combinedPath = Fin 12 := by
+  rw [show combinedPath =
+    Chain.appendThenPath prefixChain middle prefixPath middlePath from rfl]
+  simp [boundaryFamily, prefixPath, middlePath]
+
+example
+    (Family : {rounds : Nat} → Chain rounds → Type) :
+    Chain.outputFamily Family (1 + 1) (Chain.then prefixChain middle)
+        combinedPath =
+      Chain.outputFamily Family 1 (middle prefixPath) middlePath := by
+  rw [Chain.outputFamily_then]
+  change Chain.outputFamily Family 1
+      (middle (Chain.splitThenPath prefixChain middle combinedPath).1)
+      (Chain.splitThenPath prefixChain middle combinedPath).2 = _
+  rw [show combinedPath =
+    Chain.appendThenPath prefixChain middle prefixPath middlePath from rfl]
+  rw [Chain.splitThenPath_appendThenPath]
+
+example : Chain.toTypeTree (1 + 1) (Chain.then prefixChain middle) =
+    (Chain.toTypeTree 1 prefixChain).append
+      (fun path => Chain.toTypeTree 1 (middle path)) :=
+  Chain.toTypeTree_then prefixChain middle
+
+example : Chain.toTypeTree (0 + 1)
+      (Chain.then (⟨⟩ : Chain 0) (fun _ => prefixChain)) =
+    Chain.toTypeTree 1 prefixChain :=
+  Chain.toTypeTree_then_zero_left (⟨⟩ : Chain 0) (fun _ => prefixChain)
+
+example : Chain.castRounds (Nat.zero_add 1)
+      (Chain.then (⟨⟩ : Chain 0) (fun _ => prefixChain)) = prefixChain :=
+  Chain.then_zero_left (⟨⟩ : Chain 0) (fun _ => prefixChain)
+
+example : Chain.toTypeTree (1 + 0)
+      (Chain.then prefixChain (fun _ => (⟨⟩ : Chain 0))) =
+    Chain.toTypeTree 1 prefixChain :=
+  Chain.toTypeTree_then_zero_right prefixChain (fun _ => (⟨⟩ : Chain 0))
+
+example : Chain.then (n := 0) prefixChain (fun _ => (⟨⟩ : Chain 0)) = prefixChain :=
+  Chain.then_zero_right prefixChain (fun _ => (⟨⟩ : Chain 0))
+
+example :
+    Chain.toTypeTree (1 + (1 + 1))
+        (Chain.reassoc (Chain.then (Chain.then prefixChain middle) final)) =
+      Chain.toTypeTree (1 + (1 + 1))
+        (Chain.then prefixChain (fun path =>
+          Chain.then (middle path) (fun suffix =>
+            final (Chain.appendThenPath prefixChain middle path suffix)))) :=
+  Chain.toTypeTree_then_assoc prefixChain middle final
+
+end ChainAppendExamples
+end TypeTree
+end Interaction

--- a/docs/wiki/interaction.md
+++ b/docs/wiki/interaction.md
@@ -30,8 +30,8 @@ The framework is organized around a few stable principles:
   fully without controlling it.
 - **Boundary vs composition.** *Boundaries* adapt the interface of a fixed
   protocol (same path shape, same round structure). *Composition*
-  (`append`, `replicate`, `stateChain`) extends the protocol with new
-  rounds. Never conflate the two.
+  (`append`, `replicate`, `stateChain`, `Chain.then`) extends the protocol
+  with new rounds. Never conflate the two.
 - **Concurrency is layered.** The kernel is `par` + `Front` (frontier) +
   `residual` (one-step reduction). Interleaving is the basic semantics;
   independence and true concurrency are refinements on top. Dynamic
@@ -187,9 +187,10 @@ pattern:
 | Combinator | When to use |
 |------------|-------------|
 | `TypeTree.append s₁ s₂` | Two-phase protocol where phase 2 depends on phase 1's path |
-| `TypeTree.replicate spec n` | Fixed `n`-fold repetition of an identical spec |
+| `TypeTree.replicate tree n` | Fixed `n`-fold repetition of an identical type tree |
 | `TypeTree.stateChain Stage step n` | Clocked finite unfold with explicit stage-indexed state |
 | `TypeTree.Chain n` | Sigma-friendly presentation of `(TypeTree.stepPoly.Obj)^[n] PUnit` |
+| `TypeTree.Chain.then c k` | Path-dependent concatenation preserving explicit round counts |
 | `TypeTree.Telescope round step s` | Well-founded, possibly unbounded stopping tree from state `s` |
 
 These constructions share one polynomial substrate. `TypeTree.stepPoly` is
@@ -206,6 +207,13 @@ a termination certificate, because `done` is available at every state.
 `Path.liftAppend` lifts a type family on the first path to
 the combined path, avoiding `cast` / `Eq.rec` pollution.
 `Strategy.comp` composes strategies along `append`.
+At the explicit-round `Chain.then` boundary, `Chain.thenPathEquiv` and its
+split/join operations recover the two path pieces, `Chain.liftThen` transports
+dependent output families, and `Chain.strategyCompThen` composes strategies.
+Units hold at both the round-indexed and flattened levels. Three-stage
+associativity is stated after `Chain.toTypeTree`, the stable operational
+interpretation; raw equality of intensional `Chain` presentations is not part
+of the API contract.
 
 ## Two-party protocols (`TwoParty/`)
 
@@ -557,11 +565,12 @@ import PolyFun.Interaction.UC.OpenProcessModel
 | `Syntax.lean` | `SyntaxOver`, `SyntaxOver.Family` |
 | `Shape.lean` | `ShapeOver` (functorial `SyntaxOver` with continuation map) |
 | `Interaction.lean` | `InteractionOver`, `Interaction`, `run` |
-| `Strategy.lean` | `Strategy`, `Strategy.run`, `mapOutput` |
+| `Strategy.lean` | `Strategy`, `Strategy.run`, `mapOutput`, equality transport via `castSpec` |
 | `Append.lean` | `TypeTree.append`, path ops, `Strategy.comp` / `compFlat` |
 | `Replicate.lean` | `TypeTree.replicate`, `Strategy.iterate` |
 | `StateChain.lean` | `TypeTree.stateChain`, `Strategy.stateChainComp` |
 | `Chain.lean` | finite final-sequence `TypeTree.Chain`, `toTypeTree`, `ofStateChain`, `ofStateMachine` |
+| `Chain/Append.lean` | dependent `Chain.then`, units, boundary path/output/strategy composition, and three-stage coherence |
 | `Telescope.lean` | indexed stopping trees and their initial-algebra fold to `TypeTree` |
 | `Ownership.lean` | `LocalView` / `LocalRunner` builders for `SyntaxOver` |
 | `MonadDecoration.lean` | `MonadDecoration`, `Strategy.withMonads`, `runWithMonads` |

--- a/docs/wiki/repo-map.md
+++ b/docs/wiki/repo-map.md
@@ -164,7 +164,7 @@ PFunctor/Dynamical + ITree/Basic -> ITree/Unfold
 
 PFunctor/Free + Control -> Interaction/Basic/{TypeTree, Node, Decoration,
                             Syntax, Shape, Interaction, Strategy,
-                            Append, Replicate, StateChain, Chain,
+                            Append, Replicate, StateChain, Chain, Chain/Append,
                             Telescope, Sampler, MonadDecoration,
                             BundledMonad, Ownership, TypeTreeFintype}
 


### PR DESCRIPTION
## Summary

- add path-dependent `Chain.then` with explicit round counts
- prove raw and flattened left/right unit laws
- expose the dependent path equivalence through split/join operations
- add `Chain.liftThen` for dependent output families
- add `Chain.strategyCompThen` for strategy composition at the public boundary
- prove operational three-stage associativity
- update the generated imports, interaction wiki, and executable examples

## Semantic contract

A `Chain n` is an intensional finite-round presentation. `Chain.then` runs the prefix for `m` rounds and chooses the `n`-round suffix from the complete prefix path. The theorem `Chain.toTypeTree_then` identifies this operation with generic `PFunctor.FreeM.append`.

Associativity is deliberately stated for the stable operational interpretation, `toTypeTree`, rather than as raw equality between intensional `Chain` presentations. `Chain.toTypeTree_then_assoc` is the public three-stage law.

## Completed client boundary

The former external-client merge gate is superseded by an in-repository, branch-dependent executable example. It exercises:

- a `Bool` prefix branch
- `Fin 2` / `Fin 3` middle branches
- dependent `Fin 12` / `Fin 23` terminal outputs
- path splitting and reconstruction
- `liftThen` computation
- executable `strategyCompThen` path and dependent-output computation

This also closes the earlier deferred `outputFamily` and strategy-composition work against the current `StrategyOver` foundations.

## Validation

Validated at exact head `90beaf92c37317f45538ee7bce80ea5edf42c9e4`:

- `./scripts/validate.sh --lint --test`
- `lake exe lint-style`
- `git diff --check`
- axiom audit of the new public declarations (only standard Lean axioms where required)