### PR TITLE
feat(pfunctor): prove the cofree polynomial lax-monoidal structure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,8 @@ PFunctor/{Cofree, Comonoid, M/Vertex}
 PFunctor/{Cofree/Polynomial, Comonoid/Category}
   → PFunctor/Cofree/Universal
   → PFunctor/Cofree/FiniteProjection
+PFunctor/{Cofree/Universal, Comonoid/Tensor}
+  → PFunctor/Cofree/LaxMonoidal
 
 PFunctor/{Lens, Cofree, M} + Control/Coalgebra
   → PFunctor/Dynamical/{Basic, Safety, Combinators, Run, Speedup, Trajectory}

--- a/PolyFun.lean
+++ b/PolyFun.lean
@@ -118,6 +118,7 @@ import PolyFun.PFunctor.Category
 import PolyFun.PFunctor.Chart.Basic
 import PolyFun.PFunctor.Cofree
 import PolyFun.PFunctor.Cofree.FiniteProjection
+import PolyFun.PFunctor.Cofree.LaxMonoidal
 import PolyFun.PFunctor.Cofree.Polynomial
 import PolyFun.PFunctor.Cofree.Universal
 import PolyFun.PFunctor.Comonoid

--- a/PolyFun/PFunctor/Cofree/LaxMonoidal.lean
+++ b/PolyFun/PFunctor/Cofree/LaxMonoidal.lean
@@ -1,0 +1,351 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+module
+
+public import PolyFun.PFunctor.Cofree.Universal
+public import PolyFun.PFunctor.Comonoid.Tensor
+
+/-!
+# The cofree polynomial comonoid is lax monoidal
+
+The cofree-comonoid construction carries canonical comparison maps
+
+* `X ⇝ CofreeP X`, and
+* `CofreeP P ⊗ CofreeP Q ⇝ CofreeP (P ⊗ Q)`.
+
+They are the unique cofree extensions of the canonical unit comparison and of
+the tensor of the two cogenerators.  The cofree universal property reduces
+naturality, left and right unitality, and associativity to the corresponding
+tensor-lens coherence equations.
+
+This is Libkind–Spivak, *Pattern Runs on Matter*, Proposition C.1, and the
+concrete lax-monoidal construction of Spivak–Niu, Proposition 8.79 in the
+current edition (Proposition 8.81 in earlier-edition notes).  The module
+supplies the explicit maps and laws needed downstream; it does not install an
+abstract `LaxMonoidalFunctor` or symmetric-monoidal packaging.
+-/
+
+@[expose] public section
+
+universe uA uB uA₁ uB₁ uA₂ uB₂ uA₃ uB₃
+
+namespace PFunctor
+namespace CofreeP
+
+/-! ## Structure maps and generator equations -/
+
+/-- The lax-monoidal unit retrofunctor, obtained by cofreely extending the
+canonical comparison between the two required universe instances of `X`. -/
+def laxUnitHom :
+    Comonoid.Hom
+      (Comonoid.unit.{max uA uB, max uA uB})
+      (comonoid X.{uA, uB}) :=
+  extend (Comonoid.unit.{max uA uB, max uA uB})
+    (Lens.unitComparison :
+      Lens X.{max uA uB, max uA uB} X.{uA, uB})
+
+/-- The underlying lens of the lax-monoidal unit map. -/
+def laxUnit : Lens X.{max uA uB, max uA uB} (CofreeP X.{uA, uB}) :=
+  laxUnitHom.toLens
+
+@[simp]
+theorem laxUnitHom_toLens :
+    laxUnitHom.{uA, uB}.toLens = laxUnit.{uA, uB} :=
+  rfl
+
+/-- Projecting the lax unit to one generator layer recovers the canonical unit
+comparison. -/
+@[simp]
+theorem cogenerator_comp_laxUnit :
+    cogenerator X.{uA, uB} ∘ₗ laxUnit.{uA, uB} =
+      (Lens.unitComparison :
+        Lens X.{max uA uB, max uA uB} X.{uA, uB}) := by
+  exact restrict_extend (Comonoid.unit.{max uA uB, max uA uB})
+    (Lens.unitComparison :
+      Lens X.{max uA uB, max uA uB} X.{uA, uB})
+
+/-- The binary lax-monoidal comparison retrofunctor, obtained by cofreely
+extending the tensor of the two cogenerator lenses. -/
+def laxTensorHom (P : PFunctor.{uA₁, uB₁}) (Q : PFunctor.{uA₂, uB₂}) :
+    Comonoid.Hom
+      (Comonoid.tensor (comonoid P) (comonoid Q))
+      (comonoid (P ⊗ Q)) :=
+  extend (Comonoid.tensor (comonoid P) (comonoid Q))
+    (cogenerator P ⊗ₗ cogenerator Q)
+
+/-- The underlying lens of the binary lax-monoidal comparison. -/
+def laxTensor (P : PFunctor.{uA₁, uB₁}) (Q : PFunctor.{uA₂, uB₂}) :
+    Lens (CofreeP P ⊗ CofreeP Q) (CofreeP (P ⊗ Q)) :=
+  (laxTensorHom P Q).toLens
+
+@[simp]
+theorem laxTensorHom_toLens
+    (P : PFunctor.{uA₁, uB₁}) (Q : PFunctor.{uA₂, uB₂}) :
+    (laxTensorHom P Q).toLens = laxTensor P Q :=
+  rfl
+
+/-- Projecting the binary comparison to one generator layer recovers the
+tensor of the two cogenerators. -/
+@[simp]
+theorem cogenerator_comp_laxTensor
+    (P : PFunctor.{uA₁, uB₁}) (Q : PFunctor.{uA₂, uB₂}) :
+    cogenerator (P ⊗ Q) ∘ₗ laxTensor P Q =
+      cogenerator P ⊗ₗ cogenerator Q := by
+  exact restrict_extend (Comonoid.tensor (comonoid P) (comonoid Q))
+    (cogenerator P ⊗ₗ cogenerator Q)
+
+/-! ## Naturality -/
+
+/-- The binary comparison is natural in both generator polynomials.  Each
+source/target pair shares only the universe pair required by `mapHom`; the two
+tensor factors remain independent. -/
+theorem laxTensorHom_natural
+    {P P' : PFunctor.{uA₁, uB₁}} {Q Q' : PFunctor.{uA₂, uB₂}}
+    (f : Lens P P') (g : Lens Q Q') :
+    (Comonoid.Hom.tensor (mapHom f) (mapHom g)).comp
+        (laxTensorHom P' Q') =
+      (laxTensorHom P Q).comp (mapHom (f ⊗ₗ g)) := by
+  apply hom_ext_cogenerator
+  simp only [Comonoid.Hom.comp_toLens, Comonoid.Hom.tensor_toLens,
+    mapHom_toLens, laxTensorHom_toLens]
+  calc
+    cogenerator (P' ⊗ Q') ∘ₗ
+          (laxTensor P' Q' ∘ₗ (map f ⊗ₗ map g)) =
+        (cogenerator (P' ⊗ Q') ∘ₗ laxTensor P' Q') ∘ₗ
+          (map f ⊗ₗ map g) :=
+      (Lens.comp_assoc _ _ _).symm
+    _ = (cogenerator P' ⊗ₗ cogenerator Q') ∘ₗ
+          (map f ⊗ₗ map g) := by rw [cogenerator_comp_laxTensor]
+    _ = (cogenerator P' ∘ₗ map f) ⊗ₗ
+          (cogenerator Q' ∘ₗ map g) :=
+      (Lens.tensorMap_comp _ _ _ _).symm
+    _ = (f ∘ₗ cogenerator P) ⊗ₗ
+          (g ∘ₗ cogenerator Q) := by
+      rw [cogenerator_comp_map, cogenerator_comp_map]
+    _ = (f ⊗ₗ g) ∘ₗ (cogenerator P ⊗ₗ cogenerator Q) :=
+      Lens.tensorMap_comp _ _ _ _
+    _ = (f ⊗ₗ g) ∘ₗ
+          (cogenerator (P ⊗ Q) ∘ₗ laxTensor P Q) := by
+      rw [cogenerator_comp_laxTensor]
+    _ = ((f ⊗ₗ g) ∘ₗ cogenerator (P ⊗ Q)) ∘ₗ laxTensor P Q :=
+      (Lens.comp_assoc _ _ _).symm
+    _ = (cogenerator (P' ⊗ Q') ∘ₗ map (f ⊗ₗ g)) ∘ₗ
+          laxTensor P Q := by rw [cogenerator_comp_map]
+    _ = cogenerator (P' ⊗ Q') ∘ₗ
+          (map (f ⊗ₗ g) ∘ₗ laxTensor P Q) :=
+      Lens.comp_assoc _ _ _
+
+/-- Lens-level naturality of the binary lax-monoidal comparison inside each
+fixed-universe polynomial category.  Cross-universe naturality requires a
+heterogeneous retrofunctor-law API beyond the homogeneous `Comonoid.Hom`
+boundary. -/
+theorem laxTensor_natural
+    {P P' : PFunctor.{uA₁, uB₁}} {Q Q' : PFunctor.{uA₂, uB₂}}
+    (f : Lens P P') (g : Lens Q Q') :
+    laxTensor P' Q' ∘ₗ (map f ⊗ₗ map g) =
+      map (f ⊗ₗ g) ∘ₗ laxTensor P Q := by
+  exact congrArg Comonoid.Hom.toLens (laxTensorHom_natural f g)
+
+/-! ## Lax-monoidal coherence -/
+
+/-- Left-unit coherence for the lax-monoidal comparison, at the level of
+retrofunctors. -/
+theorem laxTensorHom_unit_left (P : PFunctor.{uA, uB}) :
+    ((Comonoid.Hom.tensor laxUnitHom.{uA, uB}
+        (Comonoid.Hom.id (comonoid P))).comp
+      (laxTensorHom X.{uA, uB} P)).comp
+        (mapHom (Lens.Equiv.xTensor (P := P)).toLens) =
+      (Comonoid.tensorUnitLeftIso (comonoid P)).hom := by
+  apply hom_ext_cogenerator
+  simp only [Comonoid.Hom.comp_toLens, Comonoid.Hom.tensor_toLens,
+    Comonoid.Hom.id_toLens, mapHom_toLens, laxTensorHom_toLens,
+    laxUnitHom_toLens, Comonoid.tensorUnitLeftIso_hom_toLens]
+  calc
+    cogenerator P ∘ₗ
+          (map ((Lens.Equiv.xTensor (P := P)).toLens) ∘ₗ
+            (laxTensor X.{uA, uB} P ∘ₗ
+              (laxUnit.{uA, uB} ⊗ₗ Lens.id (CofreeP P)))) =
+        ((Lens.Equiv.xTensor (P := P)).toLens ∘ₗ
+          cogenerator (X.{uA, uB} ⊗ P)) ∘ₗ
+            (laxTensor X.{uA, uB} P ∘ₗ
+              (laxUnit.{uA, uB} ⊗ₗ Lens.id (CofreeP P))) := by
+      rw [← Lens.comp_assoc, cogenerator_comp_map]
+    _ = (Lens.Equiv.xTensor (P := P)).toLens ∘ₗ
+          ((cogenerator (X.{uA, uB} ⊗ P) ∘ₗ
+              laxTensor X.{uA, uB} P) ∘ₗ
+            (laxUnit.{uA, uB} ⊗ₗ Lens.id (CofreeP P))) := by
+      simp only [Lens.comp_assoc]
+    _ = (Lens.Equiv.xTensor (P := P)).toLens ∘ₗ
+          ((cogenerator X.{uA, uB} ⊗ₗ cogenerator P) ∘ₗ
+            (laxUnit.{uA, uB} ⊗ₗ Lens.id (CofreeP P))) := by
+      rw [cogenerator_comp_laxTensor]
+    _ = (Lens.Equiv.xTensor (P := P)).toLens ∘ₗ
+          ((cogenerator X.{uA, uB} ∘ₗ laxUnit.{uA, uB}) ⊗ₗ
+            (cogenerator P ∘ₗ Lens.id (CofreeP P))) := by
+      rw [Lens.tensorMap_comp]
+    _ = (Lens.Equiv.xTensor (P := P)).toLens ∘ₗ
+          ((Lens.unitComparison :
+              Lens X.{max uA uB, max uA uB} X.{uA, uB}) ⊗ₗ
+            cogenerator P) := by
+      simp only [cogenerator_comp_laxUnit, Lens.comp_id]
+    _ = cogenerator P ∘ₗ
+          (Lens.Equiv.xTensor (P := CofreeP P)).toLens :=
+      (Lens.xTensor_natural (cogenerator P)).symm
+
+/-- Right-unit coherence for the lax-monoidal comparison, at the level of
+retrofunctors. -/
+theorem laxTensorHom_unit_right (P : PFunctor.{uA, uB}) :
+    ((Comonoid.Hom.tensor (Comonoid.Hom.id (comonoid P))
+        laxUnitHom.{uA, uB}).comp
+      (laxTensorHom P X.{uA, uB})).comp
+        (mapHom (Lens.Equiv.tensorX (P := P)).toLens) =
+      (Comonoid.tensorUnitRightIso (comonoid P)).hom := by
+  apply hom_ext_cogenerator
+  simp only [Comonoid.Hom.comp_toLens, Comonoid.Hom.tensor_toLens,
+    Comonoid.Hom.id_toLens, mapHom_toLens, laxTensorHom_toLens,
+    laxUnitHom_toLens, Comonoid.tensorUnitRightIso_hom_toLens]
+  calc
+    cogenerator P ∘ₗ
+          (map ((Lens.Equiv.tensorX (P := P)).toLens) ∘ₗ
+            (laxTensor P X.{uA, uB} ∘ₗ
+              (Lens.id (CofreeP P) ⊗ₗ laxUnit.{uA, uB}))) =
+        ((Lens.Equiv.tensorX (P := P)).toLens ∘ₗ
+          cogenerator (P ⊗ X.{uA, uB})) ∘ₗ
+            (laxTensor P X.{uA, uB} ∘ₗ
+              (Lens.id (CofreeP P) ⊗ₗ laxUnit.{uA, uB})) := by
+      rw [← Lens.comp_assoc, cogenerator_comp_map]
+    _ = (Lens.Equiv.tensorX (P := P)).toLens ∘ₗ
+          ((cogenerator (P ⊗ X.{uA, uB}) ∘ₗ
+              laxTensor P X.{uA, uB}) ∘ₗ
+            (Lens.id (CofreeP P) ⊗ₗ laxUnit.{uA, uB})) := by
+      simp only [Lens.comp_assoc]
+    _ = (Lens.Equiv.tensorX (P := P)).toLens ∘ₗ
+          ((cogenerator P ⊗ₗ cogenerator X.{uA, uB}) ∘ₗ
+            (Lens.id (CofreeP P) ⊗ₗ laxUnit.{uA, uB})) := by
+      rw [cogenerator_comp_laxTensor]
+    _ = (Lens.Equiv.tensorX (P := P)).toLens ∘ₗ
+          ((cogenerator P ∘ₗ Lens.id (CofreeP P)) ⊗ₗ
+            (cogenerator X.{uA, uB} ∘ₗ laxUnit.{uA, uB})) := by
+      rw [Lens.tensorMap_comp]
+    _ = (Lens.Equiv.tensorX (P := P)).toLens ∘ₗ
+          (cogenerator P ⊗ₗ
+            (Lens.unitComparison :
+              Lens X.{max uA uB, max uA uB} X.{uA, uB})) := by
+      simp only [cogenerator_comp_laxUnit, Lens.comp_id]
+    _ = cogenerator P ∘ₗ
+          (Lens.Equiv.tensorX (P := CofreeP P)).toLens :=
+      (Lens.tensorX_natural (cogenerator P)).symm
+
+/-- Associativity coherence for the lax-monoidal comparison, at the level of
+retrofunctors. -/
+theorem laxTensorHom_assoc
+    (P : PFunctor.{uA₁, uB₁}) (Q : PFunctor.{uA₂, uB₂})
+    (R : PFunctor.{uA₃, uB₃}) :
+    (((Comonoid.tensorAssocIso (comonoid P) (comonoid Q) (comonoid R)).hom.comp
+        (Comonoid.Hom.tensor (Comonoid.Hom.id (comonoid P))
+          (laxTensorHom Q R))).comp
+      (laxTensorHom P (Q ⊗ R))) =
+    (((Comonoid.Hom.tensor (laxTensorHom P Q)
+        (Comonoid.Hom.id (comonoid R))).comp
+      (laxTensorHom (P ⊗ Q) R)).comp
+        (mapHom (Lens.Equiv.tensorAssoc
+          (P := P) (Q := Q) (R := R)).toLens)) := by
+  apply hom_ext_cogenerator
+  simp only [Comonoid.Hom.comp_toLens, Comonoid.Hom.tensor_toLens,
+    Comonoid.Hom.id_toLens, mapHom_toLens, laxTensorHom_toLens,
+    Comonoid.tensorAssocIso_hom_toLens]
+  calc
+    cogenerator (P ⊗ (Q ⊗ R)) ∘ₗ
+          (laxTensor P (Q ⊗ R) ∘ₗ
+            ((Lens.id (CofreeP P) ⊗ₗ laxTensor Q R) ∘ₗ
+              (Lens.Equiv.tensorAssoc
+                (P := CofreeP P) (Q := CofreeP Q)
+                (R := CofreeP R)).toLens)) =
+        (cogenerator P ⊗ₗ (cogenerator Q ⊗ₗ cogenerator R)) ∘ₗ
+          (Lens.Equiv.tensorAssoc
+            (P := CofreeP P) (Q := CofreeP Q)
+            (R := CofreeP R)).toLens := by
+      rw [← Lens.comp_assoc, cogenerator_comp_laxTensor,
+        ← Lens.comp_assoc, ← Lens.tensorMap_comp]
+      simp only [cogenerator_comp_laxTensor, Lens.comp_id]
+    _ = (Lens.Equiv.tensorAssoc (P := P) (Q := Q) (R := R)).toLens ∘ₗ
+          ((cogenerator P ⊗ₗ cogenerator Q) ⊗ₗ cogenerator R) :=
+      Lens.tensorAssoc_natural (cogenerator P) (cogenerator Q) (cogenerator R)
+    _ = (Lens.Equiv.tensorAssoc (P := P) (Q := Q) (R := R)).toLens ∘ₗ
+          (cogenerator ((P ⊗ Q) ⊗ R) ∘ₗ
+            (laxTensor (P ⊗ Q) R ∘ₗ
+              (laxTensor P Q ⊗ₗ Lens.id (CofreeP R)))) := by
+      apply congrArg (fun lens =>
+        (Lens.Equiv.tensorAssoc (P := P) (Q := Q) (R := R)).toLens ∘ₗ lens)
+      calc
+        (cogenerator P ⊗ₗ cogenerator Q) ⊗ₗ cogenerator R =
+            (cogenerator (P ⊗ Q) ∘ₗ laxTensor P Q) ⊗ₗ
+              (cogenerator R ∘ₗ Lens.id (CofreeP R)) := by
+          rw [cogenerator_comp_laxTensor]
+          simp only [Lens.comp_id]
+        _ = (cogenerator (P ⊗ Q) ⊗ₗ cogenerator R) ∘ₗ
+              (laxTensor P Q ⊗ₗ Lens.id (CofreeP R)) :=
+          Lens.tensorMap_comp _ _ _ _
+        _ = (cogenerator ((P ⊗ Q) ⊗ R) ∘ₗ
+              laxTensor (P ⊗ Q) R) ∘ₗ
+              (laxTensor P Q ⊗ₗ Lens.id (CofreeP R)) := by
+          rw [cogenerator_comp_laxTensor]
+        _ = cogenerator ((P ⊗ Q) ⊗ R) ∘ₗ
+              (laxTensor (P ⊗ Q) R ∘ₗ
+                (laxTensor P Q ⊗ₗ Lens.id (CofreeP R))) :=
+          Lens.comp_assoc _ _ _
+    _ = cogenerator (P ⊗ (Q ⊗ R)) ∘ₗ
+          (map ((Lens.Equiv.tensorAssoc
+              (P := P) (Q := Q) (R := R)).toLens) ∘ₗ
+            (laxTensor (P ⊗ Q) R ∘ₗ
+              (laxTensor P Q ⊗ₗ Lens.id (CofreeP R)))) := by
+      calc
+        _ = ((Lens.Equiv.tensorAssoc (P := P) (Q := Q) (R := R)).toLens ∘ₗ
+              cogenerator ((P ⊗ Q) ⊗ R)) ∘ₗ
+              (laxTensor (P ⊗ Q) R ∘ₗ
+                (laxTensor P Q ⊗ₗ Lens.id (CofreeP R))) :=
+          (Lens.comp_assoc _ _ _).symm
+        _ = (cogenerator (P ⊗ (Q ⊗ R)) ∘ₗ
+              map ((Lens.Equiv.tensorAssoc
+                (P := P) (Q := Q) (R := R)).toLens)) ∘ₗ
+              (laxTensor (P ⊗ Q) R ∘ₗ
+                (laxTensor P Q ⊗ₗ Lens.id (CofreeP R))) := by
+          rw [cogenerator_comp_map]
+        _ = _ := Lens.comp_assoc _ _ _
+
+/-! ### Consumer-facing lens equations -/
+
+/-- Lens-level left-unit coherence. -/
+theorem laxTensor_unit_left (P : PFunctor.{uA, uB}) :
+    map ((Lens.Equiv.xTensor (P := P)).toLens) ∘ₗ
+        laxTensor X.{uA, uB} P ∘ₗ
+        (laxUnit.{uA, uB} ⊗ₗ Lens.id (CofreeP P)) =
+      (Lens.Equiv.xTensor (P := CofreeP P)).toLens := by
+  exact congrArg Comonoid.Hom.toLens (laxTensorHom_unit_left P)
+
+/-- Lens-level right-unit coherence. -/
+theorem laxTensor_unit_right (P : PFunctor.{uA, uB}) :
+    map ((Lens.Equiv.tensorX (P := P)).toLens) ∘ₗ
+        laxTensor P X.{uA, uB} ∘ₗ
+        (Lens.id (CofreeP P) ⊗ₗ laxUnit.{uA, uB}) =
+      (Lens.Equiv.tensorX (P := CofreeP P)).toLens := by
+  exact congrArg Comonoid.Hom.toLens (laxTensorHom_unit_right P)
+
+/-- Lens-level associativity coherence. -/
+theorem laxTensor_assoc
+    (P : PFunctor.{uA₁, uB₁}) (Q : PFunctor.{uA₂, uB₂})
+    (R : PFunctor.{uA₃, uB₃}) :
+    laxTensor P (Q ⊗ R) ∘ₗ
+        (Lens.id (CofreeP P) ⊗ₗ laxTensor Q R) ∘ₗ
+        (Lens.Equiv.tensorAssoc
+          (P := CofreeP P) (Q := CofreeP Q) (R := CofreeP R)).toLens =
+      map ((Lens.Equiv.tensorAssoc (P := P) (Q := Q) (R := R)).toLens) ∘ₗ
+        laxTensor (P ⊗ Q) R ∘ₗ
+        (laxTensor P Q ⊗ₗ Lens.id (CofreeP R)) := by
+  exact congrArg Comonoid.Hom.toLens (laxTensorHom_assoc P Q R)
+
+end CofreeP
+end PFunctor

--- a/PolyFun/PFunctor/Cofree/Universal.lean
+++ b/PolyFun/PFunctor/Cofree/Universal.lean
@@ -812,6 +812,16 @@ def homEquiv
   left_inv := extend_restrict C
   right_inv := restrict_extend C
 
+/-- Two retrofunctors into a cofree polynomial comonoid are equal when their
+one-layer cogenerator projections agree. -/
+theorem hom_ext_cogenerator
+    {C : Comonoid.{max uA uB, max uA uB}}
+    {f g : Comonoid.Hom C (comonoid P)}
+    (h : cogenerator P ∘ₗ f.toLens = cogenerator P ∘ₗ g.toLens) :
+    f = g := by
+  apply (homEquiv (P := P) C).injective
+  exact h
+
 /-- The cofree hom-set equivalence is natural in its source comonoid. -/
 theorem homEquiv_naturality_left
     {C₁ C₂ : Comonoid.{max uA uB, max uA uB}}

--- a/PolyFunTest/PFunctor/CofreeLaxMonoidal.lean
+++ b/PolyFunTest/PFunctor/CofreeLaxMonoidal.lean
@@ -1,0 +1,305 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+module
+
+public import PolyFun.PFunctor.Cofree.LaxMonoidal
+public import PolyFun.PFunctor.Cofree.FiniteProjection
+
+/-!
+# Regression tests for cofree lax monoidality
+
+The generic canaries keep every generator universe pair independent and pin
+naturality plus all three lax-monoidal coherence equations.  The concrete
+tests synchronize two observably different behavior trees.  Their backward
+maps distinguish the two factors and two different depth-two direction
+sequences, so a copied, swapped, reversed, or root-only implementation fails.
+
+This is the concrete lax-monoidal structure of Spivak–Niu, Proposition 8.79
+in the current edition (Proposition 8.81 in the earlier-edition notes).
+-/
+
+@[expose] public section
+
+universe pA₁ pB₁ qA₁ qB₁ rA₁ rB₁
+
+namespace PFunctor
+namespace CofreeLaxMonoidalTest
+
+/-! ## Universe and theorem-surface canaries -/
+
+/-- The unit comparison preserves the generator's independent position and
+direction universes and lands in the diagonal universe of `CofreeP`. -/
+example :
+    Lens X.{max pA₁ pB₁, max pA₁ pB₁}
+      (CofreeP X.{pA₁, pB₁}) :=
+  CofreeP.laxUnit
+
+/-- The binary laxator leaves both input universe pairs independent. -/
+example (P : PFunctor.{pA₁, pB₁}) (Q : PFunctor.{qA₁, qB₁}) :
+    Lens (CofreeP P ⊗ CofreeP Q) (CofreeP (P ⊗ Q)) :=
+  CofreeP.laxTensor P Q
+
+/-- Naturality is nontrivial in both factors while retaining separate
+universe pairs for the two functor arguments. -/
+example
+    {P₁ P₂ : PFunctor.{pA₁, pB₁}}
+    {Q₁ Q₂ : PFunctor.{qA₁, qB₁}}
+    (f : Lens P₁ P₂) (g : Lens Q₁ Q₂) :
+    CofreeP.laxTensor P₂ Q₂ ∘ₗ
+        (CofreeP.map f ⊗ₗ CofreeP.map g) =
+      CofreeP.map (f ⊗ₗ g) ∘ₗ CofreeP.laxTensor P₁ Q₁ :=
+  CofreeP.laxTensor_natural f g
+
+/-- Left- and right-unit coherence do not identify the generator's position
+and direction universes. -/
+example (P : PFunctor.{pA₁, pB₁}) :
+    CofreeP.map (Lens.Equiv.xTensor (P := P)).toLens ∘ₗ
+        CofreeP.laxTensor X.{pA₁, pB₁} P ∘ₗ
+        (CofreeP.laxUnit.{pA₁, pB₁} ⊗ₗ Lens.id (CofreeP P)) =
+      (Lens.Equiv.xTensor (P := CofreeP P)).toLens :=
+  CofreeP.laxTensor_unit_left P
+
+example (P : PFunctor.{pA₁, pB₁}) :
+    CofreeP.map (Lens.Equiv.tensorX (P := P)).toLens ∘ₗ
+        CofreeP.laxTensor P X.{pA₁, pB₁} ∘ₗ
+        (Lens.id (CofreeP P) ⊗ₗ CofreeP.laxUnit.{pA₁, pB₁}) =
+      (Lens.Equiv.tensorX (P := CofreeP P)).toLens :=
+  CofreeP.laxTensor_unit_right P
+
+/-- Associativity retains all six position/direction universes belonging to
+the three independent polynomial arguments. -/
+example
+    (P : PFunctor.{pA₁, pB₁}) (Q : PFunctor.{qA₁, qB₁})
+    (R : PFunctor.{rA₁, rB₁}) :
+    CofreeP.laxTensor P (Q ⊗ R) ∘ₗ
+        (Lens.id (CofreeP P) ⊗ₗ CofreeP.laxTensor Q R) ∘ₗ
+        (Lens.Equiv.tensorAssoc
+          (P := CofreeP P) (Q := CofreeP Q) (R := CofreeP R)).toLens =
+      CofreeP.map
+          (Lens.Equiv.tensorAssoc (P := P) (Q := Q) (R := R)).toLens ∘ₗ
+        CofreeP.laxTensor (P ⊗ Q) R ∘ₗ
+        (CofreeP.laxTensor P Q ⊗ₗ Lens.id (CofreeP R)) :=
+  CofreeP.laxTensor_assoc P Q R
+
+/-! ## Observable synchronized trees -/
+
+inductive LeftLabel where
+  | initial
+  | afterFalse
+  | afterTrue
+  deriving DecidableEq, Repr
+
+inductive RightLabel where
+  | initial
+  | afterZero
+  | afterOne
+  | afterTwo
+  deriving DecidableEq, Repr
+
+/-- A binary behavior signature whose node labels remember the last branch. -/
+abbrev leftP : PFunctor := ⟨LeftLabel, fun _ => Bool⟩
+
+/-- A ternary behavior signature, making the right factor's directions
+definitionally different from the left factor's. -/
+abbrev rightP : PFunctor := ⟨RightLabel, fun _ => Fin 3⟩
+
+/-- Reverse the observable Boolean branch of the left signature.  This is
+nonidentity on both the remembered node label and the pulled-back direction. -/
+def leftFlip : Lens leftP leftP where
+  toFunA
+    | .initial => .initial
+    | .afterFalse => .afterTrue
+    | .afterTrue => .afterFalse
+  toFunB _ direction := !direction
+
+/-- Naturality is exercised with an actual nonidentity map in the left factor,
+not only with abstract lens variables. -/
+example :
+    CofreeP.laxTensor leftP rightP ∘ₗ
+        (CofreeP.map leftFlip ⊗ₗ
+          CofreeP.map (Lens.id rightP)) =
+      CofreeP.map (leftFlip ⊗ₗ Lens.id rightP) ∘ₗ
+        CofreeP.laxTensor leftP rightP :=
+  CofreeP.laxTensor_natural leftFlip (Lens.id rightP)
+
+def leftStep (history : List Bool) : leftP (List Bool) :=
+  ⟨match history.head? with
+    | none => .initial
+    | some false => .afterFalse
+    | some true => .afterTrue,
+    fun direction => direction :: history⟩
+
+def rightStep (history : List (Fin 3)) : rightP (List (Fin 3)) :=
+  ⟨match history.head? with
+    | none => .initial
+    | some 0 => .afterZero
+    | some 1 => .afterOne
+    | some _ => .afterTwo,
+    fun direction => direction :: history⟩
+
+def leftTree : M leftP := M.corec leftStep []
+
+def rightTree : M rightP := M.corec rightStep []
+
+/-- The concrete map used above is observably nonidentity: a target `false`
+edge is pulled back to a source `true` edge. -/
+example :
+    match (CofreeP.map leftFlip).toFunB leftTree
+        (.child false (.root _)) with
+    | .child direction _ => direction = true
+    | .root _ => False := by
+  change
+    match M.Vertex.pullMapLens leftFlip leftTree
+        (.child false (.root _)) with
+    | .child direction _ => direction = true
+    | .root _ => False
+  rw [M.Vertex.pullMapLens_child]
+  rfl
+
+/-- The synchronized tree advances the two inputs only along paired
+directions. -/
+def synchronizedTree : M (leftP ⊗ rightP) :=
+  (CofreeP.laxTensor leftP rightP).toFunA (leftTree, rightTree)
+
+/-- The two different root-label types and values make factor order visible. -/
+example : M.head synchronizedTree = (.initial, .initial) := by
+  change M.head
+      (CofreeP.unfoldShape
+        (Comonoid.tensor (CofreeP.comonoid leftP)
+          (CofreeP.comonoid rightP))
+        (CofreeP.cogenerator leftP ⊗ₗ CofreeP.cogenerator rightP)
+        (leftTree, rightTree)) = _
+  rw [CofreeP.head_unfoldShape]
+  rfl
+
+/-- Pulling back the synchronized root returns both source roots, not a copied
+or swapped component. -/
+example :
+    (CofreeP.laxTensor leftP rightP).toFunB
+        (leftTree, rightTree) (.root synchronizedTree) =
+      (.root leftTree, .root rightTree) := by
+  calc
+    _ = Comonoid.identity
+          (Comonoid.tensor (CofreeP.comonoid leftP)
+            (CofreeP.comonoid rightP))
+          (leftTree, rightTree) := by
+      simpa [synchronizedTree] using
+        (CofreeP.laxTensorHom leftP rightP).map_identity
+          (leftTree, rightTree)
+    _ = (.root leftTree, .root rightTree) := rfl
+
+/-- One synchronized edge pulls back to the matching edge in each source
+tree.  This is the executable content of the laxator's generator equation. -/
+theorem laxTensor_oneLayer (left : M leftP) (right : M rightP)
+    (direction : Bool × Fin 3) :
+    (CofreeP.laxTensor leftP rightP).toFunB (left, right)
+        (.child direction (.root _)) =
+      (.child direction.1 (.root _), .child direction.2 (.root _)) := by
+  have h := congrArg
+    (fun lens : Lens (CofreeP leftP ⊗ CofreeP rightP) (leftP ⊗ rightP) =>
+      lens.toFunB (left, right) direction)
+    (CofreeP.cogenerator_comp_laxTensor leftP rightP)
+  exact h
+
+/-- The first edge of the decisive synchronized path. -/
+def synchronizedOuter : M.Vertex synchronizedTree :=
+  .child (false, 2) (.root _)
+
+/-- The second edge starts in the subtree selected by `synchronizedOuter`. -/
+def synchronizedInner : M.Vertex (M.Vertex.subtree synchronizedOuter) :=
+  .child (true, 0) (.root _)
+
+/-- A depth-two synchronized vertex with different component paths. -/
+def synchronizedVertex : M.Vertex synchronizedTree :=
+  M.Vertex.append synchronizedOuter synchronizedInner
+
+/-- Read the directions of a finite left-hand vertex from root to leaf. -/
+def leftDirections : {tree : M leftP} → M.Vertex tree → List Bool
+  | _, .root _ => []
+  | _, .child direction next => direction :: leftDirections next
+
+/-- Read the directions of a finite right-hand vertex from root to leaf. -/
+def rightDirections : {tree : M rightP} → M.Vertex tree → List (Fin 3)
+  | _, .root _ => []
+  | _, .child direction next => direction :: rightDirections next
+
+/-- The depth-two composite direction selecting the decisive synchronized
+path. -/
+def synchronizedDirection :
+    (compNth (leftP ⊗ rightP) 2).B
+      ((CofreeP.projectionN (leftP ⊗ rightP) 2).toFunA synchronizedTree) :=
+  by
+    refine ⟨(false, 2), ?_⟩
+    refine ⟨(true, 0), ?_⟩
+    exact PUnit.unit
+
+/-- The finite depth-two projection selects exactly the append-built vertex
+used by the executable behavior test. -/
+example :
+    (CofreeP.projectionN (leftP ⊗ rightP) 2).toFunB
+      synchronizedTree synchronizedDirection = synchronizedVertex := by
+  rfl
+
+/-- The backward map preserves both component sequences in outer-to-inner
+order.  This detects swapped factors, copied directions, reversed paths, and
+an implementation that only handles the root or first layer. -/
+example :
+    let pulled := (CofreeP.laxTensor leftP rightP).toFunB
+      (leftTree, rightTree)
+      ((CofreeP.projectionN (leftP ⊗ rightP) 2).toFunB
+        synchronizedTree synchronizedDirection)
+    leftDirections pulled.1 = [false, true] ∧
+      rightDirections pulled.2 = [2, 0] := by
+  let F := CofreeP.laxTensorHom leftP rightP
+  have h := congrArg
+    (fun lens : Lens
+        ((CofreeP.comonoid leftP).tensor (CofreeP.comonoid rightP)).carrier
+        (compNth (leftP ⊗ rightP) 2) =>
+      lens.toFunB (leftTree, rightTree) synchronizedDirection)
+    (CofreeP.hom_comp_projectionN F 2)
+  dsimp only
+  change
+    leftDirections
+        ((F.toLens ⨟ CofreeP.projectionN (leftP ⊗ rightP) 2).toFunB
+          (leftTree, rightTree) synchronizedDirection).1 = [false, true] ∧
+      rightDirections
+        ((F.toLens ⨟ CofreeP.projectionN (leftP ⊗ rightP) 2).toFunB
+          (leftTree, rightTree) synchronizedDirection).2 = [2, 0]
+  have hleft := congrArg (fun pair => leftDirections pair.1) h
+  have hright := congrArg (fun pair => rightDirections pair.2) h
+  constructor
+  · exact hleft.trans (by
+      dsimp only [F, CofreeP.laxTensorHom]
+      rw [CofreeP.restrict_extend]
+      simp only [CofreeP.comonoid_carrier, Comonoid.tensor_carrier, compNth,
+        Lens.compNthMap_succ, Lens.compNthMap_zero,
+        Comonoid.comultN_succ, Comonoid.comultN_zero]
+      rfl)
+  · exact hright.trans (by
+      dsimp only [F, CofreeP.laxTensorHom]
+      rw [CofreeP.restrict_extend]
+      simp only [CofreeP.comonoid_carrier, Comonoid.tensor_carrier, compNth,
+        Lens.compNthMap_succ, Lens.compNthMap_zero,
+        Comonoid.comultN_succ, Comonoid.comultN_zero]
+      rfl)
+
+/-! ## Observable lax unit -/
+
+def unitTree : M X :=
+  CofreeP.laxUnit.toFunA PUnit.unit
+
+/-- A non-root unit vertex is an elaboration and totality canary for finite
+paths.  Its output is necessarily unobservable because every direction of the
+tensor unit is `PUnit`. -/
+def unitDepthTwo : M.Vertex unitTree :=
+  .child PUnit.unit
+    (.child PUnit.unit (.root _))
+
+example : CofreeP.laxUnit.toFunB PUnit.unit unitDepthTwo = PUnit.unit := by
+  rfl
+
+end CofreeLaxMonoidalTest
+end PFunctor

--- a/docs/reading/roadmap.md
+++ b/docs/reading/roadmap.md
@@ -20,7 +20,7 @@ Announced VCVio baseline: `2026-899.pdf` (ePrint 2026/899).
 | Ch 5 factorizations, adjunctions, (co)limits | **Done**: vertical–cartesian factorization and orthogonality (A3), trivial-interface adjunctions plus binary tensor gluing (A4/A5), and cartesian closure (A2); general (co)limits remain open |
 | Ch 6 ◁ theory (composites, coclosure, duoidal) | **Done**: direct composite-lens projections, `compNthMap`, δ/`twoStep`, full left Π-distributivity, ordering/interchange naturality and complete concrete duoidal coherence; coclosure/multiadjoint (A8) remains open |
 | Ch 7 comonoids = categories, retrofunctors | **Done (B1–B4 spine)**: `Comonoid`, `Comonoid.Hom`/`Cat♯`, state comonoids, `δ^(n)`, `Run_n`, and the `IOMachine` run/composition core; §7.3.3 quadruple (B5), all-bracketing canonicity, and representable-monoid equivalence remain open |
-| Ch 8 cofree comonoid, Cat♯ ⊣ Poly, bicomodules | **C1/C2 done; C3 finite-run spine done**: `M.Vertex`, `CofreeP.comonoid`, generic coiteration, the natural hom-set equivalence, its dynamical behavior/trajectory specialization, structural finite projections, and Prop 8.49; Equation 8.32/additive reassociation, explicit pretree-limit coherence, lax monoidality, and bicomodules remain open |
+| Ch 8 cofree comonoid, Cat♯ ⊣ Poly, bicomodules | **C1/C2 done; C3 finite-run and lax-monoidal spine done**: `M.Vertex`, `CofreeP.comonoid`, generic coiteration, the natural hom-set equivalence, its dynamical behavior/trajectory specialization, structural finite projections, Prop 8.49, and the cofree laxator with its concrete coherence laws; Equation 8.32/additive reassociation, explicit pretree-limit coherence, abstract monoidal packaging, and bicomodules remain open |
 
 ## Reading units
 
@@ -285,9 +285,12 @@ canonical `FreeM` interpretation.
   Functoriality `𝒯_φ` (§8.1.5) + `φ` cartesian ⟹ `𝒯_φ` cartesian
   (Prop 8.72); `𝒯_p` free on a graph (Prop 8.57). The composition-unit
   comonoid, heterogeneous tensor of comonoids and retrofunctors, and pointwise
-  tensor unitors/associator are complete; lax monoidality
-  `t_p ⊗ t_q ⇆ t_{p⊗q}` (Prop 8.79 in the current edition; Prop 8.81
-  in earlier-edition notes) remains downstream. Worked tests with paper value:
+  tensor unitors/associator are complete. **Lax monoidality is done:** the
+  canonical retrofunctors `y ⇆ t_y` and `t_p ⊗ t_q ⇆ t_{p⊗q}` have
+  generator equations, naturality, and both unit and associativity coherence
+  laws (Prop 8.79 in the current edition; Prop 8.81 in earlier-edition notes).
+  Abstract monoidal-functor packaging is deliberately deferred. Worked tests
+  with paper value:
   DFA mate = accepted language (Example 8.51); the general Moore-mate shape of
   Example 8.52 is now captured by the behavior/reached-state bridge, while a
   concrete `List A → B` worked example remains open.

--- a/docs/wiki/pfunctor.md
+++ b/docs/wiki/pfunctor.md
@@ -193,6 +193,7 @@ displayed families, roll bounds) on top of the upstream type.
 | [`PolyFun/PFunctor/Cofree/Polynomial.lean`](../../PolyFun/PFunctor/Cofree/Polynomial.lean) | `CofreeP P`, whose positions are potentially infinite `P`-trees and whose directions are finite rooted vertices; its extension equivalence with `CofreeC P`, functorial action on lenses, and substitution-comonoid structure. Its carrier uses `max uA uB` for both polynomial universes because a vertex stores directions along an ambient `M P` tree. |
 | [`PolyFun/PFunctor/Cofree/Universal.lean`](../../PolyFun/PFunctor/Cofree/Universal.lean) | Generic coiteration and the cofree-comonoid universal property `Comonoid.Hom C (CofreeP.comonoid P) ≃ Lens C.carrier P`, with explicit naturality in both variables. The generic unfolding keeps the comonoid and generator universe pairs independent; the hom-set packaging specializes `C` to the homogeneous `max uA uB` universe pair required by the existing `Comonoid.Hom`. This is unbundled adjunction data, not a `CategoryTheory.Adjunction`. |
 | [`PolyFun/PFunctor/Cofree/FiniteProjection.lean`](../../PolyFun/PFunctor/Cofree/FiniteProjection.lean) | Universe-polymorphic structural finite projections `projectionN P n : CofreeP P ⇆ compNth P n`, their exact backward-map depth semantics and low-stage unitors, and the homogeneous algebraic bridge yielding the arbitrary-retrofunctor and cofree-extension forms of Proposition 8.49. Additive splitting (Equation 8.32) is deferred until its required composition-power reassociation equivalence is available. |
+| [`PolyFun/PFunctor/Cofree/LaxMonoidal.lean`](../../PolyFun/PFunctor/Cofree/LaxMonoidal.lean) | The cofree functor's unit comparison `y ⇆ CofreeP y` and synchronized-tree laxator `CofreeP P ⊗ CofreeP Q ⇆ CofreeP (P ⊗ Q)`, packaged as retrofunctors and equipped with generator equations, fixed-universe categorical naturality, and the two unit and associativity laws. This is Proposition 8.79 in the current Spivak–Niu edition (Proposition 8.81 in the earlier-edition notes). Cross-universe naturality needs a heterogeneous retrofunctor-law API; abstract monoidal-functor packaging and the Libkind–Spivak `FreeP` module action remain downstream. |
 | [`PolyFun/PFunctor/Trace.lean`](../../PolyFun/PFunctor/Trace.lean) | Polynomial-trace machinery shared between `PFunctor` and downstream layers. |
 
 ### Control helpers
@@ -226,7 +227,10 @@ provides the reusable monad / comonad / coalgebra plumbing. See
   universes are definitionally `max uA uB`; a future lift/equal-maximum API
   could relax this specialization. `CofreeP.homEquiv` packages the cofree
   universal property at the same fixed-maximum boundary, while its underlying
-  coiteration remains fully heterogeneous. PolyFun separately formalizes
+  coiteration remains fully heterogeneous. `CofreeP.laxTensor` synchronizes
+  two behavior trees node by node and proves the concrete naturality and
+  monoidal coherence equations without installing an abstract monoidal-functor
+  instance. PolyFun separately formalizes
   `LawfulMonad (FreeM P)` and `LawfulComonad (CofreeC F)`; those type-level
   structures are not the paper's polynomial module action
   `FreeP p ⊗ CofreeP q → FreeP (p ⊗ q)`. That module-action layer is a

--- a/docs/wiki/repo-map.md
+++ b/docs/wiki/repo-map.md
@@ -78,6 +78,8 @@ PFunctor/{Cofree, Comonoid, M/Vertex}
 PFunctor/{Cofree/Polynomial, Comonoid/Category}
   -> PFunctor/Cofree/Universal
   -> PFunctor/Cofree/FiniteProjection
+PFunctor/{Cofree/Universal, Comonoid/Tensor}
+  -> PFunctor/Cofree/LaxMonoidal
 
 PFunctor/{Lens, Cofree, M} + Control/Coalgebra
   -> PFunctor/Dynamical/{Basic, Safety, Combinators, Run, Speedup, Trajectory}


### PR DESCRIPTION
## Context and motivation

The tensor/convolution algebra in #69 is useful only after the cofree polynomial construction is shown to interact coherently with tensor product. Libkind–Spivak uses exactly this lax-monoidal structure to define the convolution monoid into which the pattern-action generator is extended.

This PR constructs the concrete unit and tensor comparison maps for `CofreeP` and proves their naturality and coherence.

## What this PR adds

### Universal-property extensionality

- `CofreeP.hom_ext_cogenerator`: two homomorphisms into a cofree polynomial comonoid are equal when they agree after the cogenerator.

This lets the large coherence diagrams be proved at the generator layer rather than by redoing dependent M-tree/vertex calculations.

### Unit comparison

- the retrofunctor/lens from the tensor unit into the cofree polynomial on the unit;
- its cogenerator equation;
- left and right unit coherence.

### Tensor comparison

- the map combining a `CofreeP P` tree and a `CofreeP Q` tree into a `CofreeP (P ⊗ Q)` tree;
- its dependent backward map, which splits a finite combined vertex into synchronized source vertices;
- generator equation;
- naturality in both generator lenses;
- associativity coherence.

Together these equations are the concrete lax-monoidal structure needed by the later module action.

## Source and mathematical boundary

This formalizes Libkind–Spivak Proposition C.1 and the concrete Spivak–Niu cofree laxator (current Proposition 8.79; earlier numbering 8.81).

The laws are explicit retrofunctor/lens equations. This PR does not package a general monoidal functor object or a global natural-isomorphism hierarchy.

Naturality is stated within each fixed-universe polynomial category, matching the current homogeneous `Comonoid.Hom` boundary. Fully cross-universe naturality would require a heterogeneous retrofunctor/coiteration-fusion API. That restriction is documented; the underlying generator operations remain separately universe-tested.

## Falsifiable coverage

Tests include:

- unit comparison at observable roots;
- tensor comparison on asymmetric trees;
- separated-universe API canaries;
- naturality equations;
- left/right unit and associativity;
- a decisive depth-two backward-path example that records both synchronized source traversals.

A shape-only construction, swapped tensor component, or incorrect vertex pullback fails these canaries.

## Stack and review history

- Stack position: **10 of 12**.
- Base: #69.
- Next: #71, the pattern-runs-on-matter action.
- Current head incorporates the fully reviewed upstream train; no PR in the train has been merged.

Ready for review; open and unmerged.

## Validation

Targeted source/test builds, the full validation wrapper, style/environment lint, imports/docs checks, diff/trust scans, and principal axiom checks pass.

## Deliberately deferred

The actual action `Xi`, its free universal characterization, and its unit/associativity module laws are #71.