### PR TITLE
feat(pfunctor): formalize the pattern-runs-on-matter action

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,13 @@ PFunctor/{Cofree/Polynomial, Comonoid/Category}
   → PFunctor/Cofree/FiniteProjection
 PFunctor/{Cofree/Universal, Comonoid/Tensor}
   → PFunctor/Cofree/LaxMonoidal
+PFunctor/{Free/Polynomial, Cofree/Polynomial}
+  → PFunctor/PatternRunsOnMatter/Basic
+PFunctor/{PatternRunsOnMatter/Basic, Free/Universal,
+  Cofree/Universal, SubstMonoid/Convolution}
+  → PFunctor/PatternRunsOnMatter/Universal
+PFunctor/{PatternRunsOnMatter/Universal, Cofree/LaxMonoidal}
+  → PFunctor/PatternRunsOnMatter/Module
 
 PFunctor/{Lens, Cofree, M} + Control/Coalgebra
   → PFunctor/Dynamical/{Basic, Safety, Combinators, Run, Speedup, Trajectory}

--- a/PolyFun.lean
+++ b/PolyFun.lean
@@ -181,6 +181,9 @@ import PolyFun.PFunctor.Lens.Factorization
 import PolyFun.PFunctor.Lens.State
 import PolyFun.PFunctor.M
 import PolyFun.PFunctor.M.Vertex
+import PolyFun.PFunctor.PatternRunsOnMatter.Basic
+import PolyFun.PFunctor.PatternRunsOnMatter.Module
+import PolyFun.PFunctor.PatternRunsOnMatter.Universal
 import PolyFun.PFunctor.Resumption
 import PolyFun.PFunctor.SubstMonoid
 import PolyFun.PFunctor.SubstMonoid.Convolution

--- a/PolyFun/PFunctor/Cofree/LaxMonoidal.lean
+++ b/PolyFun/PFunctor/Cofree/LaxMonoidal.lean
@@ -97,6 +97,120 @@ theorem cogenerator_comp_laxTensor
   exact restrict_extend (Comonoid.tensor (comonoid P) (comonoid Q))
     (cogenerator P ⊗ₗ cogenerator Q)
 
+/-! ## Executable equations -/
+
+theorem laxUnit_head :
+    M.head ((laxUnit.{uA, uB}).toFunA PUnit.unit) = PUnit.unit :=
+  rfl
+
+theorem laxUnit_children :
+    M.children ((laxUnit.{uA, uB}).toFunA PUnit.unit) PUnit.unit =
+      (laxUnit.{uA, uB}).toFunA PUnit.unit := by
+  change M.children (unfoldShape _ _ _) _ = unfoldShape _ _ _
+  rw [children_unfoldShape]
+  rfl
+
+@[simp]
+theorem laxUnit_toFunB
+    (vertex : M.Vertex ((laxUnit.{uA, uB}).toFunA PUnit.unit)) :
+    (laxUnit.{uA, uB}).toFunB PUnit.unit vertex = PUnit.unit :=
+  Subsingleton.elim _ _
+
+@[simp]
+theorem laxTensor_head (P : PFunctor.{uA₁, uB₁})
+    (Q : PFunctor.{uA₂, uB₂})
+    (left : (CofreeP P).A) (right : (CofreeP Q).A) :
+    M.head ((laxTensor P Q).toFunA (left, right)) =
+      (M.head left, M.head right) :=
+  rfl
+
+@[simp]
+theorem laxTensor_children (P : PFunctor.{uA₁, uB₁})
+    (Q : PFunctor.{uA₂, uB₂})
+    (left : (CofreeP P).A) (right : (CofreeP Q).A)
+    (direction : P.B (M.head left) × Q.B (M.head right)) :
+    M.children ((laxTensor P Q).toFunA (left, right)) direction =
+      (laxTensor P Q).toFunA
+        (M.children left direction.1, M.children right direction.2) := by
+  change M.children (unfoldShape _ _ _) _ = unfoldShape _ _ _
+  rw [children_unfoldShape]
+  rfl
+
+@[simp]
+theorem laxTensor_toFunB_root (P : PFunctor.{uA₁, uB₁})
+    (Q : PFunctor.{uA₂, uB₂})
+    (left : (CofreeP P).A) (right : (CofreeP Q).A) :
+    (laxTensor P Q).toFunB (left, right)
+        (.root ((laxTensor P Q).toFunA (left, right))) =
+      (.root left, .root right) := by
+  change unfoldDirection _ _ _ (.root _) = _
+  rw [unfoldDirection_root]
+  rfl
+
+/-- Low-level recurrence for pulling a non-root vertex back through the
+cofree laxator. Its explicit cast records the definitional mismatch between
+the actual child of the unfolded tree and the unfolding of the two selected
+children. Most consumers should use `laxTensor_childObj`, which packages and
+hides this transport. -/
+theorem laxTensor_toFunB_child (P : PFunctor.{uA₁, uB₁})
+    (Q : PFunctor.{uA₂, uB₂})
+    (left : (CofreeP P).A) (right : (CofreeP Q).A)
+    (direction : P.B (M.head left) × Q.B (M.head right))
+    (next : M.Vertex
+      (M.children ((laxTensor P Q).toFunA (left, right)) direction)) :
+    (laxTensor P Q).toFunB (left, right) (.child direction next) =
+      let childEq := laxTensor_children P Q left right direction
+      let pulled := (laxTensor P Q).toFunB
+        (M.children left direction.1, M.children right direction.2)
+        (cast (congrArg M.Vertex childEq) next)
+      (.child direction.1 pulled.1, .child direction.2 pulled.2) := by
+  change unfoldDirection
+    (Comonoid.tensor (comonoid P) (comonoid Q))
+    (cogenerator P ⊗ₗ cogenerator Q)
+    (left, right) (.child direction next) = _
+  rw [unfoldDirection.eq_def]
+  rfl
+
+/-- The synchronized child of the cofree laxator, packaged with its complete
+backward vertex map. This is the stable, cast-free rewriting boundary for
+consumers that recurse through `laxTensor`. -/
+theorem laxTensor_childObj (P : PFunctor.{uA₁, uB₁})
+    (Q : PFunctor.{uA₂, uB₂})
+    (left : (CofreeP P).A) (right : (CofreeP Q).A)
+    (direction : P.B (M.head left) × Q.B (M.head right)) :
+    let combined := (laxTensor P Q).toFunA (left, right)
+    let mappedChild := Lens.mapObj (laxTensor P Q)
+      (⟨(M.children left direction.1,
+          M.children right direction.2), id⟩ :
+        (CofreeP P ⊗ CofreeP Q).Obj
+          (M.Vertex (M.children left direction.1) ×
+            M.Vertex (M.children right direction.2)))
+    (⟨M.children combined direction, fun next =>
+        (laxTensor P Q).toFunB (left, right) (.child direction next)⟩ :
+      (CofreeP (P ⊗ Q)).Obj (M.Vertex left × M.Vertex right)) =
+    ⟨mappedChild.1, fun next =>
+      let pulled := mappedChild.2 next
+      (.child direction.1 pulled.1, .child direction.2 pulled.2)⟩ := by
+  dsimp only
+  let childEq := laxTensor_children P Q left right direction
+  apply Sigma.ext childEq
+  apply Function.hfunext (congrArg M.Vertex childEq)
+  intro leftVertex rightVertex hVertex
+  have hcast : cast (congrArg M.Vertex childEq) leftVertex = rightVertex :=
+    (cast_eq_iff_heq).2 hVertex
+  subst rightVertex
+  apply heq_of_eq
+  change (laxTensor P Q).toFunB
+      ((left, right) : (CofreeP P ⊗ CofreeP Q).A)
+      (.child direction leftVertex) =
+    let pulled := (laxTensor P Q).toFunB
+      ((M.children left direction.1,
+        M.children right direction.2) :
+        (CofreeP P ⊗ CofreeP Q).A)
+      (cast (congrArg M.Vertex childEq) leftVertex)
+    (.child direction.1 pulled.1, .child direction.2 pulled.2)
+  exact laxTensor_toFunB_child P Q left right direction leftVertex
+
 /-! ## Naturality -/
 
 /-- The binary comparison is natural in both generator polynomials.  Each

--- a/PolyFun/PFunctor/Cofree/Polynomial.lean
+++ b/PolyFun/PFunctor/Cofree/Polynomial.lean
@@ -353,6 +353,27 @@ theorem map_toFunB {Q : PFunctor.{uA₂, uB₂}} (lens : Lens P Q)
       M.Vertex.pullMapLens lens tree vertex :=
   rfl
 
+/-- Package the child of a mapped cofree tree together with its vertex
+pullback. This equality hides the dependent transport induced by
+`M.children_mapLens`, so consumers can rewrite the complete child object
+without separating its shape from its direction family. -/
+theorem mapChildObj {Q : PFunctor.{uA₂, uB₂}} (lens : Lens P Q)
+    (tree : (CofreeP P).A)
+    (direction : Q.B (M.head (M.mapLens lens tree))) :
+    let sourceDirection := M.pullDirection lens tree direction
+    let sourceChild := M.children tree sourceDirection
+    let childEq := M.children_mapLens lens tree direction
+    (⟨M.children (M.mapLens lens tree) direction,
+        fun vertex => M.Vertex.pullMapLens lens sourceChild
+          (cast (congrArg M.Vertex childEq) vertex)⟩ :
+      (CofreeP Q).Obj (M.Vertex sourceChild)) =
+      ⟨M.mapLens lens sourceChild,
+        M.Vertex.pullMapLens lens sourceChild⟩ := by
+  dsimp only
+  let childEq := M.children_mapLens lens tree direction
+  cases childEq
+  rfl
+
 /-- Pointwise container form of identity preservation for `CofreeP.map`. -/
 private theorem map_obj_id (tree : (CofreeP P).A) :
     (⟨(map (Lens.id P)).toFunA tree,

--- a/PolyFun/PFunctor/Cofree/Polynomial.lean
+++ b/PolyFun/PFunctor/Cofree/Polynomial.lean
@@ -365,7 +365,7 @@ theorem mapChildObj {Q : PFunctor.{uA₂, uB₂}} (lens : Lens P Q)
     let childEq := M.children_mapLens lens tree direction
     (⟨M.children (M.mapLens lens tree) direction,
         fun vertex => M.Vertex.pullMapLens lens sourceChild
-          (cast (congrArg M.Vertex childEq) vertex)⟩ :
+          (M.Vertex.castEquiv childEq vertex)⟩ :
       (CofreeP Q).Obj (M.Vertex sourceChild)) =
       ⟨M.mapLens lens sourceChild,
         M.Vertex.pullMapLens lens sourceChild⟩ := by

--- a/PolyFun/PFunctor/Free/Polynomial.lean
+++ b/PolyFun/PFunctor/Free/Polynomial.lean
@@ -24,7 +24,7 @@ resulting well-founded tree directly.
 
 @[expose] public section
 
-universe uA uB uA₂ uB₂ uA₃ uB₃ v w
+universe uA uB uA₂ uB₂ uA₃ uB₃ v w x
 
 namespace PFunctor
 
@@ -204,6 +204,19 @@ def relabel {β : Type w} (f : α → β) (x : (FreeP P).Obj α) :
     (FreeP P).Obj β :=
   ⟨x.1, f ∘ x.2⟩
 
+@[simp]
+theorem relabel_node {β : Type w} (f : α → β) (a : P.A)
+    (children : P.B a → (FreeP P).Obj α) :
+    relabel f (node a children) =
+      node a (fun direction => relabel f (children direction)) :=
+  rfl
+
+@[simp]
+theorem relabel_relabel {β : Type w} {γ : Type x}
+    (g : β → γ) (f : α → β) (x : (FreeP P).Obj α) :
+    relabel g (relabel f x) = relabel (g ∘ f) x :=
+  rfl
+
 /-! ## Functoriality in the generating polynomial -/
 
 variable {Q : PFunctor.{uA₂, uB₂}} {R : PFunctor.{uA₃, uB₃}}
@@ -232,6 +245,40 @@ theorem map_toFunB (l : Lens P Q) (s : (FreeP P).A)
     (map l).toFunB s path =
       FreeM.Path.pullMapLens l s
         (FreeM.Path.pullMap (fun _ => PUnit.unit) (s.mapLens l) path) :=
+  rfl
+
+/-- Pulling back a complete path through a mapped operation node pulls back
+its root direction and then recursively pulls back the child path. -/
+theorem map_toFunB_cons (l : Lens P Q) (a : P.A)
+    (rest : P.B a → FreeM P PUnit.{uB + 1})
+    (direction : Q.B (l.toFunA a))
+    (path : FreeM.Path
+      (FreeM.map (fun _ => PUnit.unit)
+        (FreeM.mapLens l (rest (l.toFunB a direction))))) :
+    (map l).toFunB (FreeM.liftBind a rest)
+        (FreeM.Path.cons (l.toFunA a)
+          (fun d => FreeM.map (fun _ => PUnit.unit)
+            (FreeM.mapLens l (rest (l.toFunB a d))))
+          direction path) =
+      FreeM.Path.cons a rest (l.toFunB a direction)
+        ((map l).toFunB (rest (l.toFunB a direction)) path) :=
+  rfl
+
+/-- Mapping a labelled free node maps its operation and each child
+recursively, pulling the target direction back through the generating lens. -/
+@[simp]
+theorem mapObj_node (l : Lens P Q) (a : P.A)
+    (children : P.B a → (FreeP P).Obj α) :
+    Lens.mapObj (map l) (node a children) =
+      node (l.toFunA a) (fun direction =>
+        Lens.mapObj (map l) (children (l.toFunB a direction))) :=
+  rfl
+
+@[simp]
+theorem mapObj_relabel {β : Type w} (l : Lens P Q)
+    (f : α → β) (x : (FreeP P).Obj α) :
+    Lens.mapObj (map l) (relabel f x) =
+      relabel f (Lens.mapObj (map l) x) :=
   rfl
 
 /-- Pointwise container form of the identity law for `FreeP.map`. Packaging

--- a/PolyFun/PFunctor/Lens/Basic.lean
+++ b/PolyFun/PFunctor/Lens/Basic.lean
@@ -720,6 +720,21 @@ def tensorAssoc : (P ⊗ Q) ⊗ R ≃ₗ P ⊗ (Q ⊗ R) where
   left_inv := rfl
   right_inv := rfl
 
+@[simp]
+theorem tensorAssoc_toFunA (position : ((P ⊗ Q) ⊗ R).A) :
+    (tensorAssoc (P := P) (Q := Q) (R := R)).toLens.toFunA position =
+      (position.1.1, (position.1.2, position.2)) :=
+  rfl
+
+@[simp]
+theorem tensorAssoc_toFunB (position : ((P ⊗ Q) ⊗ R).A)
+    (direction : (P ⊗ (Q ⊗ R)).B
+      ((tensorAssoc (P := P) (Q := Q) (R := R)).toLens.toFunA position)) :
+    (tensorAssoc (P := P) (Q := Q) (R := R)).toLens.toFunB
+        position direction =
+      ((direction.1, direction.2.1), direction.2.2) :=
+  rfl
+
 /-- Tensor product with `X` is identity (right) -/
 def tensorX : P ⊗ X ≃ₗ P where
   toLens := Prod.fst ⇆ fun _ => (·, PUnit.unit)

--- a/PolyFun/PFunctor/PatternRunsOnMatter/Basic.lean
+++ b/PolyFun/PFunctor/PatternRunsOnMatter/Basic.lean
@@ -220,7 +220,7 @@ theorem runObj_natural
           runMatterObj
               ⟨M.children (M.mapLens g matter) qDirection,
                 fun vertex => M.Vertex.pullMapLens g sourceChild
-                  (cast (congrArg M.Vertex hchild) vertex)⟩ =
+                  (M.Vertex.castEquiv hchild vertex)⟩ =
             FreeP.relabel
               (fun pulled =>
                 (⟨(FreeP.map f).toFunB

--- a/PolyFun/PFunctor/PatternRunsOnMatter/Basic.lean
+++ b/PolyFun/PFunctor/PatternRunsOnMatter/Basic.lean
@@ -1,0 +1,300 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+module
+
+public import PolyFun.PFunctor.Cofree.Polynomial
+public import PolyFun.PFunctor.Free.Polynomial
+
+/-!
+# Executing free patterns on cofree matter
+
+This file defines the executable core of the Libkind--Spivak
+pattern-runs-on-matter interaction. A finite `P`-pattern runs synchronously
+against a potentially infinite `Q`-behavior:
+
+* a pattern leaf terminates without advancing the behavior;
+* a pattern node and the current behavior root produce a `P ⊗ Q` node;
+* a joint direction selects both the next pattern branch and the next
+  behavior subtree.
+
+`runObj` packages the output shape together with its complete backward map.
+Consequently, the output path recovers both the complete source-pattern path
+and the finite source-matter vertex followed during execution. This packaged
+definition keeps all dependent indices aligned and gives `runOn` as a lens.
+
+The executable construction retains four independent generator universes.
+Its identification with the paper's internal-hom/convolution construction and
+the fixed-universe categorical module laws live in downstream modules.
+
+## Reference
+
+* Libkind and Spivak, *Pattern Runs on Matter: The Free Monad Monad as a
+  Module over the Cofree Comonad Comonad*, Equation (1) and Section 3.2.
+-/
+
+@[expose] public section
+
+universe pA pB pA' pB' qA qB qA' qB' v
+
+namespace PFunctor
+namespace FreeP
+
+variable {P : PFunctor.{pA, pB}} {Q : PFunctor.{qA, qB}}
+
+/-- Execute a finite pattern shape against a potentially infinite matter
+behavior, packaging the output shape with the exact source pattern path and
+matter vertex selected by every output path. -/
+def runObj : (pattern : (FreeP P).A) → (matter : (CofreeP Q).A) →
+    (FreeP (P ⊗ Q)).Obj (FreeM.Path pattern × M.Vertex matter)
+  | .pure _, tree =>
+      ⟨.pure PUnit.unit, fun _ => ⟨PUnit.unit, .root tree⟩⟩
+  | .liftBind a rest, tree =>
+      FreeP.node (a, M.head tree) fun direction =>
+        FreeP.relabel
+          (fun pulled =>
+            ⟨FreeM.Path.cons a rest direction.1 pulled.1,
+              M.Vertex.child direction.2 pulled.2⟩)
+          (runObj (rest direction.1) (M.children tree direction.2))
+
+theorem runObj_pure (value : PUnit.{pB + 1})
+    (matter : (CofreeP Q).A) :
+    runObj (P := P) (FreeM.pure value) matter =
+      ⟨FreeM.pure PUnit.unit,
+        fun _ => ⟨PUnit.unit, M.Vertex.root matter⟩⟩ :=
+  rfl
+
+theorem runObj_liftBind (a : P.A)
+    (rest : P.B a → FreeM P PUnit.{pB + 1})
+    (matter : (CofreeP Q).A) :
+    runObj (FreeM.liftBind a rest) matter =
+      FreeP.node (P := P ⊗ Q) (a, M.head matter) (fun direction =>
+        FreeP.relabel
+          (fun pulled =>
+            ⟨FreeM.Path.cons a rest direction.1 pulled.1,
+              M.Vertex.child direction.2 pulled.2⟩)
+          (runObj (rest direction.1)
+            (M.children matter direction.2))) :=
+  rfl
+
+/-- Run a pattern against a cofree object whose finite vertices carry
+payloads, returning each output path together with the payload at the matter
+vertex reached by that path. Packaging the matter shape and its dependent
+labelling together is also the stable rewriting boundary for mapped and
+synchronized child subtrees. -/
+def runLabeled {α : Type v} (pattern : (FreeP P).A)
+    (matter : (CofreeP Q).Obj α) :
+    (FreeP (P ⊗ Q)).Obj (FreeM.Path pattern × α) :=
+  FreeP.relabel
+    (fun pulled => ⟨pulled.1, matter.2 pulled.2⟩)
+    (runObj pattern matter.1)
+
+/-- A terminated pattern returns its leaf together with the label at the root
+of the matter object. -/
+theorem runLabeled_pure {α : Type v} (value : PUnit.{pB + 1})
+    (matter : (CofreeP Q).Obj α) :
+    runLabeled (P := P) (FreeM.pure value) matter =
+      ⟨FreeM.pure PUnit.unit, fun _ => (PUnit.unit, matter.2 (.root _))⟩ :=
+  rfl
+
+/-- Recursive equation for running a labelled matter object through one
+pattern node. -/
+theorem runLabeled_liftBind {α : Type v} (a : P.A)
+    (rest : P.B a → (FreeP P).A) (matter : (CofreeP Q).Obj α) :
+    runLabeled (FreeM.liftBind a rest) matter =
+      FreeP.node (P := P ⊗ Q) (a, M.head matter.1) (fun direction =>
+        FreeP.relabel
+          (fun pulled =>
+            (FreeM.Path.cons a rest direction.1 pulled.1, pulled.2))
+          (runLabeled (rest direction.1)
+            (⟨M.children matter.1 direction.2, fun next =>
+              matter.2 (.child direction.2 next)⟩ :
+              (CofreeP Q).Obj α))) :=
+  rfl
+
+/-- Running the shape of a labelled free node ignores its leaf labels and
+recurses on the child shapes. -/
+@[simp]
+theorem runObj_node {α : Type v} (a : P.A)
+    (children : P.B a → (FreeP P).Obj α)
+    (matter : (CofreeP Q).A) :
+    runObj (FreeP.node a children).1 matter =
+      FreeP.node (P := P ⊗ Q) (a, M.head matter) (fun direction =>
+        FreeP.relabel
+          (fun pulled =>
+            (FreeM.Path.cons a (fun d => (children d).1)
+                direction.1 pulled.1,
+              M.Vertex.child direction.2 pulled.2))
+          (runObj (children direction.1).1
+            (M.children matter direction.2))) :=
+  rfl
+
+/-- A finite pattern runs on a cofree behavior by synchronizing their nodes.
+The backward lens map splits an output path into the complete pattern path and
+the finite matter vertex visited during the run. -/
+def runOn (P : PFunctor.{pA, pB}) (Q : PFunctor.{qA, qB}) :
+    Lens (FreeP P ⊗ CofreeP Q) (FreeP (P ⊗ Q)) where
+  toFunA input := (runObj input.1 input.2).1
+  toFunB input := (runObj input.1 input.2).2
+
+@[simp]
+theorem runOn_toFunA (pattern : (FreeP P).A) (matter : (CofreeP Q).A) :
+    (runOn P Q).toFunA (pattern, matter) = (runObj pattern matter).1 :=
+  rfl
+
+@[simp]
+theorem runOn_toFunB (pattern : (FreeP P).A) (matter : (CofreeP Q).A)
+    (path : (FreeP (P ⊗ Q)).B ((runOn P Q).toFunA (pattern, matter))) :
+    (runOn P Q).toFunB (pattern, matter) path =
+      (runObj pattern matter).2 path :=
+  rfl
+
+/-! ## Naturality -/
+
+/-- Packaged operational naturality, including the complete dependent
+backward map. Mapping both generators before execution agrees with executing
+first and mapping the synchronized output. -/
+theorem runObj_natural
+    {P' : PFunctor.{pA', pB'}} {Q' : PFunctor.{qA', qB'}}
+    (f : Lens P P') (g : Lens Q Q')
+    (pattern : (FreeP P).A) (matter : (CofreeP Q).A) :
+    FreeP.relabel
+        (fun pulled =>
+          ⟨(FreeP.map f).toFunB pattern pulled.1,
+            (CofreeP.map g).toFunB matter pulled.2⟩)
+        (runObj ((FreeP.map f).toFunA pattern)
+          ((CofreeP.map g).toFunA matter)) =
+      Lens.mapObj (FreeP.map (f ⊗ₗ g)) (runObj pattern matter) := by
+  induction pattern generalizing matter with
+  | pure value =>
+      cases value
+      change
+        (⟨FreeM.pure PUnit.unit,
+          fun _ =>
+            ⟨PUnit.unit,
+              M.Vertex.pullMapLens g matter
+                (.root (M.mapLens g matter))⟩⟩ :
+          (FreeP (P' ⊗ Q')).Obj
+            (FreeM.Path (FreeM.pure PUnit.unit : FreeM P PUnit) ×
+              M.Vertex matter)) =
+        (⟨FreeM.pure PUnit.unit,
+          fun _ => ⟨PUnit.unit, .root matter⟩⟩ :
+          (FreeP (P' ⊗ Q')).Obj
+            (FreeM.Path (FreeM.pure PUnit.unit : FreeM P PUnit) ×
+              M.Vertex matter))
+      rw [M.Vertex.pullMapLens_root]
+  | liftBind a rest ih =>
+      have hhead := M.head_mapLens g matter
+      cases hhead
+      simp only [FreeP.map_toFunA, FreeP.mapShape, CofreeP.map_toFunA,
+        FreeM.mapLens, FreeM.map, runObj, FreeP.relabel_node,
+        FreeP.mapObj_node]
+      congr 1
+      funext direction
+      rcases direction with ⟨pDirection, qDirection⟩
+      let sourceQ := M.pullDirection g matter qDirection
+      have hSourceQ :
+          sourceQ = g.toFunB (M.head matter) qDirection := by
+        dsimp only [sourceQ, M.pullDirection]
+        apply congrArg (g.toFunB (M.head matter))
+        exact eq_of_heq (cast_heq _ qDirection)
+      have hchild := M.children_mapLens g matter qDirection
+      simp only [Lens.tensorMap, Prod.map]
+      let sourceChild := M.children matter sourceQ
+      let mappedPattern := (FreeP.map f).toFunA
+        (rest (f.toFunB a pDirection))
+      let runMatterObj (x : (CofreeP Q').Obj (M.Vertex sourceChild)) :=
+        FreeP.relabel
+          (fun pulled =>
+            (⟨(FreeP.map f).toFunB
+                (rest (f.toFunB a pDirection)) pulled.1,
+              pulled.2⟩ :
+              FreeM.Path (rest (f.toFunB a pDirection)) ×
+                M.Vertex sourceChild))
+          (runLabeled mappedPattern x)
+      have hMatter := congrArg runMatterObj
+        (CofreeP.mapChildObj g matter qDirection)
+      have hMatterNormalized :
+          runMatterObj
+              ⟨M.children (M.mapLens g matter) qDirection,
+                fun vertex => M.Vertex.pullMapLens g sourceChild
+                  (cast (congrArg M.Vertex hchild) vertex)⟩ =
+            FreeP.relabel
+              (fun pulled =>
+                (⟨(FreeP.map f).toFunB
+                    (rest (f.toFunB a pDirection)) pulled.1,
+                  (CofreeP.map g).toFunB sourceChild pulled.2⟩ :
+                  FreeM.Path (rest (f.toFunB a pDirection)) ×
+                    M.Vertex sourceChild))
+              (runObj mappedPattern
+                ((CofreeP.map g).toFunA sourceChild)) := by
+        simpa only [runMatterObj, runLabeled, FreeP.relabel_relabel,
+          Function.comp_def, CofreeP.map_toFunA,
+          CofreeP.map_toFunB] using hMatter
+      have hCore := hMatterNormalized.trans
+        (ih (f.toFunB a pDirection) sourceChild)
+      have h := congrArg
+        (FreeP.relabel (fun pulled :
+            FreeM.Path (rest (f.toFunB a pDirection)) ×
+              M.Vertex sourceChild =>
+          (⟨FreeM.Path.cons a rest (f.toFunB a pDirection) pulled.1,
+              M.Vertex.child sourceQ pulled.2⟩ :
+            FreeM.Path (FreeM.liftBind a rest) × M.Vertex matter)))
+        hCore
+      let rhsAt (q : Q.B (M.head matter)) :=
+        FreeP.relabel
+          (fun pulled :
+              FreeM.Path (rest (f.toFunB a pDirection)) ×
+                M.Vertex (M.children matter q) =>
+            (⟨FreeM.Path.cons a rest (f.toFunB a pDirection) pulled.1,
+                M.Vertex.child q pulled.2⟩ :
+              FreeM.Path (FreeM.liftBind a rest) × M.Vertex matter))
+          (Lens.mapObj (FreeP.map (f ⊗ₗ g))
+            (runObj (rest (f.toFunB a pDirection))
+              (M.children matter q)))
+      have hRhs : rhsAt sourceQ =
+          rhsAt (g.toFunB (M.head matter) qDirection) :=
+        congrArg rhsAt hSourceQ
+      have hFinal := h.trans hRhs
+      simpa only [FreeP.relabel_relabel, FreeP.mapObj_relabel,
+        Function.comp_def, FreeP.map_toFunB_cons,
+        CofreeP.map_toFunB, M.Vertex.pullMapLens_child,
+        FreeP.map_toFunA, FreeP.mapShape, CofreeP.map_toFunA,
+        FreeM.mapLens_lift_bind, FreeM.Path.pullMap_lift_bind,
+        FreeM.Path.pullMapLens_lift_bind, sourceQ, sourceChild,
+        mappedPattern, runMatterObj, runLabeled, rhsAt, hchild,
+        Lens.tensorMap, Prod.map] using hFinal
+
+/-- The Libkind--Spivak interaction is covariant in both the pattern and
+matter generators. All eight source and target universes remain independent. -/
+theorem runOn_natural
+    {P' : PFunctor.{pA', pB'}} {Q' : PFunctor.{qA', qB'}}
+    (f : Lens P P') (g : Lens Q Q') :
+    runOn P' Q' ∘ₗ (FreeP.map f ⊗ₗ CofreeP.map g) =
+      FreeP.map (f ⊗ₗ g) ∘ₗ runOn P Q := by
+  let lhs := runOn P' Q' ∘ₗ (FreeP.map f ⊗ₗ CofreeP.map g)
+  let rhs := FreeP.map (f ⊗ₗ g) ∘ₗ runOn P Q
+  have hobj : ∀ input : (FreeP P ⊗ CofreeP Q).A,
+      Lens.mapObj lhs
+          (⟨input, id⟩ : (FreeP P ⊗ CofreeP Q).Obj
+            ((FreeP P ⊗ CofreeP Q).B input)) =
+        Lens.mapObj rhs
+          (⟨input, id⟩ : (FreeP P ⊗ CofreeP Q).Obj
+            ((FreeP P ⊗ CofreeP Q).B input)) := by
+    rintro ⟨pattern, matter⟩
+    exact runObj_natural f g pattern matter
+  let hA : ∀ input, lhs.toFunA input = rhs.toFunA input :=
+    fun input => congrArg Sigma.fst (hobj input)
+  refine Lens.ext lhs rhs hA ?_
+  intro input
+  apply eq_of_heq
+  have hraw : lhs.toFunB input ≍ rhs.toFunB input :=
+    (Sigma.ext_iff.mp (hobj input)).2
+  have hcast : (hA input ▸ rhs.toFunB input) ≍ rhs.toFunB input :=
+    eqRec_heq_self _ _
+  exact hraw.trans hcast.symm
+
+end FreeP
+end PFunctor

--- a/PolyFun/PFunctor/PatternRunsOnMatter/Module.lean
+++ b/PolyFun/PFunctor/PatternRunsOnMatter/Module.lean
@@ -1,0 +1,379 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+module
+
+public import PolyFun.PFunctor.PatternRunsOnMatter.Universal
+public import PolyFun.PFunctor.Cofree.LaxMonoidal
+
+/-!
+# The pattern-runs-on-matter module laws
+
+This file proves the unit and associativity equations of Libkind--Spivak,
+*Pattern Runs on Matter*, Theorem 3.4. We use the right-action orientation of
+the paper's Equation (1), `FreeP P ⊗ CofreeP Q ⇆ FreeP (P ⊗ Q)`.
+Appendix D draws symmetry-equivalent left-action diagrams; no unmentioned
+symmetry is inserted here.
+
+The laws are stated in one square universe because they compare the universal
+`xi` construction and the cofree lax-monoidal structure inside a fixed
+polynomial category. The executable `runOn` and its naturality remain fully
+heterogeneous in `Basic`.
+-/
+
+@[expose] public section
+
+universe u
+
+namespace PFunctor
+namespace FreeP
+
+private theorem runObj_unit (P : PFunctor.{u, u})
+    (pattern : (FreeP P).A) :
+    Lens.mapObj (FreeP.map (Lens.Equiv.tensorX (P := P)).toLens)
+        (FreeP.relabel
+          (fun pulled => (pulled.1, PUnit.unit))
+          (runObj pattern
+            ((CofreeP.laxUnit.{u, u}).toFunA
+              (PUnit.unit : X.{u, u}.A)))) =
+      (⟨pattern, fun path => (path, PUnit.unit)⟩ :
+        (FreeP P).Obj (FreeM.Path pattern × PUnit.{u + 1})) := by
+  induction pattern with
+  | pure value =>
+      cases value
+      rfl
+  | liftBind a rest ih =>
+      rw [runObj_liftBind, FreeP.relabel_node, FreeP.mapObj_node]
+      rw [← FreeP.node_paths a rest (fun path => (path, PUnit.unit))]
+      congr 1
+      funext direction
+      change P.B a at direction
+      change Lens.mapObj (FreeP.map
+          (Lens.Equiv.tensorX (P := P)).toLens)
+          (FreeP.relabel (fun pulled => (pulled.1, PUnit.unit))
+            (FreeP.relabel
+              (fun pulled =>
+                (FreeM.Path.cons a rest direction pulled.1,
+                  M.Vertex.child
+                    (t := (CofreeP.laxUnit.{u, u}).toFunA
+                      (PUnit.unit : X.{u, u}.A))
+                    PUnit.unit pulled.2))
+              (runObj (rest direction)
+                (M.children
+                  ((CofreeP.laxUnit.{u, u}).toFunA
+                    (PUnit.unit : X.{u, u}.A)) PUnit.unit)))) = _
+      rw [FreeP.relabel_relabel, FreeP.mapObj_relabel]
+      change FreeP.relabel
+          (fun pulled =>
+            (FreeM.Path.cons a rest direction pulled.1, PUnit.unit))
+          (Lens.mapObj (FreeP.map
+              (Lens.Equiv.tensorX (P := P)).toLens)
+            (runObj (rest direction)
+              (M.children
+                ((CofreeP.laxUnit.{u, u}).toFunA
+                  (PUnit.unit : X.{u, u}.A)) PUnit.unit))) = _
+      rw [CofreeP.laxUnit_children]
+      have ih' :
+          FreeP.relabel (fun pulled => (pulled.1, PUnit.unit))
+              (Lens.mapObj (FreeP.map
+                (Lens.Equiv.tensorX (P := P)).toLens)
+                (runObj (rest direction)
+                  ((CofreeP.laxUnit.{u, u}).toFunA
+                    (PUnit.unit : X.{u, u}.A)))) =
+            (⟨rest direction, fun path => (path, PUnit.unit)⟩ :
+              (FreeP P).Obj
+                (FreeM.Path (rest direction) × PUnit.{u + 1})) := by
+        rw [← FreeP.mapObj_relabel]
+        exact ih direction
+      have hi := congrArg
+        (FreeP.relabel (P := P)
+          (fun pulled : FreeM.Path (rest direction) × PUnit.{u + 1} =>
+            (FreeM.Path.cons a rest direction pulled.1, pulled.2)))
+        ih'
+      simpa only [FreeP.relabel_relabel, FreeP.mapObj_relabel,
+        FreeP.relabel, Function.comp_def] using hi
+
+private def unitLhs (P : PFunctor.{u, u}) :
+    Lens (FreeP P ⊗ X.{u, u}) (FreeP P) :=
+  (FreeP.map (Lens.Equiv.tensorX (P := P)).toLens ∘ₗ
+      runOn P X.{u, u}) ∘ₗ
+    (Lens.id (FreeP P) ⊗ₗ CofreeP.laxUnit.{u, u})
+
+private theorem unitObj (P : PFunctor.{u, u})
+    (pattern : (FreeP P).A) :
+    Lens.mapObj (unitLhs P)
+        (⟨(pattern, (PUnit.unit : X.{u, u}.A)), id⟩ :
+          (FreeP P ⊗ X.{u, u}).Obj
+            (FreeM.Path pattern × PUnit.{u + 1})) =
+      Lens.mapObj (Lens.Equiv.tensorX (P := FreeP P)).toLens
+        (⟨(pattern, (PUnit.unit : X.{u, u}.A)), id⟩ :
+          (FreeP P ⊗ X.{u, u}).Obj
+            (FreeM.Path pattern × PUnit.{u + 1})) := by
+  change Lens.mapObj (FreeP.map
+      (Lens.Equiv.tensorX (P := P)).toLens)
+      (FreeP.relabel
+        (fun pulled =>
+          (pulled.1,
+            (CofreeP.laxUnit.{u, u}).toFunB
+              (PUnit.unit : X.{u, u}.A) pulled.2))
+        (runObj pattern
+          ((CofreeP.laxUnit.{u, u}).toFunA
+            (PUnit.unit : X.{u, u}.A)))) =
+    (⟨pattern, fun path => (path, PUnit.unit)⟩ :
+      (FreeP P).Obj (FreeM.Path pattern × PUnit.{u + 1}))
+  have hlabel :
+      (fun pulled : FreeM.Path pattern ×
+          M.Vertex ((CofreeP.laxUnit.{u, u}).toFunA
+            (PUnit.unit : X.{u, u}.A)) =>
+        (pulled.1,
+          (CofreeP.laxUnit.{u, u}).toFunB
+            (PUnit.unit : X.{u, u}.A) pulled.2)) =
+      (fun pulled => (pulled.1, PUnit.unit)) := by
+    funext pulled
+    apply Prod.ext
+    · rfl
+    · exact CofreeP.laxUnit_toFunB pulled.2
+  rw [hlabel]
+  exact runObj_unit P pattern
+
+/-- Right-unit coherence for the executable pattern action. -/
+theorem runOn_unit (P : PFunctor.{u, u}) :
+    (FreeP.map (Lens.Equiv.tensorX (P := P)).toLens ∘ₗ
+        runOn P X.{u, u}) ∘ₗ
+        (Lens.id (FreeP P) ⊗ₗ CofreeP.laxUnit.{u, u}) =
+      (Lens.Equiv.tensorX (P := FreeP P)).toLens := by
+  let lhs := unitLhs P
+  let rhs := (Lens.Equiv.tensorX (P := FreeP P)).toLens
+  have hobj : ∀ input : (FreeP P ⊗ X.{u, u}).A,
+      Lens.mapObj lhs
+          (⟨input, id⟩ : (FreeP P ⊗ X.{u, u}).Obj
+            ((FreeP P ⊗ X.{u, u}).B input)) =
+        Lens.mapObj rhs
+          (⟨input, id⟩ : (FreeP P ⊗ X.{u, u}).Obj
+            ((FreeP P ⊗ X.{u, u}).B input)) := by
+    rintro ⟨pattern, xPosition⟩
+    cases xPosition
+    exact unitObj P pattern
+  let hA : ∀ input, lhs.toFunA input = rhs.toFunA input :=
+    fun input => congrArg Sigma.fst (hobj input)
+  refine Lens.ext lhs rhs hA ?_
+  intro input
+  apply eq_of_heq
+  have hraw : lhs.toFunB input ≍ rhs.toFunB input :=
+    (Sigma.ext_iff.mp (hobj input)).2
+  have hcast : (hA input ▸ rhs.toFunB input) ≍ rhs.toFunB input :=
+    eqRec_heq_self _ _
+  exact hraw.trans hcast.symm
+
+/-- Right-unit coherence for the universal interaction. -/
+theorem xi_unit (P : PFunctor.{u, u}) :
+    (FreeP.map (Lens.Equiv.tensorX (P := P)).toLens ∘ₗ
+        xi P X.{u, u}) ∘ₗ
+        (Lens.id (FreeP P) ⊗ₗ CofreeP.laxUnit.{u, u}) =
+      (Lens.Equiv.tensorX (P := FreeP P)).toLens := by
+  rw [← runOn_eq_xi P X.{u, u}]
+  exact runOn_unit P
+
+/-! ## Associativity -/
+
+private def vertexPairObj {Q R : PFunctor.{u, u}}
+    (matterQ : (CofreeP Q).A) (matterR : (CofreeP R).A) :
+    (CofreeP Q ⊗ CofreeP R).Obj
+      (M.Vertex matterQ × M.Vertex matterR) :=
+  ⟨(matterQ, matterR), id⟩
+
+private def laxTensorVertexObj {Q R : PFunctor.{u, u}}
+    (matterQ : (CofreeP Q).A) (matterR : (CofreeP R).A) :
+    (CofreeP (Q ⊗ R)).Obj (M.Vertex matterQ × M.Vertex matterR) :=
+  Lens.mapObj (CofreeP.laxTensor Q R) (vertexPairObj matterQ matterR)
+
+private theorem laxTensorVertexObj_child (Q R : PFunctor.{u, u})
+    (matterQ : (CofreeP Q).A) (matterR : (CofreeP R).A)
+    (direction : Q.B (M.head matterQ) × R.B (M.head matterR)) :
+    (⟨M.children (laxTensorVertexObj matterQ matterR).1 direction,
+        fun next => (laxTensorVertexObj matterQ matterR).2
+          (.child direction next)⟩ :
+      (CofreeP (Q ⊗ R)).Obj (M.Vertex matterQ × M.Vertex matterR)) =
+    let mappedChild := Lens.mapObj (CofreeP.laxTensor Q R)
+      (⟨(M.children matterQ direction.1,
+          M.children matterR direction.2), id⟩ :
+        (CofreeP Q ⊗ CofreeP R).Obj
+          (M.Vertex (M.children matterQ direction.1) ×
+            M.Vertex (M.children matterR direction.2)))
+    ⟨mappedChild.1, fun next =>
+      let pulled := mappedChild.2 next
+      (.child direction.1 pulled.1, .child direction.2 pulled.2)⟩ := by
+  simpa only [laxTensorVertexObj, vertexPairObj, Lens.mapObj,
+    Function.comp_apply, id_eq] using
+    CofreeP.laxTensor_childObj Q R matterQ matterR direction
+
+private theorem runObj_assoc (P Q R : PFunctor.{u, u})
+    (pattern : (FreeP P).A) (matterQ : (CofreeP Q).A)
+    (matterR : (CofreeP R).A) :
+    FreeP.relabel (fun pulled => ((pulled.1, pulled.2.1), pulled.2.2))
+      (runLabeled pattern (laxTensorVertexObj matterQ matterR)) =
+      Lens.mapObj (FreeP.map
+          (Lens.Equiv.tensorAssoc
+            (P := P) (Q := Q) (R := R)).toLens)
+        (FreeP.relabel
+          (fun pulled => ((runObj pattern matterQ).2 pulled.1, pulled.2))
+          (runObj (runObj pattern matterQ).1 matterR)) := by
+  induction pattern generalizing matterQ matterR with
+  | pure value =>
+      cases value
+      change (⟨FreeM.pure PUnit.unit, fun _ =>
+        ((PUnit.unit,
+          ((CofreeP.laxTensor Q R).toFunB (matterQ, matterR)
+            (.root ((CofreeP.laxTensor Q R).toFunA
+              (matterQ, matterR)))).1),
+          ((CofreeP.laxTensor Q R).toFunB (matterQ, matterR)
+            (.root ((CofreeP.laxTensor Q R).toFunA
+              (matterQ, matterR)))).2)⟩ :
+        (FreeP (P ⊗ (Q ⊗ R))).Obj
+          ((FreeM.Path (FreeM.pure PUnit.unit) × M.Vertex matterQ) ×
+            M.Vertex matterR)) = _
+      rw [CofreeP.laxTensor_toFunB_root]
+      rfl
+  | liftBind a rest ih =>
+      rw [FreeP.runLabeled_liftBind, FreeP.relabel_node]
+      simp only [runObj_liftBind, FreeP.relabel_relabel]
+      rw [FreeP.runObj_node]
+      simp only [FreeP.mapObj_relabel]
+      let rightChildren := fun direction :
+          (P.B a × Q.B (M.head matterQ)) × R.B (M.head matterR) =>
+        FreeP.relabel
+          (fun pulled =>
+            (FreeM.Path.cons (P := P ⊗ Q) (a, M.head matterQ)
+                (fun d : P.B a × Q.B (M.head matterQ) =>
+                  (FreeP.relabel
+                    (fun pulled =>
+                      (FreeM.Path.cons a rest d.1 pulled.1,
+                        M.Vertex.child d.2 pulled.2))
+                    (runObj (rest d.1)
+                      (M.children matterQ d.2))).1)
+                direction.1 pulled.1,
+              M.Vertex.child direction.2 pulled.2))
+          (runObj
+            (FreeP.relabel
+              (fun pulled =>
+                (FreeM.Path.cons a rest direction.1.1 pulled.1,
+                  M.Vertex.child direction.1.2 pulled.2))
+              (runObj (rest direction.1.1)
+                (M.children matterQ direction.1.2))).1
+            (M.children matterR direction.2))
+      have hmap := FreeP.mapObj_node
+        (Lens.Equiv.tensorAssoc (P := P) (Q := Q) (R := R)).toLens
+        ((a, M.head matterQ), M.head matterR) rightChildren
+      conv_rhs =>
+        change FreeP.relabel _
+          (Lens.mapObj (FreeP.map
+              (Lens.Equiv.tensorAssoc
+                (P := P) (Q := Q) (R := R)).toLens)
+            (FreeP.node ((a, M.head matterQ), M.head matterR)
+              rightChildren))
+      rw [hmap]
+      rw [FreeP.relabel_node]
+      congr 1
+      funext direction
+      let patternDirection := direction.1
+      let matterQDirection := direction.2.1
+      let matterRDirection := direction.2.2
+      have hchild := laxTensorVertexObj_child Q R matterQ matterR
+        (matterQDirection, matterRDirection)
+      have hrun := congrArg (runLabeled (rest patternDirection)) hchild
+      dsimp only [patternDirection, matterQDirection,
+        matterRDirection] at hrun
+      simp only [Prod.eta] at hrun ⊢
+      rw [hrun]
+      simp only [runLabeled, FreeP.relabel_relabel, Function.comp_def]
+      have ihChild := ih direction.1
+        (M.children matterQ direction.2.1)
+        (M.children matterR direction.2.2)
+      have wrapped := congrArg
+        (FreeP.relabel (P := P ⊗ (Q ⊗ R))
+          (fun pulled =>
+            ((FreeM.Path.cons a rest direction.1 pulled.1.1,
+                M.Vertex.child direction.2.1 pulled.1.2),
+              M.Vertex.child direction.2.2 pulled.2)))
+        ihChild
+      simpa only [runLabeled, FreeP.relabel_relabel,
+        FreeP.mapObj_relabel, FreeP.relabel,
+        Function.comp_def, laxTensorVertexObj, vertexPairObj,
+        rightChildren, Lens.mapObj, Function.comp_apply, id_eq,
+        Lens.Equiv.tensorAssoc_toFunA, Lens.Equiv.tensorAssoc_toFunB,
+        FreeP.node, FreeM.Path.cons, FreeM.Path.head,
+        FreeM.Path.tail] using wrapped
+
+/-- Associativity coherence for the executable pattern action. -/
+theorem runOn_assoc (P Q R : PFunctor.{u, u}) :
+    (runOn P (Q ⊗ R) ∘ₗ
+        (Lens.id (FreeP P) ⊗ₗ CofreeP.laxTensor Q R)) ∘ₗ
+        (Lens.Equiv.tensorAssoc
+          (P := FreeP P) (Q := CofreeP Q)
+          (R := CofreeP R)).toLens =
+      (FreeP.map
+          (Lens.Equiv.tensorAssoc
+            (P := P) (Q := Q) (R := R)).toLens ∘ₗ
+        runOn (P ⊗ Q) R) ∘ₗ
+        (runOn P Q ⊗ₗ Lens.id (CofreeP R)) := by
+  let lhs :=
+    (runOn P (Q ⊗ R) ∘ₗ
+        (Lens.id (FreeP P) ⊗ₗ CofreeP.laxTensor Q R)) ∘ₗ
+      (Lens.Equiv.tensorAssoc
+        (P := FreeP P) (Q := CofreeP Q)
+        (R := CofreeP R)).toLens
+  let rhs :=
+    (FreeP.map
+        (Lens.Equiv.tensorAssoc
+          (P := P) (Q := Q) (R := R)).toLens ∘ₗ
+      runOn (P ⊗ Q) R) ∘ₗ
+      (runOn P Q ⊗ₗ Lens.id (CofreeP R))
+  have hobj : ∀ input : ((FreeP P ⊗ CofreeP Q) ⊗ CofreeP R).A,
+      Lens.mapObj lhs
+          (⟨input, id⟩ : ((FreeP P ⊗ CofreeP Q) ⊗ CofreeP R).Obj
+            (((FreeP P ⊗ CofreeP Q) ⊗ CofreeP R).B input)) =
+        Lens.mapObj rhs
+          (⟨input, id⟩ : ((FreeP P ⊗ CofreeP Q) ⊗ CofreeP R).Obj
+            (((FreeP P ⊗ CofreeP Q) ⊗ CofreeP R).B input)) := by
+    rintro ⟨⟨pattern, matterQ⟩, matterR⟩
+    change FreeP.relabel
+        (fun pulled => ((pulled.1, pulled.2.1), pulled.2.2))
+        (runLabeled pattern (laxTensorVertexObj matterQ matterR)) =
+      Lens.mapObj (FreeP.map
+          (Lens.Equiv.tensorAssoc
+            (P := P) (Q := Q) (R := R)).toLens)
+        (FreeP.relabel
+          (fun pulled => ((runObj pattern matterQ).2 pulled.1, pulled.2))
+          (runObj (runObj pattern matterQ).1 matterR))
+    exact runObj_assoc P Q R pattern matterQ matterR
+  let hA : ∀ input, lhs.toFunA input = rhs.toFunA input :=
+    fun input => congrArg Sigma.fst (hobj input)
+  refine Lens.ext lhs rhs hA ?_
+  intro input
+  apply eq_of_heq
+  have hraw : lhs.toFunB input ≍ rhs.toFunB input :=
+    (Sigma.ext_iff.mp (hobj input)).2
+  have hcast : (hA input ▸ rhs.toFunB input) ≍ rhs.toFunB input :=
+    eqRec_heq_self _ _
+  exact hraw.trans hcast.symm
+
+/-- Associativity coherence for the universal interaction. -/
+theorem xi_assoc (P Q R : PFunctor.{u, u}) :
+    (xi P (Q ⊗ R) ∘ₗ
+        (Lens.id (FreeP P) ⊗ₗ CofreeP.laxTensor Q R)) ∘ₗ
+        (Lens.Equiv.tensorAssoc
+          (P := FreeP P) (Q := CofreeP Q)
+          (R := CofreeP R)).toLens =
+      (FreeP.map
+          (Lens.Equiv.tensorAssoc
+            (P := P) (Q := Q) (R := R)).toLens ∘ₗ
+        xi (P ⊗ Q) R) ∘ₗ
+        (xi P Q ⊗ₗ Lens.id (CofreeP R)) := by
+  rw [← runOn_eq_xi P (Q ⊗ R), ← runOn_eq_xi (P ⊗ Q) R,
+    ← runOn_eq_xi P Q]
+  exact runOn_assoc P Q R
+
+end FreeP
+end PFunctor

--- a/PolyFun/PFunctor/PatternRunsOnMatter/Universal.lean
+++ b/PolyFun/PFunctor/PatternRunsOnMatter/Universal.lean
@@ -1,0 +1,176 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+module
+
+public import PolyFun.PFunctor.PatternRunsOnMatter.Basic
+public import PolyFun.PFunctor.Cofree.Universal
+public import PolyFun.PFunctor.Free.Universal
+public import PolyFun.PFunctor.SubstMonoid.Convolution
+
+/-!
+# Universal characterization of pattern running
+
+Libkind--Spivak construct the interaction
+
+`FreeP P ⊗ CofreeP Q ⇆ FreeP (P ⊗ Q)`
+
+by currying the one-generator synchronized step, extending it from the free
+substitution monoid into the convolution monoid
+`[CofreeP Q, FreeP (P ⊗ Q)]`, and uncurrying. This file implements that
+construction as `xi` and proves that it is exactly the independently
+executable `FreeP.runOn`.
+
+The universal construction retains independent position universes and the two
+universes of `Q`. Its only constraint is that `P`'s direction universe is
+`max qA qB`: `CofreeP Q` raises both carrier universes to that maximum, and
+the homogeneous `SubstMonoid.Hom`/`FreeP.extend` boundary requires the free
+source and convolution target to share it. The executable `runOn` itself has
+no such constraint. No resizing or stronger square-universe restriction is
+hidden here.
+
+## Reference
+
+* Libkind and Spivak, *Pattern Runs on Matter: The Free Monad Monad as a
+  Module over the Cofree Comonad Comonad*, Section 3.2.
+-/
+
+@[expose] public section
+
+universe pA pA' pB qA qB qA' qB' u
+
+namespace PFunctor
+namespace FreeP
+
+/-- The one-generator synchronized step, curried into the convolution
+carrier. -/
+def xiGenerator (P : PFunctor.{pA, max qA qB})
+    (Q : PFunctor.{qA, qB}) :
+    Lens P (SubstMonoid.convolution (CofreeP.comonoid Q)
+      (FreeP.substMonoid (P ⊗ Q))).carrier :=
+  Lens.curry (FreeP.generator (P ⊗ Q) ∘ₗ
+    (Lens.id P ⊗ₗ CofreeP.cogenerator Q))
+
+/-- The substitution-monoid homomorphism induced from the synchronized
+generator by the free universal property. -/
+def xiHom (P : PFunctor.{pA, max qA qB})
+    (Q : PFunctor.{qA, qB}) :
+    SubstMonoid.Hom (FreeP.substMonoid P)
+      (SubstMonoid.convolution (CofreeP.comonoid Q)
+        (FreeP.substMonoid (P ⊗ Q))) :=
+  FreeP.extend _ (xiGenerator P Q)
+
+/-- The Libkind--Spivak interaction obtained by uncurrying the universal
+substitution-monoid homomorphism. -/
+def xi (P : PFunctor.{pA, max qA qB})
+    (Q : PFunctor.{qA, qB}) :
+    Lens (FreeP P ⊗ CofreeP Q) (FreeP (P ⊗ Q)) :=
+  Lens.uncurry (xiHom P Q).toLens
+
+/-- Running a one-node pattern is exactly the synchronized generator step.
+This operational equation is fully heterogeneous. -/
+theorem runOn_comp_generator (P : PFunctor.{pA, pB})
+    (Q : PFunctor.{qA, qB}) :
+    runOn P Q ∘ₗ
+        (FreeP.generator P ⊗ₗ Lens.id (CofreeP Q)) =
+      FreeP.generator (P ⊗ Q) ∘ₗ
+        (Lens.id P ⊗ₗ CofreeP.cogenerator Q) := by
+  rfl
+
+/-- The universal interaction restricts to the synchronized generator step. -/
+theorem xi_comp_generator (P : PFunctor.{pA, max qA qB})
+    (Q : PFunctor.{qA, qB}) :
+    xi P Q ∘ₗ
+        (FreeP.generator P ⊗ₗ Lens.id (CofreeP Q)) =
+      FreeP.generator (P ⊗ Q) ∘ₗ
+        (Lens.id P ⊗ₗ CofreeP.cogenerator Q) := by
+  rfl
+
+/-- Strong operational characterization of the universal interaction.
+It identifies the complete output object, including the backward map from
+output paths to source pattern paths and matter vertices. -/
+theorem runObj_eq_xi_mapObj (P : PFunctor.{pA, max qA qB})
+    (Q : PFunctor.{qA, qB})
+    (pattern : (FreeP P).A) (matter : (CofreeP Q).A) :
+    runObj pattern matter =
+      Lens.mapObj (xi P Q)
+        (⟨(pattern, matter), id⟩ :
+          (FreeP P ⊗ CofreeP Q).Obj
+            (FreeM.Path pattern × M.Vertex matter)) := by
+  induction pattern generalizing matter with
+  | pure value =>
+      cases value
+      rfl
+  | liftBind a rest ih =>
+      let prepend (direction : P.B a × Q.B (M.head matter)) :
+          FreeM.Path (rest direction.1) ×
+              M.Vertex (M.children matter direction.2) →
+            FreeM.Path (FreeM.liftBind a rest) × M.Vertex matter :=
+        fun pulled =>
+          ⟨FreeM.Path.cons a rest direction.1 pulled.1,
+            M.Vertex.child direction.2 pulled.2⟩
+      let middle : (FreeP (P ⊗ Q)).Obj
+          (FreeM.Path (FreeM.liftBind a rest) × M.Vertex matter) :=
+        FreeP.node (P := P ⊗ Q) (a, M.head matter) fun direction =>
+          FreeP.relabel (prepend direction)
+            (Lens.mapObj (xi P Q)
+              (⟨(rest direction.1,
+                  M.children matter direction.2), id⟩ :
+                (FreeP P ⊗ CofreeP Q).Obj
+                  (FreeM.Path (rest direction.1) ×
+                    M.Vertex (M.children matter direction.2))))
+      have hfirst : runObj (FreeM.liftBind a rest) matter = middle := by
+        change FreeP.node (P := P ⊗ Q) (a, M.head matter) _ =
+          FreeP.node (P := P ⊗ Q) (a, M.head matter) _
+        congr 1
+        funext direction
+        exact congrArg
+          (FreeP.relabel (prepend direction))
+          (ih direction.1 (M.children matter direction.2))
+      have hsecond : middle =
+          Lens.mapObj (xi P Q)
+            (⟨(FreeM.liftBind a rest, matter), id⟩ :
+              (FreeP P ⊗ CofreeP Q).Obj
+                (FreeM.Path (FreeM.liftBind a rest) ×
+                  M.Vertex matter)) := by
+        rfl
+      exact hfirst.trans hsecond
+
+/-- The executable synchronized traversal is exactly the paper's
+internal-hom/convolution construction. -/
+theorem runOn_eq_xi (P : PFunctor.{pA, max qA qB})
+    (Q : PFunctor.{qA, qB}) :
+    runOn P Q = xi P Q := by
+  let hA : ∀ input,
+      (runOn P Q).toFunA input = (xi P Q).toFunA input :=
+    fun input =>
+      congrArg Sigma.fst (runObj_eq_xi_mapObj P Q input.1 input.2)
+  refine Lens.ext _ _ hA ?_
+  intro input
+  rcases input with ⟨pattern, matter⟩
+  apply eq_of_heq
+  have hraw : (runOn P Q).toFunB (pattern, matter) ≍
+      (xi P Q).toFunB (pattern, matter) :=
+    (Sigma.ext_iff.mp (runObj_eq_xi_mapObj P Q pattern matter)).2
+  have hcast : (hA (pattern, matter) ▸
+      (xi P Q).toFunB (pattern, matter)) ≍
+      (xi P Q).toFunB (pattern, matter) :=
+    eqRec_heq_self _ _
+  exact hraw.trans hcast.symm
+
+/-- The universal interaction is natural in both generators at the minimal
+direction-universe ceilings required by its convolution construction. -/
+theorem xi_natural
+    {P : PFunctor.{pA, max qA qB}}
+    {P' : PFunctor.{pA', max qA' qB'}}
+    {Q : PFunctor.{qA, qB}} {Q' : PFunctor.{qA', qB'}}
+    (f : Lens P P') (g : Lens Q Q') :
+    xi P' Q' ∘ₗ (FreeP.map f ⊗ₗ CofreeP.map g) =
+      FreeP.map (f ⊗ₗ g) ∘ₗ xi P Q := by
+  rw [← runOn_eq_xi P' Q', ← runOn_eq_xi P Q]
+  exact runOn_natural f g
+
+end FreeP
+end PFunctor

--- a/PolyFunTest/PFunctor/PatternRunsOnMatter.lean
+++ b/PolyFunTest/PFunctor/PatternRunsOnMatter.lean
@@ -1,0 +1,486 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+module
+
+public import PolyFun.PFunctor.PatternRunsOnMatter.Module
+public import PolyFun.PFunctor.Cofree.FiniteProjection
+
+/-!
+# Regression tests for pattern running on matter
+
+The decisive example below uses different branching types in the pattern and
+matter and follows two different directions in each. It detects a swapped
+tensor factor, a repeated root, a discarded continuation, or a backward map
+that records only the final edge.
+-/
+
+@[expose] public section
+
+universe pA pB pA' pB' qA qB qA' qB' u
+
+namespace PFunctor
+namespace PatternRunsOnMatterTest
+
+/-- The executable interaction does not identify any of the four generator
+universes. -/
+example (P : PFunctor.{pA, pB}) (Q : PFunctor.{qA, qB}) :
+    Lens (FreeP P ⊗ CofreeP Q) (FreeP (P ⊗ Q)) :=
+  FreeP.runOn P Q
+
+/-- Naturality likewise preserves all eight source/target generator
+universes. -/
+example {P : PFunctor.{pA, pB}} {P' : PFunctor.{pA', pB'}}
+    {Q : PFunctor.{qA, qB}} {Q' : PFunctor.{qA', qB'}}
+    (f : Lens P P') (g : Lens Q Q') :
+    FreeP.runOn P' Q' ∘ₗ (FreeP.map f ⊗ₗ CofreeP.map g) =
+      FreeP.map (f ⊗ₗ g) ∘ₗ FreeP.runOn P Q :=
+  FreeP.runOn_natural f g
+
+/-- The convolution/free-universal construction needs only the direction
+ceiling induced by the matter polynomial, not a square category. -/
+example (P : PFunctor.{pA, max qA qB}) (Q : PFunctor.{qA, qB}) :
+    Lens (FreeP P ⊗ CofreeP Q) (FreeP (P ⊗ Q)) :=
+  FreeP.xi P Q
+
+example (P : PFunctor.{pA, max qA qB}) (Q : PFunctor.{qA, qB}) :
+    FreeP.runOn P Q = FreeP.xi P Q :=
+  FreeP.runOn_eq_xi P Q
+
+example {P : PFunctor.{pA, max qA qB}}
+    {P' : PFunctor.{pA', max qA' qB'}}
+    {Q : PFunctor.{qA, qB}} {Q' : PFunctor.{qA', qB'}}
+    (f : Lens P P') (g : Lens Q Q') :
+    FreeP.xi P' Q' ∘ₗ (FreeP.map f ⊗ₗ CofreeP.map g) =
+      FreeP.map (f ⊗ₗ g) ∘ₗ FreeP.xi P Q :=
+  FreeP.xi_natural f g
+
+/-- A square category remains an important specialization for the module
+coherence laws. -/
+example (P Q : PFunctor.{u, u}) :
+    Lens (FreeP P ⊗ CofreeP Q) (FreeP (P ⊗ Q)) :=
+  FreeP.xi P Q
+
+example (P Q : PFunctor.{u, u}) :
+    FreeP.runOn P Q = FreeP.xi P Q :=
+  FreeP.runOn_eq_xi P Q
+
+example (P : PFunctor.{u, u}) :
+    (FreeP.map (Lens.Equiv.tensorX (P := P)).toLens ∘ₗ
+        FreeP.runOn P X.{u, u}) ∘ₗ
+        (Lens.id (FreeP P) ⊗ₗ CofreeP.laxUnit.{u, u}) =
+      (Lens.Equiv.tensorX (P := FreeP P)).toLens :=
+  FreeP.runOn_unit P
+
+example (P Q R : PFunctor.{u, u}) :
+    (FreeP.runOn P (Q ⊗ R) ∘ₗ
+        (Lens.id (FreeP P) ⊗ₗ CofreeP.laxTensor Q R)) ∘ₗ
+        (Lens.Equiv.tensorAssoc
+          (P := FreeP P) (Q := CofreeP Q)
+          (R := CofreeP R)).toLens =
+      (FreeP.map
+          (Lens.Equiv.tensorAssoc
+            (P := P) (Q := Q) (R := R)).toLens ∘ₗ
+        FreeP.runOn (P ⊗ Q) R) ∘ₗ
+        (FreeP.runOn P Q ⊗ₗ Lens.id (CofreeP R)) :=
+  FreeP.runOn_assoc P Q R
+
+abbrev patternP : PFunctor := ⟨Bool, fun _ => Bool⟩
+
+inductive MatterLabel where
+  | initial
+  | afterZero
+  | afterOne
+  | afterTwo
+  deriving DecidableEq
+
+abbrev matterP : PFunctor := ⟨MatterLabel, fun _ => Fin 3⟩
+
+def pattern : (FreeP patternP).A :=
+  .liftBind false fun first =>
+    .liftBind first fun _ =>
+      .pure PUnit.unit
+
+def matterStep (history : List (Fin 3)) : matterP (List (Fin 3)) :=
+  ⟨match history.head? with
+    | none => .initial
+    | some 0 => .afterZero
+    | some 1 => .afterOne
+    | some _ => .afterTwo,
+    fun direction => direction :: history⟩
+
+def matter : (CofreeP matterP).A := M.corec matterStep []
+
+def oneNode : (FreeP patternP).A :=
+  .liftBind false fun _ : Bool => .pure PUnit.unit
+
+def oneNodeOutputPath : FreeM.Path
+    ((FreeP.runOn patternP matterP).toFunA (oneNode, matter)) :=
+  ⟨(true, 2), ⟨⟩⟩
+
+/-- Observe the root operation label of a nonempty free tree. -/
+def rootLabel {P : PFunctor} {α : Type} : FreeM P α → Option P.A
+  | .pure _ => none
+  | .liftBind operation _ => some operation
+
+/-- The forward one-node run synchronizes the pattern and matter root labels
+in the advertised tensor order. -/
+example : rootLabel
+    ((FreeP.runOn patternP matterP).toFunA (oneNode, matter)) =
+      some (false, .initial) := by
+  rfl
+
+/-- One synchronized step pairs the two root labels and preserves the order
+of the pattern and matter directions in the backward result. -/
+example :
+    (FreeP.runOn patternP matterP).toFunB
+      (oneNode, matter) oneNodeOutputPath =
+      (⟨true, ⟨⟩⟩, .child 2 (.root _)) := by
+  rfl
+
+/-- A leaf pattern terminates immediately and returns the unadvanced matter
+root through the backward map. -/
+example :
+    (FreeP.runOn patternP matterP).toFunB
+        ((FreeM.pure PUnit.unit : (FreeP patternP).A), matter)
+        ⟨⟩ =
+      (⟨⟩, .root matter) :=
+  rfl
+
+/-- The chosen output path takes pattern branches `[false, true]` and matter
+branches `[2, 0]`. -/
+def outputPath : FreeM.Path
+    ((FreeP.runOn patternP matterP).toFunA (pattern, matter)) :=
+  ⟨(false, 2), ⟨(true, 0), ⟨⟩⟩⟩
+
+def expectedPatternPath : FreeM.Path pattern :=
+  ⟨false, ⟨true, ⟨⟩⟩⟩
+
+def expectedMatterVertex : M.Vertex matter :=
+  .child 2 (.child 0 (.root _))
+
+/-- The complete dependent backward result records both synchronized steps in
+the correct factor order. -/
+example :
+    (FreeP.runOn patternP matterP).toFunB (pattern, matter) outputPath =
+      (expectedPatternPath, expectedMatterVertex) := by
+  rfl
+
+/-- The synchronized traversal consumes exactly two matter edges before the
+finite pattern terminates. -/
+example : M.Vertex.depth expectedMatterVertex = 2 := by
+  rfl
+
+/-- Change both operation labels and pull target branches back through a
+nonidentity permutation. -/
+def patternFlip : Lens patternP patternP :=
+  (fun label => !label) ⇆ (fun _ direction => !direction)
+
+/-- Rotate ternary directions while changing the visible matter state. -/
+def matterRotate : Lens matterP matterP :=
+  (fun label => match label with
+    | .initial => .afterOne
+    | .afterZero => .afterTwo
+    | .afterOne => .initial
+    | .afterTwo => .afterZero) ⇆
+  (fun _ direction => (direction + 1) % 3)
+
+def mappedAction : Lens (FreeP patternP ⊗ CofreeP matterP)
+    (FreeP (patternP ⊗ matterP)) :=
+  FreeP.runOn patternP matterP ∘ₗ
+    (FreeP.map patternFlip ⊗ₗ CofreeP.map matterRotate)
+
+def mappedOutputPath : FreeM.Path
+    (mappedAction.toFunA (pattern, matter)) :=
+  ⟨(false, 2), ⟨(true, 0), ⟨⟩⟩⟩
+
+/-- Read a pattern path as its root-to-leaf direction sequence. -/
+def patternDirections : (tree : (FreeP patternP).A) →
+    FreeM.Path tree → List Bool
+  | .pure _, _ => []
+  | .liftBind _ rest, path =>
+      path.1 :: patternDirections (rest path.1) path.2
+
+/-- Observe the first direction of a matter vertex without exposing its
+dependent tail. -/
+def matterFirst : {tree : (CofreeP matterP).A} →
+    M.Vertex tree → Option (Fin 3)
+  | _, .root _ => none
+  | _, .child direction _ => some direction
+
+/-- Read every matter direction, erasing only the dependent subtree indices. -/
+def matterDirections : {tree : (CofreeP matterP).A} →
+    M.Vertex tree → List (Fin 3)
+  | _, .root _ => []
+  | _, .child direction next => direction :: matterDirections next
+
+/-- The nonidentity pattern map is observable in the complete pulled-back
+pattern path: both Boolean directions are flipped. -/
+example :
+    let pulled := mappedAction.toFunB (pattern, matter) mappedOutputPath
+    patternDirections pattern pulled.1 = [true, false] := by
+  rfl
+
+/-- The mapped forward root observes both nonidentity label maps. -/
+example : rootLabel (mappedAction.toFunA (pattern, matter)) =
+    some (true, .afterOne) := by
+  rfl
+
+/-- The mapped matter vertex starts with the rotated source direction. -/
+example :
+    let pulled := mappedAction.toFunB (pattern, matter) mappedOutputPath
+    matterFirst pulled.2 = some 0 := by
+  change matterFirst
+      (M.Vertex.pullMapLens matterRotate matter
+        (.child 2 (.child 0 (.root _)))) = some 0
+  rw [M.Vertex.pullMapLens_child]
+  rfl
+
+/-- Pulling through the nonidentity matter map preserves the complete
+two-edge traversal rather than truncating its dependent tail. -/
+example :
+    let pulled := mappedAction.toFunB (pattern, matter) mappedOutputPath
+    M.Vertex.depth pulled.2 = 2 := by
+  change M.Vertex.depth
+      (M.Vertex.pullMapLens matterRotate matter
+        (.child 2 (.child 0 (.root _)))) = 2
+  rw [M.Vertex.depth_pullMapLens]
+  rfl
+
+/-- Both generator-level direction rotations used by the depth-two mapped
+path are pinned independently. -/
+example : matterRotate.toFunB .initial 2 = 0 := by rfl
+
+example : matterRotate.toFunB .afterZero 0 = 1 := by rfl
+
+def mappedMatter : (CofreeP matterP).A :=
+  (CofreeP.map matterRotate).toFunA matter
+
+def mappedMatterDirection :
+    (compNth matterP 2).B
+      ((CofreeP.projectionN matterP 2).toFunA mappedMatter) :=
+  ⟨2, ⟨0, PUnit.unit⟩⟩
+
+def mappedMatterVertex : M.Vertex mappedMatter :=
+  (CofreeP.projectionN matterP 2).toFunB
+    mappedMatter mappedMatterDirection
+
+/-- Both rotated directions occur in the actual mapped cofree traversal. -/
+theorem mappedMatterDirections :
+    matterDirections
+      ((CofreeP.map matterRotate).toFunB matter mappedMatterVertex) =
+        [0, 1] := by
+  let F := CofreeP.mapHom matterRotate
+  have h := congrArg
+    (fun lens : Lens (CofreeP.comonoid matterP).carrier
+        (compNth matterP 2) =>
+      lens.toFunB matter mappedMatterDirection)
+    (CofreeP.hom_comp_projectionN F 2)
+  dsimp only [mappedMatterVertex]
+  change matterDirections
+      ((F.toLens ⨟ CofreeP.projectionN matterP 2).toFunB
+        matter mappedMatterDirection) = [0, 1]
+  have hdirections := congrArg matterDirections h
+  have hrestrict :
+      CofreeP.restrict (CofreeP.comonoid matterP) F =
+        matterRotate ∘ₗ CofreeP.cogenerator matterP := by
+    dsimp only [F, CofreeP.restrict]
+    exact CofreeP.cogenerator_comp_map matterRotate
+  exact hdirections.trans (by
+    rw [hrestrict]
+    simp only [CofreeP.comonoid_carrier, compNth,
+      Lens.compNthMap_succ, Lens.compNthMap_zero,
+      Comonoid.comultN_succ, Comonoid.comultN_zero]
+    rfl)
+
+/-- The mapped interaction uses that complete cofree pullback, not merely its
+first edge and depth. -/
+example :
+    let pulled := mappedAction.toFunB (pattern, matter) mappedOutputPath
+    matterDirections pulled.2 = [0, 1] := by
+  change matterDirections
+      ((CofreeP.map matterRotate).toFunB matter mappedMatterVertex) = [0, 1]
+  exact mappedMatterDirections
+
+/-- Proposition 3.3 is exercised with observable nonidentity maps in both
+factors, rather than only identities or unit signatures. -/
+example :
+    FreeP.runOn patternP matterP ∘ₗ
+        (FreeP.map patternFlip ⊗ₗ CofreeP.map matterRotate) =
+      FreeP.map (patternFlip ⊗ₗ matterRotate) ∘ₗ
+        FreeP.runOn patternP matterP :=
+  FreeP.runOn_natural patternFlip matterRotate
+
+/-- The universal construction computes the same complete labelled object on
+the decisive depth-two input, including its backward map. -/
+example :
+    FreeP.runObj pattern matter =
+      Lens.mapObj (FreeP.xi patternP matterP)
+        (⟨(pattern, matter), id⟩ :
+          (FreeP patternP ⊗ CofreeP matterP).Obj
+            (FreeM.Path pattern × M.Vertex matter)) :=
+  FreeP.runObj_eq_xi_mapObj patternP matterP pattern matter
+
+/-- Unit coherence is operationally nontrivial on the two-node pattern. -/
+example :
+    ((FreeP.map (Lens.Equiv.tensorX (P := patternP)).toLens ∘ₗ
+        FreeP.runOn patternP X) ∘ₗ
+        (Lens.id (FreeP patternP) ⊗ₗ CofreeP.laxUnit)).toFunA
+        (pattern, PUnit.unit) = pattern := by
+  have h := congrArg
+    (fun lens : Lens (FreeP patternP ⊗ X) (FreeP patternP) =>
+      lens.toFunA (pattern, PUnit.unit))
+    (FreeP.runOn_unit patternP)
+  exact h
+
+def unitAction : Lens (FreeP patternP ⊗ X.{0, 0}) (FreeP patternP) :=
+  (FreeP.map (Lens.Equiv.tensorX (P := patternP)).toLens ∘ₗ
+      FreeP.runOn patternP X) ∘ₗ
+    (Lens.id (FreeP patternP) ⊗ₗ CofreeP.laxUnit)
+
+/-- Unit coherence preserves a complete nonempty pattern path through the
+backward map, including the unit direction discarded by tensor unitor. -/
+example :
+    unitAction.toFunB (pattern, PUnit.unit) expectedPatternPath =
+      (expectedPatternPath, PUnit.unit) := by
+  rfl
+
+abbrev auxiliaryP : PFunctor := ⟨Bool, fun _ => Bool⟩
+
+def auxiliaryStep (history : List Bool) : auxiliaryP (List Bool) :=
+  ⟨history.head?.getD false, fun direction => direction :: history⟩
+
+def auxiliaryMatter : (CofreeP auxiliaryP).A :=
+  M.corec auxiliaryStep []
+
+def assocLhs :
+    Lens ((FreeP patternP ⊗ CofreeP matterP) ⊗ CofreeP auxiliaryP)
+      (FreeP (patternP ⊗ (matterP ⊗ auxiliaryP))) :=
+  (FreeP.runOn patternP (matterP ⊗ auxiliaryP) ∘ₗ
+      (Lens.id (FreeP patternP) ⊗ₗ
+        CofreeP.laxTensor matterP auxiliaryP)) ∘ₗ
+    (Lens.Equiv.tensorAssoc
+      (P := FreeP patternP) (Q := CofreeP matterP)
+      (R := CofreeP auxiliaryP)).toLens
+
+def assocRhs :
+    Lens ((FreeP patternP ⊗ CofreeP matterP) ⊗ CofreeP auxiliaryP)
+      (FreeP (patternP ⊗ (matterP ⊗ auxiliaryP))) :=
+  (FreeP.map
+      (Lens.Equiv.tensorAssoc
+        (P := patternP) (Q := matterP) (R := auxiliaryP)).toLens ∘ₗ
+      FreeP.runOn (patternP ⊗ matterP) auxiliaryP) ∘ₗ
+    (FreeP.runOn patternP matterP ⊗ₗ Lens.id (CofreeP auxiliaryP))
+
+def assocOutputPath : FreeM.Path
+    (assocRhs.toFunA ((pattern, matter), auxiliaryMatter)) :=
+  ⟨(false, (2, true)), ⟨(true, (0, false)), ⟨⟩⟩⟩
+
+def expectedAuxiliaryVertex : M.Vertex auxiliaryMatter :=
+  .child true (.child false (.root _))
+
+/-- Read every auxiliary direction, erasing only dependent subtree indices. -/
+def auxiliaryDirections : {tree : (CofreeP auxiliaryP).A} →
+    M.Vertex tree → List Bool
+  | _, .root _ => []
+  | _, .child direction next => direction :: auxiliaryDirections next
+
+def synchronizedMatter : (CofreeP (matterP ⊗ auxiliaryP)).A :=
+  (CofreeP.laxTensor matterP auxiliaryP).toFunA
+    (matter, auxiliaryMatter)
+
+def synchronizedDirection :
+    (compNth (matterP ⊗ auxiliaryP) 2).B
+      ((CofreeP.projectionN (matterP ⊗ auxiliaryP) 2).toFunA
+        synchronizedMatter) :=
+  ⟨(2, true), ⟨(0, false), PUnit.unit⟩⟩
+
+def synchronizedVertex : M.Vertex synchronizedMatter :=
+  (CofreeP.projectionN (matterP ⊗ auxiliaryP) 2).toFunB
+    synchronizedMatter synchronizedDirection
+
+/-- The cofree laxator's finite projection independently exposes both
+component direction streams through its cast-free universal equation. -/
+theorem synchronizedBackwardDirections :
+    let pulled := (CofreeP.laxTensor matterP auxiliaryP).toFunB
+      (matter, auxiliaryMatter) synchronizedVertex
+    matterDirections pulled.1 = [2, 0] ∧
+      auxiliaryDirections pulled.2 = [true, false] := by
+  let F := CofreeP.laxTensorHom matterP auxiliaryP
+  have h := congrArg
+    (fun lens : Lens
+        ((CofreeP.comonoid matterP).tensor
+          (CofreeP.comonoid auxiliaryP)).carrier
+        (compNth (matterP ⊗ auxiliaryP) 2) =>
+      lens.toFunB (matter, auxiliaryMatter) synchronizedDirection)
+    (CofreeP.hom_comp_projectionN F 2)
+  dsimp only [synchronizedVertex]
+  change
+    matterDirections
+        ((F.toLens ⨟
+          CofreeP.projectionN (matterP ⊗ auxiliaryP) 2).toFunB
+          (matter, auxiliaryMatter) synchronizedDirection).1 = [2, 0] ∧
+      auxiliaryDirections
+        ((F.toLens ⨟
+          CofreeP.projectionN (matterP ⊗ auxiliaryP) 2).toFunB
+          (matter, auxiliaryMatter) synchronizedDirection).2 = [true, false]
+  have hmatter := congrArg (fun pair => matterDirections pair.1) h
+  have hauxiliary := congrArg (fun pair => auxiliaryDirections pair.2) h
+  constructor
+  · exact hmatter.trans (by
+      dsimp only [F, CofreeP.laxTensorHom]
+      rw [CofreeP.restrict_extend]
+      simp only [CofreeP.comonoid_carrier, Comonoid.tensor_carrier, compNth,
+        Lens.compNthMap_succ, Lens.compNthMap_zero,
+        Comonoid.comultN_succ, Comonoid.comultN_zero]
+      rfl)
+  · exact hauxiliary.trans (by
+      dsimp only [F, CofreeP.laxTensorHom]
+      rw [CofreeP.restrict_extend]
+      simp only [CofreeP.comonoid_carrier, Comonoid.tensor_carrier, compNth,
+        Lens.compNthMap_succ, Lens.compNthMap_zero,
+        Comonoid.comultN_succ, Comonoid.comultN_zero]
+      rfl)
+
+/-- The two parenthesizations compute the same depth-two output position. -/
+example : assocLhs.toFunA ((pattern, matter), auxiliaryMatter) =
+    assocRhs.toFunA ((pattern, matter), auxiliaryMatter) := by
+  rfl
+
+def assocLhsOutputPath : FreeM.Path
+    (assocLhs.toFunA ((pattern, matter), auxiliaryMatter)) :=
+  ⟨(false, (2, true)), ⟨(true, (0, false)), ⟨⟩⟩⟩
+
+/-- The cast-heavy combined route is evaluated directly, independently of
+`runOn_assoc`: it preserves the complete pattern path and both distinguishable
+matter streams. -/
+example :
+    let pulled := assocLhs.toFunB
+      ((pattern, matter), auxiliaryMatter) assocLhsOutputPath
+    patternDirections pattern pulled.1.1 = [false, true] ∧
+      matterDirections pulled.1.2 = [2, 0] ∧
+      auxiliaryDirections pulled.2 = [true, false] := by
+  dsimp only [assocLhs, assocLhsOutputPath]
+  change [false, true] = [false, true] ∧
+    matterDirections
+        ((CofreeP.laxTensor matterP auxiliaryP).toFunB
+          (matter, auxiliaryMatter) synchronizedVertex).1 = [2, 0] ∧
+      auxiliaryDirections
+        ((CofreeP.laxTensor matterP auxiliaryP).toFunB
+          (matter, auxiliaryMatter) synchronizedVertex).2 = [true, false]
+  exact ⟨rfl, synchronizedBackwardDirections⟩
+
+/-- The decisive associativity canary independently evaluates the sequential
+route, distinguishing all three direction streams. Together with the explicit
+full-lens theorem surface above, this pins the combined route as well. -/
+example :
+    assocRhs.toFunB ((pattern, matter), auxiliaryMatter)
+        assocOutputPath =
+      ((expectedPatternPath, expectedMatterVertex),
+        expectedAuxiliaryVertex) := by
+  rfl
+
+end PatternRunsOnMatterTest
+end PFunctor

--- a/docs/reading/pattern-runs-on-matter.md
+++ b/docs/reading/pattern-runs-on-matter.md
@@ -1,0 +1,61 @@
+# Libkind--Spivak: pattern runs on matter
+
+This note records the source correspondence for the formalization of
+Libkind and Spivak, *Pattern Runs on Matter: The Free Monad Monad as a Module
+over the Cofree Comonad Comonad* (arXiv:2404.16321v3).
+
+## Formalized map
+
+The paper's Equation (1) and Section 3.2 construct
+
+```text
+Xi(P,Q) : Free(P) ⊗ Cofree(Q) → Free(P ⊗ Q).
+```
+
+Operationally, a finite `P`-tree is the pattern and a possibly infinite
+`Q`-tree is the matter. A pattern leaf stops without advancing the matter. At
+a pattern node, the two current operation symbols are paired. A direction in
+the product selects both the next pattern branch and the next matter subtree.
+An output leaf therefore determines a complete path through the pattern and a
+finite vertex of the matter.
+
+`FreeP.runObj` is this executable traversal, including its dependent backward
+map, and `FreeP.runOn` packages it as a polynomial lens. `FreeP.xi` follows the
+paper's categorical construction: curry the synchronized generator, extend it
+from the free substitution monoid into the convolution monoid, and uncurry.
+`FreeP.runOn_eq_xi` proves that the executable map is the source construction,
+not merely an implementation with similar forward behavior.
+
+## Source ledger
+
+| Source | Lean statement |
+|---|---|
+| Equation (1), Section 3.2 | `FreeP.runOn`, `FreeP.xi`, `FreeP.runOn_eq_xi` |
+| Proposition 3.3 | covariance in both generators, `FreeP.runOn_natural` |
+| Theorem 3.4 | the right action's unit and associativity equations |
+| Appendix C.1 | `CofreeP.laxUnit`, `CofreeP.laxTensor`, and their coherence laws |
+| Appendix D | proof guidance for naturality and the module equations |
+
+The paper calls the result a left module, while its principal displayed map is
+written `Free(P) ⊗ Cofree(Q)`. Appendix D draws symmetry-equivalent diagrams
+in the opposite tensor order. PolyFun follows Equation (1): its concrete API is
+a right action. No symmetry is hidden in the theorem statements.
+
+## Universe boundary
+
+The executable `runOn` keeps the position and direction universes of `P` and
+`Q` independent. The universal `xi` also keeps both position universes and
+both universes of `Q` independent; it requires only
+`P : PFunctor.{pA, max qA qB}` for `Q : PFunctor.{qA,qB}`. This direction
+ceiling is forced by the current homogeneous `SubstMonoid.Hom` API:
+`CofreeP Q` raises both carrier universes to `max qA qB`, while `FreeP.extend`
+requires its target substitution monoid to have exactly the free monoid's
+universe pair. The module coherence laws remain in `PFunctor.{u,u}` because
+they compare this interaction with fixed-category monoidal structure maps.
+The formalization does not conceal either boundary with `ULift` transport.
+
+## Scope
+
+These results are structural and deterministic. They establish no
+cryptographic security claim. Protocol, game, voting, and generalized-duality
+applications from Section 4 belong to the downstream examples layer.

--- a/docs/reading/roadmap.md
+++ b/docs/reading/roadmap.md
@@ -294,12 +294,17 @@ canonical `FreeM` interpretation.
   DFA mate = accepted language (Example 8.51); the general Moore-mate shape of
   Example 8.52 is now captured by the behavior/reached-state bridge, while a
   concrete `List A → B` worked example remains open.
-- **C4** honest statement replacing the `FreeM ⊣ Cofree` slogan: the true
+- **C4 core done** honest statement replacing the `FreeM ⊣ Cofree` slogan:
+  the true
   adjunction is `U ⊣ 𝒯_₋` between `Comon(Poly)` and `Poly` (Thm 8.45);
   the free-monad/cofree-comonad relationship is Libkind–Spivak's module
-  structure (EPTCS 429). Fix `Interaction/Basic/TypeTree.lean:83` +
-  `REFERENCES.md:65` wording; resolves `corrections.md` item 1; recast
-  `behavior`/`trajectory` as induced universal maps.
+  structure (EPTCS 429). `PatternRunsOnMatter/Basic` gives the executable
+  action and full naturality; `Universal` identifies it with the paper's
+  convolution extension; `Module` proves unit and associativity. Section 4
+  operational bridges and worked applications remain the next slice. The
+  corrected wording in `Interaction/Basic/TypeTree.lean` and `REFERENCES.md`
+  resolves `corrections.md` item 1 and presents `behavior`/`trajectory` as
+  induced universal maps.
 
 ### Phase D — comodules, bicomodules, research (Ch 8.3 + Ch 9)
 

--- a/docs/wiki/pfunctor.md
+++ b/docs/wiki/pfunctor.md
@@ -193,7 +193,10 @@ displayed families, roll bounds) on top of the upstream type.
 | [`PolyFun/PFunctor/Cofree/Polynomial.lean`](../../PolyFun/PFunctor/Cofree/Polynomial.lean) | `CofreeP P`, whose positions are potentially infinite `P`-trees and whose directions are finite rooted vertices; its extension equivalence with `CofreeC P`, functorial action on lenses, and substitution-comonoid structure. Its carrier uses `max uA uB` for both polynomial universes because a vertex stores directions along an ambient `M P` tree. |
 | [`PolyFun/PFunctor/Cofree/Universal.lean`](../../PolyFun/PFunctor/Cofree/Universal.lean) | Generic coiteration and the cofree-comonoid universal property `Comonoid.Hom C (CofreeP.comonoid P) ≃ Lens C.carrier P`, with explicit naturality in both variables. The generic unfolding keeps the comonoid and generator universe pairs independent; the hom-set packaging specializes `C` to the homogeneous `max uA uB` universe pair required by the existing `Comonoid.Hom`. This is unbundled adjunction data, not a `CategoryTheory.Adjunction`. |
 | [`PolyFun/PFunctor/Cofree/FiniteProjection.lean`](../../PolyFun/PFunctor/Cofree/FiniteProjection.lean) | Universe-polymorphic structural finite projections `projectionN P n : CofreeP P ⇆ compNth P n`, their exact backward-map depth semantics and low-stage unitors, and the homogeneous algebraic bridge yielding the arbitrary-retrofunctor and cofree-extension forms of Proposition 8.49. Additive splitting (Equation 8.32) is deferred until its required composition-power reassociation equivalence is available. |
-| [`PolyFun/PFunctor/Cofree/LaxMonoidal.lean`](../../PolyFun/PFunctor/Cofree/LaxMonoidal.lean) | The cofree functor's unit comparison `y ⇆ CofreeP y` and synchronized-tree laxator `CofreeP P ⊗ CofreeP Q ⇆ CofreeP (P ⊗ Q)`, packaged as retrofunctors and equipped with generator equations, fixed-universe categorical naturality, and the two unit and associativity laws. This is Proposition 8.79 in the current Spivak–Niu edition (Proposition 8.81 in the earlier-edition notes). Cross-universe naturality needs a heterogeneous retrofunctor-law API; abstract monoidal-functor packaging and the Libkind–Spivak `FreeP` module action remain downstream. |
+| [`PolyFun/PFunctor/Cofree/LaxMonoidal.lean`](../../PolyFun/PFunctor/Cofree/LaxMonoidal.lean) | The cofree functor's unit comparison `y ⇆ CofreeP y` and synchronized-tree laxator `CofreeP P ⊗ CofreeP Q ⇆ CofreeP (P ⊗ Q)`, packaged as retrofunctors and equipped with generator equations, fixed-universe categorical naturality, and the two unit and associativity laws. This is Proposition 8.79 in the current Spivak–Niu edition (Proposition 8.81 in the earlier-edition notes). Cross-universe naturality needs a heterogeneous retrofunctor-law API; abstract monoidal-functor packaging remains downstream. |
+| [`PolyFun/PFunctor/PatternRunsOnMatter/Basic.lean`](../../PolyFun/PFunctor/PatternRunsOnMatter/Basic.lean) | The fully heterogeneous executable traversal `FreeP.runOn : FreeP P ⊗ CofreeP Q ⇆ FreeP (P ⊗ Q)`, including the complete backward map from output paths to pattern paths and finite matter vertices, and covariance in both generators. |
+| [`PolyFun/PFunctor/PatternRunsOnMatter/Universal.lean`](../../PolyFun/PFunctor/PatternRunsOnMatter/Universal.lean) | The paper's curried convolution construction `FreeP.xi` and its equality with the independently executable traversal. For `Q : PFunctor.{qA,qB}`, the homogeneous free-extension API requires only `P`'s direction universe to be `max qA qB`; their position universes remain independent. |
+| [`PolyFun/PFunctor/PatternRunsOnMatter/Module.lean`](../../PolyFun/PFunctor/PatternRunsOnMatter/Module.lean) | The concrete right-module unit and associativity laws for the Libkind--Spivak interaction. |
 | [`PolyFun/PFunctor/Trace.lean`](../../PolyFun/PFunctor/Trace.lean) | Polynomial-trace machinery shared between `PFunctor` and downstream layers. |
 
 ### Control helpers
@@ -232,9 +235,11 @@ provides the reusable monad / comonad / coalgebra plumbing. See
   monoidal coherence equations without installing an abstract monoidal-functor
   instance. PolyFun separately formalizes
   `LawfulMonad (FreeM P)` and `LawfulComonad (CofreeC F)`; those type-level
-  structures are not the paper's polynomial module action
-  `FreeP p ⊗ CofreeP q → FreeP (p ⊗ q)`. That module-action layer is a
-  later slice of the formalization.
+  structures are not the paper's polynomial module action. The latter is
+  `FreeP.runOn : FreeP p ⊗ CofreeP q ⇆ FreeP (p ⊗ q)`: it executes a
+  finite pattern against potentially infinite matter, is natural in both
+  inputs, agrees with the paper's convolution/free-universal construction
+  `FreeP.xi`, and satisfies the concrete unit and associativity equations.
 - `Lens P Q` and `Chart P Q` are the two natural categorical morphisms
   between polynomial functors. Lenses go `forward on positions, backward
   on directions`; charts go forward on both. Both categories are useful

--- a/docs/wiki/repo-map.md
+++ b/docs/wiki/repo-map.md
@@ -80,6 +80,13 @@ PFunctor/{Cofree/Polynomial, Comonoid/Category}
   -> PFunctor/Cofree/FiniteProjection
 PFunctor/{Cofree/Universal, Comonoid/Tensor}
   -> PFunctor/Cofree/LaxMonoidal
+PFunctor/{Free/Polynomial, Cofree/Polynomial}
+  -> PFunctor/PatternRunsOnMatter/Basic
+PFunctor/{PatternRunsOnMatter/Basic, Free/Universal,
+  Cofree/Universal, SubstMonoid/Convolution}
+  -> PFunctor/PatternRunsOnMatter/Universal
+PFunctor/{PatternRunsOnMatter/Universal, Cofree/LaxMonoidal}
+  -> PFunctor/PatternRunsOnMatter/Module
 
 PFunctor/{Lens, Cofree, M} + Control/Coalgebra
   -> PFunctor/Dynamical/{Basic, Safety, Combinators, Run, Speedup, Trajectory}


### PR DESCRIPTION
## Context and motivation

This PR formalizes the central construction of Libkind–Spivak: a finite free pattern runs synchronously on potentially infinite cofree matter,

```text
FreeP P ⊗ CofreeP Q  ⇆  FreeP (P ⊗ Q).
```

It gives both an executable recursive lens and the paper's universal convolution construction, proves that they are equal, and establishes naturality plus the right-module unit and associativity laws.

## What this PR adds

### Executable interaction

- `FreeP.runObj`: recursively combines a finite `P`-pattern and a `Q`-matter tree.
- `FreeP.runOn`: the resulting lens.
- at a pattern leaf, execution terminates without advancing matter;
- at a pattern node, the current pattern operation and matter root form a `P ⊗ Q` operation;
- a joint target direction selects the next pattern branch and matter child.

The backward map returns both:

1. the complete source-pattern path; and
2. the finite source-matter vertex traversed during execution.

Thus the theorem is not merely about output tree shapes.

### Universal construction

- the one-step interaction generator;
- its curried map into the convolution substitution monoid from #69/#70;
- `xiHom`, obtained from the free universal property in #55;
- `xi`, the uncurried paper map;
- `runOn_eq_xi`: equality of the executable and universal lenses, including dependent backward maps.

### Naturality and module laws

- full heterogeneous covariance of `runOn` in both generator lenses;
- right-unit coherence;
- associativity with the cofree lax-monoidal comparison;
- equations in the right-action orientation of the paper's Equation (1).

The appendix's symmetry-equivalent left-action diagrams are documented; no hidden symmetry is inserted into the formal statements.

## Source correspondence

- Equation (1): the action itself;
- Proposition 3.3: universal/convolution characterization;
- Theorem 3.4: module unit and associativity;
- Appendix C: the cofree laxator supplied by #70.

The executable definition keeps all four generator universes independent. The categorical module equations are stated in a fixed square universe because they compare the convolution/free-universal construction with the current homogeneous cofree laxator.

## Falsifiable coverage

Committed tests include:

- one-node and mapped interactions;
- direct dependent backward-map evaluations;
- depth-two synchronized traversal;
- right-unit behavior;
- executable-versus-universal equality;
- three-stream associativity with distinguishable pattern, matter, and auxiliary branches;
- separated-universe naturality canaries.

The associativity test evaluates the cast-heavy route directly without assuming `runOn_assoc`, making branch and order errors observable.

## Stack and history

- Stack position: **11 of 12**.
- Base: #70.
- Next: #72, operational/dynamical/application bridges.
- During restacking, a remaining raw vertex cast in the naturality proof and its helper equation were normalized to `castEquiv`; a duplicate `decode_relabel` introduced at the #72 boundary was removed there.

Ready for review; open and unmerged.

## Validation and trust

- full integrated validation;
- targeted PatternRunsOnMatter source/test builds;
- lint/style/import/docs checks;
- diff/trust scans;
- principal axiom footprint: only `propext`, `Classical.choice`, and `Quot.sound`.

This is deterministic polynomial/tree mathematics. It makes no cryptographic-security, probability, complexity, or adversarial-reduction claim.

## Deliberately deferred

Concrete operational interpreters, dynamical-system execution, games, and Section 4 applications are the final #72 slice. Abstract bundled module/functor packaging remains optional future work.