### PR TITLE
Remove the redundant PFunctor.ofFamily wrapper

### DIFF
--- a/PolyFun/PFunctor/Basic.lean
+++ b/PolyFun/PFunctor/Basic.lean
@@ -91,21 +91,6 @@ instance search, keeping transitions over `univ` as ergonomic as bare functions.
 def univ : PFunctor.{u + 1, u} :=
   ⟨Type u, fun T => T⟩
 
-section ofFamily
-
-/-- Construct a polynomial functor from a dependent family of directions.
-
-The family's domain remains the position type, so this constructor is useful
-when an API keeps the position type explicit and passes only its direction
-family. It is the generic polynomial-functor form of interfaces such as an
-oracle specification `Query → Type`. -/
-@[reducible, simps]
-def ofFamily {A : Type uA₁} (B : (a : A) → Type uB) : PFunctor.{uA₁, uB} where
-  A := A
-  B := B
-
-end ofFamily
-
 section Coprod
 instance {a} : IsEmpty (B 1 a) := inferInstanceAs (IsEmpty PEmpty)
 instance {α} (a : α) : IsEmpty (B (C α) a) := inferInstanceAs (IsEmpty PEmpty)

--- a/PolyFunTest/PFunctor/TraceAndRootPredicates.lean
+++ b/PolyFunTest/PFunctor/TraceAndRootPredicates.lean
@@ -18,13 +18,6 @@ namespace PFunctor.PredicateExamples
 
 variable {P : PFunctor.{uA, uB}} {α : Type v}
 
-/-- A direction family reconstructs its polynomial while keeping both
-universes independent. -/
-example {A : Type uA} (B : A → Type uB) :
-    (PFunctor.ofFamily B).A = A ∧
-      (∀ a, (PFunctor.ofFamily B).B a = B a) := by
-  simp
-
 /-- The trace predicate accepts genuinely dependent direction fibers without
 requiring decidable equality on positions. -/
 example (allowed : (a : P.A) → Set (P.B a)) (a : P.A) (b : P.B a)


### PR DESCRIPTION
## Summary

- remove `PFunctor.ofFamily`, a reducible wrapper around `PFunctor.mk`
- remove its wrapper-specific producer test while retaining trace/root-predicate coverage

## Rationale

`PFunctor.mk A B` is already the canonical structure constructor and has kernel-supported projection reduction. `ofFamily` added no data or invariant, and introduced another reducible name that downstream structural indexing had to normalize. The only production consumer was VCVio's `OracleSpec.toPFunctor`, which will switch to `PFunctor.mk` directly in a follow-up PR.

## Compatibility

No currently open PolyFun PR modifies either affected file.

## Validation

- `./scripts/validate.sh --lint --test`
- umbrella build: 8,820 jobs passed
- tests: 1,951 jobs passed