### PR TITLE
feat(responder): add parallel presentation coherence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,6 +183,12 @@ PFunctor/Dynamical/Simulation
   → PFunctor/Dynamical/Responder/VerifiedPresentation
 PFunctor/{Display/Lens, Dynamical/Responder/VerifiedPresentation}
   → PFunctor/Dynamical/Responder/Lens
+PFunctor/{Free/Parallel, Dynamical/Responder/Lens,
+  Dynamical/Responder/Parallel/Behavior}
+  → PFunctor/Dynamical/Responder/Parallel/Coherence
+PFunctor/{Dynamical/Responder/VerifiedPresentation,
+  Dynamical/Responder/Parallel/Behavior}
+  → PFunctor/Dynamical/Responder/Parallel/VerifiedPresentation
 PFunctor/{Dynamical/Responder/Parallel/Behavior, Free/Parallel}
   → PFunctor/Dynamical/Responder/Parallel/Compatibility
 PFunctor/{Display/Category, PatternRunsOnMatter/Applications,

--- a/PolyFun.lean
+++ b/PolyFun.lean
@@ -154,8 +154,10 @@ import PolyFun.PFunctor.Dynamical.Responder.Display
 import PolyFun.PFunctor.Dynamical.Responder.Lens
 import PolyFun.PFunctor.Dynamical.Responder.Parallel
 import PolyFun.PFunctor.Dynamical.Responder.Parallel.Behavior
+import PolyFun.PFunctor.Dynamical.Responder.Parallel.Coherence
 import PolyFun.PFunctor.Dynamical.Responder.Parallel.Compatibility
 import PolyFun.PFunctor.Dynamical.Responder.Parallel.Display
+import PolyFun.PFunctor.Dynamical.Responder.Parallel.VerifiedPresentation
 import PolyFun.PFunctor.Dynamical.Responder.Reindex
 import PolyFun.PFunctor.Dynamical.Responder.VerifiedPresentation
 import PolyFun.PFunctor.Dynamical.Run

--- a/PolyFun/PFunctor/Dynamical/Responder/Parallel/Coherence.lean
+++ b/PolyFun/PFunctor/Dynamical/Responder/Parallel/Coherence.lean
@@ -1,0 +1,316 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+
+public import PolyFun.PFunctor.Free.Parallel
+public import PolyFun.PFunctor.Dynamical.Responder.Lens
+public import PolyFun.PFunctor.Dynamical.Responder.Parallel.Behavior
+
+/-!
+# Structural coherence of state-free parallel responder behavior
+
+The structural parallel-sum lenses witness symmetry, both units, and
+associativity of ordinary lockstep state-free behavior. The proofs factor
+through explicit responder state maps so their scheduling content is visible
+rather than hidden behind raw coinductive equality.
+-/
+
+@[expose] public section
+
+universe uA₁ uA₂ uA₃ uB uC₁ uD₁ uC₂ uD₂ uC₃ uD₃
+
+namespace PFunctor
+namespace Responder
+
+variable {P : PFunctor.{uA₁, uB}} {Q : PFunctor.{uA₂, uB}}
+
+/-- The empty state-free responder behavior. -/
+def zeroBehavior :
+    PFunctor.M ((0 : PFunctor.{uA₁, uB}) ⊸ X.{uA₁, uB}) :=
+  (Responder.zero : Responder PUnit.{1} (0 : PFunctor.{uA₁, uB})).behavior
+    PUnit.unit
+
+/-- Parallel behavior is symmetric after reindexing by the interface
+braiding. -/
+theorem mapBehavior_parallel_comm
+    (left : PFunctor.M (P ⊸ X.{uA₁, uB}))
+    (right : PFunctor.M (Q ⊸ X.{uA₂, uB})) :
+    mapBehavior (PFunctor.Lens.parallelSumComm P Q)
+        (parallelBehavior right left) =
+      parallelBehavior left right := by
+  let swapped := Responder.parallel (Responder.terminal (P := Q))
+    (Responder.terminal (P := P))
+  let normal := Responder.parallel (Responder.terminal (P := P))
+    (Responder.terminal (P := Q))
+  let mapped := Responder.reindex
+    (PFunctor.Handler.ofLens (PFunctor.Lens.parallelSumComm P Q)) swapped
+  have hBehavior : mapped.behavior (right, left) =
+      normal.behavior (left, right) := by
+    apply behavior_eq_of_responderMap mapped normal Prod.swap _ _ (left, right)
+    · intro state operation
+      rw [Responder.answer_reindex, runFree_ofLens]
+      cases operation <;> rfl
+    · intro state operation
+      rw [Responder.next_reindex, runFree_ofLens]
+      exact parallel_next_comm (Responder.terminal (P := P))
+        (Responder.terminal (P := Q)) state operation
+  calc
+    mapBehavior (PFunctor.Lens.parallelSumComm P Q)
+        (parallelBehavior right left) = mapped.behavior (right, left) :=
+      reindexBehavior_behavior
+        (PFunctor.Handler.ofLens (PFunctor.Lens.parallelSumComm P Q))
+        swapped (right, left)
+    _ = normal.behavior (left, right) := hBehavior
+    _ = parallelBehavior left right := rfl
+
+/-- The right zero interface is a unit for state-free parallel behavior after
+reindexing by the structural unitor. -/
+theorem mapBehavior_parallel_zero_right
+    (left : PFunctor.M (P ⊸ X.{uA₁, uB})) :
+    mapBehavior
+        (PFunctor.Lens.parallelSumZero P :
+          PFunctor.Lens (P ∥ (0 : PFunctor.{uA₂, uB})) P)
+        left =
+      parallelBehavior left
+        (zeroBehavior : PFunctor.M
+          ((0 : PFunctor.{uA₂, uB}) ⊸ X.{uA₂, uB})) := by
+  let base := Responder.terminal (P := P)
+  let empty := (Responder.zero :
+    Responder PUnit.{1} (0 : PFunctor.{uA₂, uB}))
+  let parallel := Responder.parallel base empty
+  let mapped := Responder.reindex
+    (PFunctor.Handler.ofLens
+      (PFunctor.Lens.parallelSumZero P :
+        PFunctor.Lens (P ∥ (0 : PFunctor.{uA₂, uB})) P)) base
+  have hBehavior : mapped.behavior left =
+      parallel.behavior
+        (left, PUnit.unit) := by
+    apply behavior_eq_of_responderMap mapped parallel Prod.fst _ _
+      (left, PUnit.unit)
+    · intro state operation
+      rw [Responder.answer_reindex, runFree_ofLens]
+      cases operation with
+      | left operation => rfl
+      | right impossible => exact PEmpty.elim impossible
+      | both operation impossible => exact PEmpty.elim impossible
+    · intro state operation
+      rw [Responder.next_reindex, runFree_ofLens]
+      cases operation with
+      | left operation => rfl
+      | right impossible => exact PEmpty.elim impossible
+      | both operation impossible => exact PEmpty.elim impossible
+  let terminalParallel := Responder.parallel base
+    (Responder.terminal (P := (0 : PFunctor.{uA₂, uB})))
+  have hPresentation : parallel.behavior (left, PUnit.unit) =
+      terminalParallel.behavior (left, empty.behavior PUnit.unit) := by
+    apply behavior_eq_of_responderMap parallel terminalParallel
+      (fun state => (state.1, PUnit.unit)) _ _
+      (left, empty.behavior PUnit.unit)
+    · intro state operation
+      cases operation with
+      | left operation => rfl
+      | right impossible => exact PEmpty.elim impossible
+      | both operation impossible => exact PEmpty.elim impossible
+    · intro state operation
+      cases operation with
+      | left operation => rfl
+      | right impossible => exact PEmpty.elim impossible
+      | both operation impossible => exact PEmpty.elim impossible
+  calc
+    mapBehavior
+        (PFunctor.Lens.parallelSumZero P :
+          PFunctor.Lens (P ∥ (0 : PFunctor.{uA₂, uB})) P) left =
+      mapBehavior
+        (PFunctor.Lens.parallelSumZero P :
+          PFunctor.Lens (P ∥ (0 : PFunctor.{uA₂, uB})) P)
+        (base.behavior left) := by rw [terminal_behavior]
+    _ = mapped.behavior left :=
+        reindexBehavior_behavior
+          (PFunctor.Handler.ofLens
+            (PFunctor.Lens.parallelSumZero P :
+              PFunctor.Lens (P ∥ (0 : PFunctor.{uA₂, uB})) P))
+          base left
+    _ = parallel.behavior
+        (left, PUnit.unit) := hBehavior
+    _ = terminalParallel.behavior (left, empty.behavior PUnit.unit) :=
+      hPresentation
+    _ = parallelBehavior left
+        (zeroBehavior : PFunctor.M
+          ((0 : PFunctor.{uA₂, uB}) ⊸ X.{uA₂, uB})) := rfl
+
+/-- The left zero interface is a unit for state-free parallel behavior after
+reindexing by the structural unitor. -/
+theorem mapBehavior_parallel_zero_left
+    (right : PFunctor.M (P ⊸ X.{uA₁, uB})) :
+    mapBehavior
+        (PFunctor.Lens.zeroParallelSum P :
+          PFunctor.Lens ((0 : PFunctor.{uA₂, uB}) ∥ P) P)
+        right =
+      parallelBehavior
+        (zeroBehavior : PFunctor.M
+          ((0 : PFunctor.{uA₂, uB}) ⊸ X.{uA₂, uB})) right := by
+  let base := Responder.terminal (P := P)
+  let empty := (Responder.zero :
+    Responder PUnit.{1} (0 : PFunctor.{uA₂, uB}))
+  let parallel := Responder.parallel empty base
+  let mapped := Responder.reindex
+    (PFunctor.Handler.ofLens
+      (PFunctor.Lens.zeroParallelSum P :
+        PFunctor.Lens ((0 : PFunctor.{uA₂, uB}) ∥ P) P)) base
+  have hBehavior : mapped.behavior right =
+      parallel.behavior (PUnit.unit, right) := by
+    apply behavior_eq_of_responderMap mapped parallel Prod.snd _ _
+      (PUnit.unit, right)
+    · intro state operation
+      rw [Responder.answer_reindex, runFree_ofLens]
+      cases operation with
+      | left impossible => exact PEmpty.elim impossible
+      | right operation => rfl
+      | both impossible operation => exact PEmpty.elim impossible
+    · intro state operation
+      rw [Responder.next_reindex, runFree_ofLens]
+      cases operation with
+      | left impossible => exact PEmpty.elim impossible
+      | right operation => rfl
+      | both impossible operation => exact PEmpty.elim impossible
+  let terminalParallel := Responder.parallel
+    (Responder.terminal (P := (0 : PFunctor.{uA₂, uB}))) base
+  have hPresentation : parallel.behavior (PUnit.unit, right) =
+      terminalParallel.behavior (empty.behavior PUnit.unit, right) := by
+    apply behavior_eq_of_responderMap parallel terminalParallel
+      (fun state => (PUnit.unit, state.2)) _ _
+      (empty.behavior PUnit.unit, right)
+    · intro state operation
+      cases operation with
+      | left impossible => exact PEmpty.elim impossible
+      | right operation => rfl
+      | both impossible operation => exact PEmpty.elim impossible
+    · intro state operation
+      cases operation with
+      | left impossible => exact PEmpty.elim impossible
+      | right operation => rfl
+      | both impossible operation => exact PEmpty.elim impossible
+  calc
+    mapBehavior
+        (PFunctor.Lens.zeroParallelSum P :
+          PFunctor.Lens ((0 : PFunctor.{uA₂, uB}) ∥ P) P) right =
+      mapBehavior
+        (PFunctor.Lens.zeroParallelSum P :
+          PFunctor.Lens ((0 : PFunctor.{uA₂, uB}) ∥ P) P)
+        (base.behavior right) := by rw [terminal_behavior]
+    _ = mapped.behavior right :=
+      reindexBehavior_behavior
+        (PFunctor.Handler.ofLens
+          (PFunctor.Lens.zeroParallelSum P :
+            PFunctor.Lens ((0 : PFunctor.{uA₂, uB}) ∥ P) P))
+        base right
+    _ = parallel.behavior (PUnit.unit, right) := hBehavior
+    _ = terminalParallel.behavior (empty.behavior PUnit.unit, right) :=
+      hPresentation
+    _ = parallelBehavior
+        (zeroBehavior : PFunctor.M
+          ((0 : PFunctor.{uA₂, uB}) ⊸ X.{uA₂, uB})) right := rfl
+
+/-- Parallel state-free behavior associates after reindexing by the interface
+associator. -/
+theorem mapBehavior_parallel_assoc
+    {R : PFunctor.{uA₃, uB}}
+    (left : PFunctor.M (P ⊸ X.{uA₁, uB}))
+    (middle : PFunctor.M (Q ⊸ X.{uA₂, uB}))
+    (right : PFunctor.M (R ⊸ X.{uA₃, uB})) :
+    mapBehavior (PFunctor.Lens.parallelSumAssoc P Q R)
+        (parallelBehavior left (parallelBehavior middle right)) =
+      parallelBehavior (parallelBehavior left middle) right := by
+  let pResponder := Responder.terminal (P := P)
+  let qResponder := Responder.terminal (P := Q)
+  let rResponder := Responder.terminal (P := R)
+  let rightAssociated := Responder.parallel pResponder
+    (Responder.parallel qResponder rResponder)
+  let leftAssociated := Responder.parallel
+    (Responder.parallel pResponder qResponder) rResponder
+  let mapped := Responder.reindex
+    (PFunctor.Handler.ofLens
+      (PFunctor.Lens.parallelSumAssoc P Q R)) rightAssociated
+  let reassocState :
+      ((PFunctor.M (P ⊸ X.{uA₁, uB}) ×
+          PFunctor.M (Q ⊸ X.{uA₂, uB})) ×
+        PFunctor.M (R ⊸ X.{uA₃, uB})) →
+      (PFunctor.M (P ⊸ X.{uA₁, uB}) ×
+        (PFunctor.M (Q ⊸ X.{uA₂, uB}) ×
+          PFunctor.M (R ⊸ X.{uA₃, uB}))) :=
+    fun state => (state.1.1, (state.1.2, state.2))
+  have hBehavior :
+      mapped.behavior (reassocState ((left, middle), right)) =
+        leftAssociated.behavior ((left, middle), right) := by
+    apply behavior_eq_of_responderMap mapped leftAssociated reassocState _ _
+      ((left, middle), right)
+    · intro state operation
+      rw [Responder.answer_reindex, runFree_ofLens]
+      cases operation with
+      | left operation => cases operation <;> rfl
+      | right operation => rfl
+      | both operation rightOperation => cases operation <;> rfl
+    · intro state operation
+      rw [Responder.next_reindex, runFree_ofLens]
+      cases operation with
+      | left operation => cases operation <;> rfl
+      | right operation => rfl
+      | both operation rightOperation => cases operation <;> rfl
+  let rightPresentation := Responder.parallel pResponder
+    (Responder.terminal (P := Q ∥ R))
+  have hRightPresentation :
+      rightPresentation.behavior
+          (left, parallelBehavior middle right) =
+        rightAssociated.behavior (left, (middle, right)) := by
+    apply behavior_eq_of_responderMap rightPresentation rightAssociated
+      (fun state => (state.1, parallelBehavior state.2.1 state.2.2)) _ _
+      (left, (middle, right))
+    · intro state operation
+      dsimp [rightPresentation, rightAssociated, pResponder,
+        qResponder, rResponder]
+      cases operation <;> simp [parallelBehavior]
+    · intro state operation
+      dsimp [rightPresentation, rightAssociated, pResponder,
+        qResponder, rResponder]
+      cases operation <;> simp [parallelBehavior]
+  let leftPresentation := Responder.parallel
+    (Responder.terminal (P := P ∥ Q)) rResponder
+  have hLeftPresentation :
+      leftPresentation.behavior
+          (parallelBehavior left middle, right) =
+        leftAssociated.behavior ((left, middle), right) := by
+    apply behavior_eq_of_responderMap leftPresentation leftAssociated
+      (fun state => (parallelBehavior state.1.1 state.1.2, state.2)) _ _
+      ((left, middle), right)
+    · intro state operation
+      dsimp [leftPresentation, leftAssociated, pResponder,
+        qResponder, rResponder]
+      cases operation <;> simp [parallelBehavior]
+    · intro state operation
+      dsimp [leftPresentation, leftAssociated, pResponder,
+        qResponder, rResponder]
+      cases operation <;> simp [parallelBehavior]
+  calc
+    mapBehavior (PFunctor.Lens.parallelSumAssoc P Q R)
+        (parallelBehavior left (parallelBehavior middle right)) =
+      mapBehavior (PFunctor.Lens.parallelSumAssoc P Q R)
+        (rightAssociated.behavior (left, (middle, right))) := by
+          exact congrArg (mapBehavior
+            (PFunctor.Lens.parallelSumAssoc P Q R)) hRightPresentation
+    _ =
+      mapped.behavior (reassocState ((left, middle), right)) :=
+        reindexBehavior_behavior
+          (PFunctor.Handler.ofLens
+            (PFunctor.Lens.parallelSumAssoc P Q R))
+          rightAssociated (reassocState ((left, middle), right))
+    _ = leftAssociated.behavior ((left, middle), right) := hBehavior
+    _ = leftPresentation.behavior
+        (parallelBehavior left middle, right) := hLeftPresentation.symm
+    _ = parallelBehavior (parallelBehavior left middle) right := rfl
+
+end Responder
+end PFunctor

--- a/PolyFun/PFunctor/Dynamical/Responder/Parallel/VerifiedPresentation.lean
+++ b/PolyFun/PFunctor/Dynamical/Responder/Parallel/VerifiedPresentation.lean
@@ -1,0 +1,320 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+
+public import PolyFun.PFunctor.Dynamical.Responder.VerifiedPresentation
+public import PolyFun.PFunctor.Dynamical.Responder.Parallel.Behavior
+
+/-!
+# Parallel composition of verified responder presentations
+
+Verified presentation homomorphisms compose componentwise under lockstep
+parallel. This proof-relevant bifunctoriality is distinct from unrestricted
+parallel composition of free handlers, which would require a Kleisli
+interchange law.
+-/
+
+@[expose] public section
+
+universe uA₁ uA₂ uA₃ uB uC₁ uD₁ uC₂ uD₂ uC₃ uD₃ uLift
+
+namespace PFunctor
+namespace Responder
+
+variable {P : PFunctor.{uA₁, uB}} {Q : PFunctor.{uA₂, uB}}
+
+private theorem ulift_heq
+    {A B : Type uC₁} {a : A} {b : B}
+    (h : HEq a b) :
+    HEq (ULift.up.{uLift, uC₁} a) (ULift.up.{uLift, uC₁} b) := by
+  cases h
+  rfl
+
+private theorem prod_heq
+    {A B : Type uC₁} {C D : Type uD₁}
+    {a : A} {b : B} {c : C} {d : D}
+    (h₁ : HEq a b) (h₂ : HEq c d) : HEq (a, c) (b, d) := by
+  cases h₁
+  cases h₂
+  rfl
+
+universe uS₁ uS₂ uT₁ uT₂ uI₁ uI₂ uJ₁ uJ₂ uK₁ uK₂ uL₁ uL₂
+
+namespace VerifiedPresentationHom
+
+/-- Componentwise parallel composition of verified presentation
+homomorphisms. Unlike arbitrary free-handler parallel composition, this is
+available without an interchange hypothesis: lockstep parallel combines the
+two one-step coalgebra squares branchwise. -/
+def parallel
+    {S : Display.{uA₁, uB, uC₁, uD₁} P}
+    {T : Display.{uA₂, uB, uC₂, uD₂} Q}
+    {SourceState₁ : Type uS₁} {SourceState₂ : Type uS₂}
+    {TargetState₁ : Type uT₁} {TargetState₂ : Type uT₂}
+    {source₁ : Responder SourceState₁ P}
+    {source₂ : Responder SourceState₂ Q}
+    {target₁ : Responder TargetState₁ P}
+    {target₂ : Responder TargetState₂ Q}
+    {SourceWitness₁ : SourceState₁ → Type uI₁}
+    {SourceWitness₂ : SourceState₂ → Type uI₂}
+    {TargetWitness₁ : TargetState₁ → Type uJ₁}
+    {TargetWitness₂ : TargetState₂ → Type uJ₂}
+    {displayedSource₁ : Display.Coalgebra (Display.responder S)
+      source₁.out SourceWitness₁}
+    {displayedSource₂ : Display.Coalgebra (Display.responder T)
+      source₂.out SourceWitness₂}
+    {displayedTarget₁ : Display.Coalgebra (Display.responder S)
+      target₁.out TargetWitness₁}
+    {displayedTarget₂ : Display.Coalgebra (Display.responder T)
+      target₂.out TargetWitness₂}
+    (f : VerifiedPresentationHom S source₁ SourceWitness₁ displayedSource₁
+      target₁ TargetWitness₁ displayedTarget₁)
+    (g : VerifiedPresentationHom T source₂ SourceWitness₂ displayedSource₂
+      target₂ TargetWitness₂ displayedTarget₂) :
+    VerifiedPresentationHom (Display.parallelSum S T)
+      (Responder.parallel source₁ source₂)
+      (fun state => SourceWitness₁ state.1 × SourceWitness₂ state.2)
+      (parallelCoalgebra source₁ source₂ SourceWitness₁ SourceWitness₂
+        displayedSource₁ displayedSource₂)
+      (Responder.parallel target₁ target₂)
+      (fun state => TargetWitness₁ state.1 × TargetWitness₂ state.2)
+      (parallelCoalgebra target₁ target₂ TargetWitness₁ TargetWitness₂
+        displayedTarget₁ displayedTarget₂) where
+  toState state := (f.toState state.1, g.toState state.2)
+  toWitness _ witness :=
+    (f.toWitness _ witness.1, g.toWitness _ witness.2)
+  map_step := by
+    intro state witness
+    have hf := f.map_step state.1 witness.1
+    have hg := g.map_step state.2 witness.2
+    dsimp [verifiedTotalStep, totalMap] at hf hg ⊢
+    apply Sigma.ext_iff.mpr
+    constructor
+    · apply Sigma.ext_iff.mpr
+      constructor
+      · calc
+          _ = parallelBehavior
+              (target₁.behavior (f.toState state.1))
+              (target₂.behavior (g.toState state.2)) :=
+            parallel_behavior _ _ _
+          _ = parallelBehavior
+              (source₁.behavior state.1) (source₂.behavior state.2) := by
+            rw [f.behavior_eq state.1 witness.1,
+              g.behavior_eq state.2 witness.2]
+          _ = _ := (parallel_behavior _ _ _).symm
+      · apply Function.hfunext rfl
+        intro operation operation' hOperation
+        cases hOperation
+        apply Function.hfunext rfl
+        intro contract contract' hContract
+        cases hContract
+        cases operation with
+        | left operation =>
+            apply ulift_heq
+            exact congr_arg_heq
+              (fun step => step.1.2 operation contract.down) hf
+        | right operation =>
+            apply ulift_heq
+            exact congr_arg_heq
+              (fun step => step.1.2 operation contract.down) hg
+        | both leftOperation rightOperation =>
+            apply prod_heq
+            · exact congr_arg_heq
+                (fun step => step.1.2 leftOperation contract.1) hf
+            · exact congr_arg_heq
+                (fun step => step.1.2 rightOperation contract.2) hg
+    · apply Function.hfunext
+      · apply congrArg
+          (Display.mStep (Display.responder
+            (Display.parallelSum S T))).sigmaPFunctor.B
+        apply Sigma.ext_iff.mpr
+        constructor
+        · calc
+            _ = parallelBehavior
+                (target₁.behavior (f.toState state.1))
+                (target₂.behavior (g.toState state.2)) :=
+              parallel_behavior _ _ _
+            _ = parallelBehavior
+                (source₁.behavior state.1) (source₂.behavior state.2) := by
+              rw [f.behavior_eq state.1 witness.1,
+                g.behavior_eq state.2 witness.2]
+            _ = _ := (parallel_behavior _ _ _).symm
+        · apply Function.hfunext rfl
+          intro operation operation' hOperation
+          cases hOperation
+          apply Function.hfunext rfl
+          intro contract contract' hContract
+          cases hContract
+          cases operation with
+          | left operation =>
+              apply ulift_heq
+              exact congr_arg_heq
+                (fun step => step.1.2 operation contract.down) hf
+          | right operation =>
+              apply ulift_heq
+              exact congr_arg_heq
+                (fun step => step.1.2 operation contract.down) hg
+          | both leftOperation rightOperation =>
+              apply prod_heq
+              · exact congr_arg_heq
+                  (fun step => step.1.2 leftOperation contract.1) hf
+              · exact congr_arg_heq
+                  (fun step => step.1.2 rightOperation contract.2) hg
+      · intro direction direction' hDirection
+        cases hDirection
+        rcases direction with ⟨⟨operation, trivialDirection⟩, contract⟩
+        cases trivialDirection
+        cases operation with
+        | left operation =>
+            have hLeft := congr_arg_heq
+              (fun step => step.2
+                ⟨⟨operation, PUnit.unit⟩, contract.down⟩) hf
+            exact heq_of_eq (congrArg
+              (fun child : Σ next, TargetWitness₁ next =>
+                (⟨(child.1, g.toState state.2),
+                  (child.2, g.toWitness state.2 witness.2)⟩ :
+                  Σ next, TargetWitness₁ next.1 ×
+                    TargetWitness₂ next.2)) (eq_of_heq hLeft))
+        | right operation =>
+            have hRight := congr_arg_heq
+              (fun step => step.2
+                ⟨⟨operation, PUnit.unit⟩, contract.down⟩) hg
+            exact heq_of_eq (congrArg
+              (fun child : Σ next, TargetWitness₂ next =>
+                (⟨(f.toState state.1, child.1),
+                  (f.toWitness state.1 witness.1, child.2)⟩ :
+                  Σ next, TargetWitness₁ next.1 ×
+                    TargetWitness₂ next.2)) (eq_of_heq hRight))
+        | both leftOperation rightOperation =>
+            have hLeft := congr_arg_heq
+              (fun step => step.2
+                ⟨⟨leftOperation, PUnit.unit⟩, contract.1⟩) hf
+            have hRight := congr_arg_heq
+              (fun step => step.2
+                ⟨⟨rightOperation, PUnit.unit⟩, contract.2⟩) hg
+            exact heq_of_eq (congrArg₂
+              (fun (leftChild : Σ next, TargetWitness₁ next)
+                  (rightChild : Σ next, TargetWitness₂ next) =>
+                (⟨(leftChild.1, rightChild.1),
+                  (leftChild.2, rightChild.2)⟩ :
+                  Σ next, TargetWitness₁ next.1 ×
+                    TargetWitness₂ next.2))
+              (eq_of_heq hLeft) (eq_of_heq hRight))
+
+@[simp] theorem parallel_toState
+    {S : Display.{uA₁, uB, uC₁, uD₁} P}
+    {T : Display.{uA₂, uB, uC₂, uD₂} Q}
+    {SourceState₁ : Type uS₁} {SourceState₂ : Type uS₂}
+    {TargetState₁ : Type uT₁} {TargetState₂ : Type uT₂}
+    {source₁ : Responder SourceState₁ P} {source₂ : Responder SourceState₂ Q}
+    {target₁ : Responder TargetState₁ P} {target₂ : Responder TargetState₂ Q}
+    {SourceWitness₁ : SourceState₁ → Type uI₁}
+    {SourceWitness₂ : SourceState₂ → Type uI₂}
+    {TargetWitness₁ : TargetState₁ → Type uJ₁}
+    {TargetWitness₂ : TargetState₂ → Type uJ₂}
+    {dS₁ : Display.Coalgebra (Display.responder S) source₁.out SourceWitness₁}
+    {dS₂ : Display.Coalgebra (Display.responder T) source₂.out SourceWitness₂}
+    {dT₁ : Display.Coalgebra (Display.responder S) target₁.out TargetWitness₁}
+    {dT₂ : Display.Coalgebra (Display.responder T) target₂.out TargetWitness₂}
+    (f : VerifiedPresentationHom S source₁ SourceWitness₁ dS₁ target₁ TargetWitness₁ dT₁)
+    (g : VerifiedPresentationHom T source₂ SourceWitness₂ dS₂ target₂ TargetWitness₂ dT₂)
+    (state : SourceState₁ × SourceState₂) :
+    (f.parallel g).toState state = (f.toState state.1, g.toState state.2) := rfl
+
+@[simp] theorem parallel_toWitness
+    {S : Display.{uA₁, uB, uC₁, uD₁} P}
+    {T : Display.{uA₂, uB, uC₂, uD₂} Q}
+    {SourceState₁ : Type uS₁} {SourceState₂ : Type uS₂}
+    {TargetState₁ : Type uT₁} {TargetState₂ : Type uT₂}
+    {source₁ : Responder SourceState₁ P} {source₂ : Responder SourceState₂ Q}
+    {target₁ : Responder TargetState₁ P} {target₂ : Responder TargetState₂ Q}
+    {SourceWitness₁ : SourceState₁ → Type uI₁}
+    {SourceWitness₂ : SourceState₂ → Type uI₂}
+    {TargetWitness₁ : TargetState₁ → Type uJ₁}
+    {TargetWitness₂ : TargetState₂ → Type uJ₂}
+    {dS₁ : Display.Coalgebra (Display.responder S) source₁.out SourceWitness₁}
+    {dS₂ : Display.Coalgebra (Display.responder T) source₂.out SourceWitness₂}
+    {dT₁ : Display.Coalgebra (Display.responder S) target₁.out TargetWitness₁}
+    {dT₂ : Display.Coalgebra (Display.responder T) target₂.out TargetWitness₂}
+    (f : VerifiedPresentationHom S source₁ SourceWitness₁ dS₁ target₁ TargetWitness₁ dT₁)
+    (g : VerifiedPresentationHom T source₂ SourceWitness₂ dS₂ target₂ TargetWitness₂ dT₂)
+    (state : SourceState₁ × SourceState₂)
+    (witness : SourceWitness₁ state.1 × SourceWitness₂ state.2) :
+    (f.parallel g).toWitness state witness =
+      (f.toWitness state.1 witness.1, g.toWitness state.2 witness.2) := rfl
+
+/-- Componentwise parallel preserves identity presentation homomorphisms. -/
+@[simp] theorem parallel_id
+    {S : Display.{uA₁, uB, uC₁, uD₁} P}
+    {T : Display.{uA₂, uB, uC₂, uD₂} Q}
+    {State₁ : Type uS₁} {State₂ : Type uS₂}
+    {source₁ : Responder State₁ P} {source₂ : Responder State₂ Q}
+    {Witness₁ : State₁ → Type uI₁}
+    {Witness₂ : State₂ → Type uI₂}
+    {displayed₁ : Display.Coalgebra (Display.responder S)
+      source₁.out Witness₁}
+    {displayed₂ : Display.Coalgebra (Display.responder T)
+      source₂.out Witness₂} :
+    (VerifiedPresentationHom.id (S := S) (source := source₁)
+      (SourceWitness := Witness₁) (displayedSource := displayed₁)).parallel
+      (VerifiedPresentationHom.id (S := T) (source := source₂)
+        (SourceWitness := Witness₂) (displayedSource := displayed₂)) =
+      VerifiedPresentationHom.id := by
+  apply VerifiedPresentationHom.ext
+  · rfl
+  · rfl
+
+/-- Interchange for componentwise parallel and presentation composition.
+This is the bifunctoriality law for lockstep parallel. -/
+theorem parallel_comp
+    {S : Display.{uA₁, uB, uC₁, uD₁} P}
+    {T : Display.{uA₂, uB, uC₂, uD₂} Q}
+    {SourceState₁ : Type uS₁} {SourceState₂ : Type uS₂}
+    {MiddleState₁ : Type uT₁} {MiddleState₂ : Type uT₂}
+    {FinalState₁ : Type uK₁} {FinalState₂ : Type uK₂}
+    {source₁ : Responder SourceState₁ P}
+    {source₂ : Responder SourceState₂ Q}
+    {middle₁ : Responder MiddleState₁ P}
+    {middle₂ : Responder MiddleState₂ Q}
+    {final₁ : Responder FinalState₁ P}
+    {final₂ : Responder FinalState₂ Q}
+    {SourceWitness₁ : SourceState₁ → Type uI₁}
+    {SourceWitness₂ : SourceState₂ → Type uI₂}
+    {MiddleWitness₁ : MiddleState₁ → Type uJ₁}
+    {MiddleWitness₂ : MiddleState₂ → Type uJ₂}
+    {FinalWitness₁ : FinalState₁ → Type uL₁}
+    {FinalWitness₂ : FinalState₂ → Type uL₂}
+    {displayedSource₁ : Display.Coalgebra (Display.responder S)
+      source₁.out SourceWitness₁}
+    {displayedSource₂ : Display.Coalgebra (Display.responder T)
+      source₂.out SourceWitness₂}
+    {displayedMiddle₁ : Display.Coalgebra (Display.responder S)
+      middle₁.out MiddleWitness₁}
+    {displayedMiddle₂ : Display.Coalgebra (Display.responder T)
+      middle₂.out MiddleWitness₂}
+    {displayedFinal₁ : Display.Coalgebra (Display.responder S)
+      final₁.out FinalWitness₁}
+    {displayedFinal₂ : Display.Coalgebra (Display.responder T)
+      final₂.out FinalWitness₂}
+    (first₁ : VerifiedPresentationHom S source₁ SourceWitness₁
+      displayedSource₁ middle₁ MiddleWitness₁ displayedMiddle₁)
+    (first₂ : VerifiedPresentationHom T source₂ SourceWitness₂
+      displayedSource₂ middle₂ MiddleWitness₂ displayedMiddle₂)
+    (second₁ : VerifiedPresentationHom S middle₁ MiddleWitness₁
+      displayedMiddle₁ final₁ FinalWitness₁ displayedFinal₁)
+    (second₂ : VerifiedPresentationHom T middle₂ MiddleWitness₂
+      displayedMiddle₂ final₂ FinalWitness₂ displayedFinal₂) :
+    (second₁.parallel second₂).comp (first₁.parallel first₂) =
+      (second₁.comp first₁).parallel (second₂.comp first₂) := by
+  apply VerifiedPresentationHom.ext
+  · rfl
+  · rfl
+
+end VerifiedPresentationHom
+
+end Responder
+end PFunctor

--- a/PolyFunTest/PFunctor/ParallelCoherence.lean
+++ b/PolyFunTest/PFunctor/ParallelCoherence.lean
@@ -1,0 +1,127 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+
+public import PolyFun.PFunctor.Dynamical.Responder.Parallel.Coherence
+public import PolyFun.PFunctor.Dynamical.Responder.Parallel.VerifiedPresentation
+
+/-!
+# Regression tests for parallel presentation and behavior coherence
+
+These examples observe componentwise state/witness maps and pin the symmetry,
+unit, associativity, and interchange interfaces used by later verified
+coherence.
+-/
+
+@[expose] public section
+
+namespace PFunctor.ParallelCoherenceCanary
+
+abbrev Interface : PFunctor.{0, 0} := ⟨PUnit, fun _ => Nat⟩
+
+def responder : Responder Nat Interface :=
+  Responder.mk' (fun state _ => state) (fun state _ => state + 10)
+
+abbrev contract : Display Interface where
+  position _ := String
+  direction _ _ _ := Bool
+
+def Invariant (_ : Nat) : Type := PUnit
+
+def verified :
+    Display.Coalgebra (Display.responder contract) responder.out Invariant :=
+  (Display.responderCoalgebraEquiv contract responder Invariant).symm
+    fun _ _ _ _ => ⟨false, PUnit.unit⟩
+
+def presentationId :
+    Responder.VerifiedPresentationHom contract
+      responder Invariant verified responder Invariant verified :=
+  Responder.VerifiedPresentationHom.id
+
+def toTerminal :=
+  Responder.VerifiedPresentationHom.toTerminal contract
+    responder Invariant verified
+
+def mixedParallel := toTerminal.parallel presentationId
+
+example : mixedParallel.toState (5, 7) = (responder.behavior 5, 7) :=
+  rfl
+
+example : (mixedParallel.toWitness (5, 7) (PUnit.unit, PUnit.unit)).2 =
+    PUnit.unit :=
+  rfl
+
+example :
+    (Responder.respondDisplayed contract
+      (mixedParallel.toWitness (5, 7) (PUnit.unit, PUnit.unit)).1
+      PUnit.unit "contract").1 = false :=
+  rfl
+
+example : presentationId.parallel presentationId =
+    Responder.VerifiedPresentationHom.id :=
+  Responder.VerifiedPresentationHom.parallel_id
+
+example :
+    (toTerminal.parallel presentationId).comp
+        (presentationId.parallel presentationId) =
+      (toTerminal.comp presentationId).parallel
+        (presentationId.comp presentationId) :=
+  Responder.VerifiedPresentationHom.parallel_comp _ _ _ _
+
+def leftBehavior := responder.behavior 5
+
+def rightBehavior := responder.behavior 7
+
+example :
+    Responder.mapBehavior (Lens.parallelSumComm Interface Interface)
+        (Responder.parallelBehavior rightBehavior leftBehavior) =
+      Responder.parallelBehavior leftBehavior rightBehavior :=
+  Responder.mapBehavior_parallel_comm leftBehavior rightBehavior
+
+example : (Responder.terminal (P := Interface ∥ Interface)).answer
+    (Responder.mapBehavior (Lens.parallelSumComm Interface Interface)
+      (Responder.parallelBehavior rightBehavior leftBehavior))
+    (.both PUnit.unit PUnit.unit) = (5, 7) :=
+  rfl
+
+example :
+    Responder.mapBehavior
+        (Lens.parallelSumZero Interface :
+          Lens (Interface ∥ (0 : PFunctor.{0, 0})) Interface)
+        leftBehavior =
+      Responder.parallelBehavior leftBehavior Responder.zeroBehavior :=
+  Responder.mapBehavior_parallel_zero_right leftBehavior
+
+example :
+    Responder.mapBehavior
+        (Lens.zeroParallelSum Interface :
+          Lens ((0 : PFunctor.{0, 0}) ∥ Interface) Interface)
+        leftBehavior =
+      Responder.parallelBehavior Responder.zeroBehavior leftBehavior :=
+  Responder.mapBehavior_parallel_zero_left leftBehavior
+
+example :
+    Responder.mapBehavior
+        (Lens.parallelSumAssoc Interface Interface Interface)
+        (Responder.parallelBehavior leftBehavior
+          (Responder.parallelBehavior rightBehavior leftBehavior)) =
+      Responder.parallelBehavior
+        (Responder.parallelBehavior leftBehavior rightBehavior)
+        leftBehavior :=
+  Responder.mapBehavior_parallel_assoc _ _ _
+
+example :
+    (Responder.terminal
+      (P := (Interface ∥ Interface) ∥ Interface)).answer
+      (Responder.mapBehavior
+        (Lens.parallelSumAssoc Interface Interface Interface)
+        (Responder.parallelBehavior leftBehavior
+          (Responder.parallelBehavior rightBehavior leftBehavior)))
+      (.both (.both PUnit.unit PUnit.unit) PUnit.unit) = ((5, 7), 5) :=
+  rfl
+
+end PFunctor.ParallelCoherenceCanary

--- a/docs/wiki/pfunctor.md
+++ b/docs/wiki/pfunctor.md
@@ -165,6 +165,8 @@ carrier varies.
 | [`PolyFun/PFunctor/Dynamical/Responder/Parallel/Display.lean`](../../PolyFun/PFunctor/Dynamical/Responder/Parallel/Display.lean) | Proof-relevant coproduct and parallel responder coalgebras, including branchwise obligation equations. |
 | [`PolyFun/PFunctor/Dynamical/Responder/Parallel/Behavior.lean`](../../PolyFun/PFunctor/Dynamical/Responder/Parallel/Behavior.lean) | Ordinary and verified state-free coproduct/parallel behavior, with exact answer, postcondition, and continuation equations. |
 | [`PolyFun/PFunctor/Dynamical/Responder/Parallel/Compatibility.lean`](../../PolyFun/PFunctor/Dynamical/Responder/Parallel/Compatibility.lean) | Compatibility of sum restriction, free execution, and handler reindexing with parallel responders. |
+| [`PolyFun/PFunctor/Dynamical/Responder/Parallel/VerifiedPresentation.lean`](../../PolyFun/PFunctor/Dynamical/Responder/Parallel/VerifiedPresentation.lean) | Componentwise parallel composition of verified presentation homomorphisms, with identity and interchange laws. |
+| [`PolyFun/PFunctor/Dynamical/Responder/Parallel/Coherence.lean`](../../PolyFun/PFunctor/Dynamical/Responder/Parallel/Coherence.lean) | Ordinary state-free parallel behavior coherence under symmetry, units, and associativity. |
 
 Displayed responder coalgebras preserve proof-relevant evidence over one
 responder. They are distinct from `DynSystem.SafetyRefinement`, whose policy is

--- a/docs/wiki/repo-map.md
+++ b/docs/wiki/repo-map.md
@@ -131,6 +131,11 @@ PFunctor/{Dynamical/Responder/Behavior,
   -> PFunctor/Dynamical/Responder/Parallel/Behavior
 PFunctor/{Dynamical/Responder/Parallel/Behavior, Free/Parallel}
   -> PFunctor/Dynamical/Responder/Parallel/Compatibility
+PFunctor/Dynamical/Responder/{VerifiedPresentation, Parallel/Behavior}
+  -> PFunctor/Dynamical/Responder/Parallel/VerifiedPresentation
+PFunctor/{Free/Parallel, Dynamical/Responder/Lens,
+  Dynamical/Responder/Parallel/Behavior}
+  -> PFunctor/Dynamical/Responder/Parallel/Coherence
 PFunctor/{Display/Category, PatternRunsOnMatter/Applications,
   Dynamical/Responder/Behavior} -> PFunctor/PatternRunsOnMatter/Display
 


### PR DESCRIPTION
## Motivation and stack context

This is replacement slice 6/8 for frozen PR #89. It adds componentwise verified presentation maps and the ordinary state-free structural coherence needed before proof-relevant coherence is transported in #97.

Base: `agent/aberle-g6e-responder-parallel` at exact `c273cbc6b948eca7515234f1a271c0fcffbc8875`.

## What this PR does

- Defines componentwise parallel composition of `Responder.VerifiedPresentationHom`.
- Proves exact state/witness equations, identity, and interchange with presentation composition.
- Defines the empty state-free responder behavior.
- Proves ordinary `mapBehavior` coherence for symmetry, right and left zero/unit interfaces, and associativity.
- Uses explicit responder state maps so scheduling and associator direction remain visible rather than hidden behind coinductive equality.

## Layering decision

`Parallel/Coherence.lean` is ordinary and state-free. It now imports `Free.Parallel`, `Responder.Lens`, and `Parallel.Behavior` directly; it does not depend on the proof-relevant displayed lens layer. The displayed associator is imported by its actual consumer in #97. This is the only production delta from frozen #89 in this slice.

## Deliberately not included

- No proof-relevant transport of braiding/unit/associativity; that is #97.
- No claim of arbitrary handler interchange.
- No application-level wiring theorem.

## Implementation and review findings

The sole reviewer identified the accidental displayed-layer import and weak coherence canaries. The repair moved the dependency to its true owner and added direct tests for `parallel_id`, the nontrivial terminal witness, both units, composition interchange, and an observable nested associator result `((5, 7), 5)`. Final and ancestry-only re-reviews report zero P0–P3.

## Validation

- Exact head: `31338030a73fca7953199f07401070b2e984e173`
- Exact base/merge-base: `c273cbc6b948eca7515234f1a271c0fcffbc8875`
- Full `./scripts/validate.sh --lint --test`: passed (8,872 build jobs, 211 imports, 2,033 tests, docs/lint)
- Hosted style/summary checks passed; worktree clean

## Merge order

Merge after #95 and before #97. Full chain: #91 → #92 → #93 → #94 → #95 → #96 → #97 → #98.
