### PR TITLE
feat(responder): add proof-relevant parallel coherence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,6 +189,11 @@ PFunctor/{Free/Parallel, Dynamical/Responder/Lens,
 PFunctor/{Dynamical/Responder/VerifiedPresentation,
   Dynamical/Responder/Parallel/Behavior}
   → PFunctor/Dynamical/Responder/Parallel/VerifiedPresentation
+PFunctor/{Display/Parallel/Lens,
+  Dynamical/Responder/Parallel/Coherence,
+  Dynamical/Responder/Parallel/VerifiedPresentation}
+  → PFunctor/Dynamical/Responder/Parallel/VerifiedAssociativity
+  → PFunctor/Dynamical/Responder/Parallel/VerifiedCoherence
 PFunctor/{Dynamical/Responder/Parallel/Behavior, Free/Parallel}
   → PFunctor/Dynamical/Responder/Parallel/Compatibility
 PFunctor/{Display/Category, PatternRunsOnMatter/Applications,

--- a/PolyFun.lean
+++ b/PolyFun.lean
@@ -157,6 +157,8 @@ import PolyFun.PFunctor.Dynamical.Responder.Parallel.Behavior
 import PolyFun.PFunctor.Dynamical.Responder.Parallel.Coherence
 import PolyFun.PFunctor.Dynamical.Responder.Parallel.Compatibility
 import PolyFun.PFunctor.Dynamical.Responder.Parallel.Display
+import PolyFun.PFunctor.Dynamical.Responder.Parallel.VerifiedAssociativity
+import PolyFun.PFunctor.Dynamical.Responder.Parallel.VerifiedCoherence
 import PolyFun.PFunctor.Dynamical.Responder.Parallel.VerifiedPresentation
 import PolyFun.PFunctor.Dynamical.Responder.Reindex
 import PolyFun.PFunctor.Dynamical.Responder.VerifiedPresentation

--- a/PolyFun/PFunctor/Dynamical/Responder/Parallel/VerifiedAssociativity.lean
+++ b/PolyFun/PFunctor/Dynamical/Responder/Parallel/VerifiedAssociativity.lean
@@ -1,0 +1,422 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+
+public import PolyFun.PFunctor.Display.Parallel.Lens
+public import PolyFun.PFunctor.Dynamical.Responder.Parallel.Coherence
+public import PolyFun.PFunctor.Dynamical.Responder.Parallel.VerifiedPresentation
+
+/-!
+# Associativity of verified parallel responder behavior
+
+The displayed parallel associator is realized first between explicit verified
+responder presentations, then transported to the canonical state-free API.
+The public theorem exposes only the ordinary named associativity equality.
+-/
+
+@[expose] public section
+
+universe uA₁ uA₂ uA₃ uB uC₁ uD₁ uC₂ uD₂ uC₃ uD₃ uLift
+
+namespace PFunctor
+namespace Responder
+
+variable {P : PFunctor.{uA₁, uB}} {Q : PFunctor.{uA₂, uB}}
+
+
+/-- The displayed associator is a verified presentation homomorphism between
+the two raw three-responder presentations. -/
+private def parallelAssocVerifiedPresentationHom
+    {R : PFunctor.{uA₃, uB}}
+    (S : Display.{uA₁, uB, uC₁, uD₁} P)
+    (T : Display.{uA₂, uB, uC₂, uD₂} Q)
+    (U : Display.{uA₃, uB, uC₃, uD₃} R) :
+    VerifiedPresentationHom
+      (Display.parallelSum (Display.parallelSum S T) U)
+      (Responder.parallel
+        (Responder.parallel (Responder.terminal (P := P))
+          (Responder.terminal (P := Q)))
+        (Responder.terminal (P := R)))
+      (fun state =>
+        (Display.M (Display.responder S) state.1.1 ×
+          Display.M (Display.responder T) state.1.2) ×
+        Display.M (Display.responder U) state.2)
+      (parallelCoalgebra
+        (Responder.parallel (Responder.terminal (P := P))
+          (Responder.terminal (P := Q)))
+        (Responder.terminal (P := R))
+        (fun state =>
+          Display.M (Display.responder S) state.1 ×
+            Display.M (Display.responder T) state.2)
+        (Display.M (Display.responder U))
+        (parallelCoalgebra (Responder.terminal (P := P))
+          (Responder.terminal (P := Q))
+          (Display.M (Display.responder S))
+          (Display.M (Display.responder T))
+          (Display.Coalgebra.terminal (Display.responder S))
+          (Display.Coalgebra.terminal (Display.responder T)))
+        (Display.Coalgebra.terminal (Display.responder U)))
+      (Responder.reindex
+        (PFunctor.Handler.ofLens (PFunctor.Lens.parallelSumAssoc P Q R))
+        (Responder.parallel (Responder.terminal (P := P))
+          (Responder.parallel (Responder.terminal (P := Q))
+            (Responder.terminal (P := R)))))
+      (fun state =>
+        Display.M (Display.responder S) state.1 ×
+          (Display.M (Display.responder T) state.2.1 ×
+            Display.M (Display.responder U) state.2.2))
+      (Responder.reindexCoalgebra
+        (Display.parallelSum (Display.parallelSum S T) U)
+        (Display.parallelSum S (Display.parallelSum T U))
+        (PFunctor.Handler.ofLens (PFunctor.Lens.parallelSumAssoc P Q R))
+        (Display.Lens.parallelSumAssoc S T U).toHandler
+        (Responder.parallel (Responder.terminal (P := P))
+          (Responder.parallel (Responder.terminal (P := Q))
+            (Responder.terminal (P := R))))
+        (parallelCoalgebra (Responder.terminal (P := P))
+          (Responder.parallel (Responder.terminal (P := Q))
+            (Responder.terminal (P := R)))
+          (Display.M (Display.responder S))
+          (fun state =>
+            Display.M (Display.responder T) state.1 ×
+              Display.M (Display.responder U) state.2)
+          (Display.Coalgebra.terminal (Display.responder S))
+          (parallelCoalgebra (Responder.terminal (P := Q))
+            (Responder.terminal (P := R))
+            (Display.M (Display.responder T))
+            (Display.M (Display.responder U))
+            (Display.Coalgebra.terminal (Display.responder T))
+            (Display.Coalgebra.terminal (Display.responder U))))) where
+  toState state := (state.1.1, (state.1.2, state.2))
+  toWitness _ witness := (witness.1.1, (witness.1.2, witness.2))
+  map_step := by
+    intro state witness
+    rcases state with ⟨⟨left, middle⟩, right⟩
+    rcases witness with ⟨⟨displayedLeft, displayedMiddle⟩,
+      displayedRight⟩
+    have hBase := behavior_eq_of_responderMap
+      (Responder.reindex
+        (PFunctor.Handler.ofLens (PFunctor.Lens.parallelSumAssoc P Q R))
+        (Responder.parallel (Responder.terminal (P := P))
+          (Responder.parallel (Responder.terminal (P := Q))
+            (Responder.terminal (P := R)))))
+      (Responder.parallel
+        (Responder.parallel (Responder.terminal (P := P))
+          (Responder.terminal (P := Q)))
+        (Responder.terminal (P := R)))
+      (fun state => (state.1.1, (state.1.2, state.2)))
+      (by
+        intro state operation
+        rw [Responder.answer_reindex, runFree_ofLens]
+        cases operation with
+        | left operation => cases operation <;> rfl
+        | right operation => rfl
+        | both operation rightOperation => cases operation <;> rfl)
+      (by
+        intro state operation
+        rw [Responder.next_reindex, runFree_ofLens]
+        cases operation with
+        | left operation => cases operation <;> rfl
+        | right operation => rfl
+        | both operation rightOperation => cases operation <;> rfl)
+      ((left, middle), right)
+    dsimp [verifiedTotalStep, VerifiedPresentationHom.totalMap]
+    apply Sigma.ext_iff.mpr
+    constructor
+    · apply Sigma.ext_iff.mpr
+      constructor
+      · exact hBase
+      · apply Function.hfunext rfl
+        intro operation operation' hOperation
+        cases hOperation
+        apply Function.hfunext rfl
+        intro contract contract' hContract
+        cases hContract
+        cases operation with
+        | left operation => cases operation <;> rfl
+        | right operation => rfl
+        | both operation rightOperation => cases operation <;> rfl
+    · apply Function.hfunext
+      · apply congrArg
+          (Display.mStep (Display.responder
+            (Display.parallelSum (Display.parallelSum S T) U))).sigmaPFunctor.B
+        apply Sigma.ext_iff.mpr
+        constructor
+        · exact hBase
+        · apply Function.hfunext rfl
+          intro operation operation' hOperation
+          cases hOperation
+          apply Function.hfunext rfl
+          intro contract contract' hContract
+          cases hContract
+          cases operation with
+          | left operation => cases operation <;> rfl
+          | right operation => rfl
+          | both operation rightOperation => cases operation <;> rfl
+      · intro direction direction' hDirection
+        cases hDirection
+        rcases direction with ⟨⟨operation, trivialDirection⟩, contract⟩
+        cases trivialDirection
+        cases operation with
+        | left operation => cases operation <;> rfl
+        | right operation => rfl
+        | both operation rightOperation => cases operation <;> rfl
+
+/-- Present a raw right-associated parallel responder by terminalizing its
+inner parallel component. -/
+private def parallelAssocRightPresentationHom
+    {R : PFunctor.{uA₃, uB}}
+    (S : Display.{uA₁, uB, uC₁, uD₁} P)
+    (T : Display.{uA₂, uB, uC₂, uD₂} Q)
+    (U : Display.{uA₃, uB, uC₃, uD₃} R) :=
+  VerifiedPresentationHom.parallel
+    (VerifiedPresentationHom.id (S := S)
+      (source := Responder.terminal (P := P))
+      (SourceWitness := Display.M (Display.responder S))
+      (displayedSource := Display.Coalgebra.terminal (Display.responder S)))
+    (VerifiedPresentationHom.toTerminal (Display.parallelSum T U)
+      (Responder.parallel (Responder.terminal (P := Q))
+        (Responder.terminal (P := R)))
+      (fun state => Display.M (Display.responder T) state.1 ×
+        Display.M (Display.responder U) state.2)
+      (parallelCoalgebra (Responder.terminal (P := Q))
+        (Responder.terminal (P := R))
+        (Display.M (Display.responder T))
+        (Display.M (Display.responder U))
+        (Display.Coalgebra.terminal (Display.responder T))
+        (Display.Coalgebra.terminal (Display.responder U))))
+
+/-- Present a raw left-associated parallel responder by terminalizing its
+inner parallel component. -/
+private def parallelAssocLeftPresentationHom
+    {R : PFunctor.{uA₃, uB}}
+    (S : Display.{uA₁, uB, uC₁, uD₁} P)
+    (T : Display.{uA₂, uB, uC₂, uD₂} Q)
+    (U : Display.{uA₃, uB, uC₃, uD₃} R) :=
+  VerifiedPresentationHom.parallel
+    (VerifiedPresentationHom.toTerminal (Display.parallelSum S T)
+      (Responder.parallel (Responder.terminal (P := P))
+        (Responder.terminal (P := Q)))
+      (fun state => Display.M (Display.responder S) state.1 ×
+        Display.M (Display.responder T) state.2)
+      (parallelCoalgebra (Responder.terminal (P := P))
+        (Responder.terminal (P := Q))
+        (Display.M (Display.responder S))
+        (Display.M (Display.responder T))
+        (Display.Coalgebra.terminal (Display.responder S))
+        (Display.Coalgebra.terminal (Display.responder T))))
+    (VerifiedPresentationHom.id (S := U)
+      (source := Responder.terminal (P := R))
+      (SourceWitness := Display.M (Display.responder U))
+      (displayedSource := Display.Coalgebra.terminal (Display.responder U)))
+
+/-- Verified parallel behavior associates after the single canonical
+transport along the ordinary associator law. -/
+theorem mapVerifiedBehavior_parallel_assoc
+    {R : PFunctor.{uA₃, uB}}
+    (S : Display.{uA₁, uB, uC₁, uD₁} P)
+    (T : Display.{uA₂, uB, uC₂, uD₂} Q)
+    (U : Display.{uA₃, uB, uC₃, uD₃} R)
+    (left : PFunctor.M (P ⊸ X.{uA₁, uB}))
+    (displayedLeft : Display.M (Display.responder S) left)
+    (middle : PFunctor.M (Q ⊸ X.{uA₂, uB}))
+    (displayedMiddle : Display.M (Display.responder T) middle)
+    (right : PFunctor.M (R ⊸ X.{uA₃, uB}))
+    (displayedRight : Display.M (Display.responder U) right) :
+    Display.M.transport (mapBehavior_parallel_assoc left middle right)
+        (mapVerifiedBehavior (Display.Lens.parallelSumAssoc S T U)
+          (parallelBehavior left (parallelBehavior middle right))
+          (parallelVerifiedBehavior S (Display.parallelSum T U)
+            left displayedLeft (parallelBehavior middle right)
+            (parallelVerifiedBehavior T U middle displayedMiddle
+              right displayedRight))) =
+      parallelVerifiedBehavior (Display.parallelSum S T) U
+        (parallelBehavior left middle)
+        (parallelVerifiedBehavior S T left displayedLeft middle displayedMiddle)
+        right displayedRight := by
+  let pResponder := Responder.terminal (P := P)
+  let qResponder := Responder.terminal (P := Q)
+  let rResponder := Responder.terminal (P := R)
+  let rawRight := Responder.parallel pResponder
+    (Responder.parallel qResponder rResponder)
+  let rawLeft := Responder.parallel
+    (Responder.parallel pResponder qResponder) rResponder
+  let rawRightWitness := fun state :
+      PFunctor.M (P ⊸ X.{uA₁, uB}) ×
+        (PFunctor.M (Q ⊸ X.{uA₂, uB}) ×
+          PFunctor.M (R ⊸ X.{uA₃, uB})) =>
+    Display.M (Display.responder S) state.1 ×
+      (Display.M (Display.responder T) state.2.1 ×
+        Display.M (Display.responder U) state.2.2)
+  let rawLeftWitness := fun state :
+      (PFunctor.M (P ⊸ X.{uA₁, uB}) ×
+        PFunctor.M (Q ⊸ X.{uA₂, uB})) ×
+          PFunctor.M (R ⊸ X.{uA₃, uB}) =>
+    (Display.M (Display.responder S) state.1.1 ×
+      Display.M (Display.responder T) state.1.2) ×
+        Display.M (Display.responder U) state.2
+  let displayedRawRight := parallelCoalgebra pResponder
+    (Responder.parallel qResponder rResponder)
+    (Display.M (Display.responder S))
+    (fun state => Display.M (Display.responder T) state.1 ×
+      Display.M (Display.responder U) state.2)
+    (Display.Coalgebra.terminal (Display.responder S))
+    (parallelCoalgebra qResponder rResponder
+      (Display.M (Display.responder T))
+      (Display.M (Display.responder U))
+      (Display.Coalgebra.terminal (Display.responder T))
+      (Display.Coalgebra.terminal (Display.responder U)))
+  let displayedRawLeft := parallelCoalgebra
+    (Responder.parallel pResponder qResponder) rResponder
+    (fun state => Display.M (Display.responder S) state.1 ×
+      Display.M (Display.responder T) state.2)
+    (Display.M (Display.responder U))
+    (parallelCoalgebra pResponder qResponder
+      (Display.M (Display.responder S))
+      (Display.M (Display.responder T))
+      (Display.Coalgebra.terminal (Display.responder S))
+      (Display.Coalgebra.terminal (Display.responder T)))
+    (Display.Coalgebra.terminal (Display.responder U))
+  let sourceDisplayed := parallelVerifiedBehavior S
+    (Display.parallelSum T U) left displayedLeft
+    (parallelBehavior middle right)
+    (parallelVerifiedBehavior T U middle displayedMiddle right displayedRight)
+  let rawRightDisplayed := verifiedBehavior
+    (Display.parallelSum S (Display.parallelSum T U))
+    rawRight rawRightWitness displayedRawRight
+    (left, (middle, right))
+    (displayedLeft, (displayedMiddle, displayedRight))
+  let rawLeftDisplayed := verifiedBehavior
+    (Display.parallelSum (Display.parallelSum S T) U)
+    rawLeft rawLeftWitness displayedRawLeft
+    ((left, middle), right)
+    ((displayedLeft, displayedMiddle), displayedRight)
+  let publicLeftDisplayed := parallelVerifiedBehavior
+    (Display.parallelSum S T) U (parallelBehavior left middle)
+    (parallelVerifiedBehavior S T left displayedLeft middle displayedMiddle)
+    right displayedRight
+  let rightEq :=
+    (parallelAssocRightPresentationHom S T U).behavior_eq
+      (left, (middle, right))
+      (displayedLeft, (displayedMiddle, displayedRight))
+  have hRight : Display.M.transport rightEq sourceDisplayed =
+      rawRightDisplayed := by
+    have h := (parallelAssocRightPresentationHom S T U).verifiedBehavior_naturality
+        (left, (middle, right))
+        (displayedLeft, (displayedMiddle, displayedRight))
+    change Display.M.transport _ sourceDisplayed = rawRightDisplayed at h
+    exact (Display.M.transport_proof_irrel rightEq _ sourceDisplayed).trans h
+  let mappedPublic := mapVerifiedBehavior
+    (Display.Lens.parallelSumAssoc S T U) _ sourceDisplayed
+  let mappedRawInput := mapVerifiedBehavior
+    (Display.Lens.parallelSumAssoc S T U) _ rawRightDisplayed
+  let mappedRightEq := congrArg
+    (mapBehavior (PFunctor.Lens.parallelSumAssoc P Q R)) rightEq
+  have hMappedRight : Display.M.transport mappedRightEq mappedPublic =
+      mappedRawInput := by
+    calc
+      _ = mapVerifiedBehavior (Display.Lens.parallelSumAssoc S T U) _
+          (Display.M.transport rightEq sourceDisplayed) :=
+        mapVerifiedBehavior_transport
+          (Display.Lens.parallelSumAssoc S T U) rightEq sourceDisplayed
+      _ = mappedRawInput := congrArg
+        (mapVerifiedBehavior (Display.Lens.parallelSumAssoc S T U) _)
+        hRight
+  let handler := PFunctor.Handler.ofLens
+    (PFunctor.Lens.parallelSumAssoc P Q R)
+  let presentationEq := reindexBehavior_behavior handler rawRight
+    (left, (middle, right))
+  let rawMapped := verifiedBehavior
+    (Display.parallelSum (Display.parallelSum S T) U)
+    (Responder.reindex handler rawRight) rawRightWitness
+    (Responder.reindexCoalgebra
+      (Display.parallelSum (Display.parallelSum S T) U)
+      (Display.parallelSum S (Display.parallelSum T U)) handler
+      (Display.Lens.parallelSumAssoc S T U).toHandler
+      rawRight displayedRawRight)
+    (left, (middle, right))
+    (displayedLeft, (displayedMiddle, displayedRight))
+  have hPresentation : Display.M.transport presentationEq mappedRawInput =
+      rawMapped := by
+    exact reindexVerifiedBehavior_verifiedBehavior handler
+      (Display.Lens.parallelSumAssoc S T U).toHandler rawRight
+      rawRightWitness displayedRawRight _ _
+  let rawEq := (parallelAssocVerifiedPresentationHom S T U).behavior_eq
+    ((left, middle), right)
+    ((displayedLeft, displayedMiddle), displayedRight)
+  have hRaw : Display.M.transport rawEq rawMapped = rawLeftDisplayed := by
+    have h := (parallelAssocVerifiedPresentationHom S T U).verifiedBehavior_naturality
+        ((left, middle), right)
+        ((displayedLeft, displayedMiddle), displayedRight)
+    change Display.M.transport _ rawMapped = rawLeftDisplayed at h
+    exact (Display.M.transport_proof_irrel rawEq _ rawMapped).trans h
+  let leftEq :=
+    (parallelAssocLeftPresentationHom S T U).behavior_eq
+      ((left, middle), right)
+      ((displayedLeft, displayedMiddle), displayedRight)
+  have hLeft : Display.M.transport leftEq publicLeftDisplayed =
+      rawLeftDisplayed := by
+    have h := (parallelAssocLeftPresentationHom S T U).verifiedBehavior_naturality
+        ((left, middle), right)
+        ((displayedLeft, displayedMiddle), displayedRight)
+    change Display.M.transport _ publicLeftDisplayed = rawLeftDisplayed at h
+    exact (Display.M.transport_proof_irrel leftEq _ publicLeftDisplayed).trans h
+  have hRawToPublic : Display.M.transport leftEq.symm rawLeftDisplayed =
+      publicLeftDisplayed := by
+    calc
+      _ = Display.M.transport leftEq.symm
+          (Display.M.transport leftEq publicLeftDisplayed) :=
+        congrArg (Display.M.transport leftEq.symm) hLeft.symm
+      _ = _ := Display.M.transport_symm_transport leftEq publicLeftDisplayed
+  let chainEq := (((mappedRightEq.trans presentationEq).trans rawEq).trans
+    leftEq.symm)
+  have hChain : Display.M.transport chainEq mappedPublic =
+      publicLeftDisplayed := by
+    calc
+      _ = Display.M.transport leftEq.symm
+          (Display.M.transport ((mappedRightEq.trans presentationEq).trans rawEq)
+            mappedPublic) :=
+        (Display.M.transport_trans
+          ((mappedRightEq.trans presentationEq).trans rawEq)
+          leftEq.symm mappedPublic).symm
+      _ = Display.M.transport leftEq.symm
+          (Display.M.transport rawEq
+            (Display.M.transport (mappedRightEq.trans presentationEq)
+              mappedPublic)) :=
+        congrArg (Display.M.transport leftEq.symm)
+          (Display.M.transport_trans (mappedRightEq.trans presentationEq)
+            rawEq mappedPublic).symm
+      _ = Display.M.transport leftEq.symm
+          (Display.M.transport rawEq
+            (Display.M.transport presentationEq
+              (Display.M.transport mappedRightEq mappedPublic))) :=
+        congrArg (fun displayed =>
+          Display.M.transport leftEq.symm
+            (Display.M.transport rawEq displayed))
+          (Display.M.transport_trans mappedRightEq presentationEq
+            mappedPublic).symm
+      _ = Display.M.transport leftEq.symm
+          (Display.M.transport rawEq
+            (Display.M.transport presentationEq mappedRawInput)) := by
+        exact congrArg (fun displayed =>
+          Display.M.transport leftEq.symm
+            (Display.M.transport rawEq
+              (Display.M.transport presentationEq displayed))) hMappedRight
+      _ = Display.M.transport leftEq.symm
+          (Display.M.transport rawEq rawMapped) := by
+        exact congrArg (fun displayed =>
+          Display.M.transport leftEq.symm
+            (Display.M.transport rawEq displayed)) hPresentation
+      _ = Display.M.transport leftEq.symm rawLeftDisplayed := by
+        exact congrArg (Display.M.transport leftEq.symm) hRaw
+      _ = publicLeftDisplayed := hRawToPublic
+  exact (Display.M.transport_proof_irrel
+    (mapBehavior_parallel_assoc left middle right) chainEq mappedPublic).trans
+    hChain
+
+end Responder
+end PFunctor

--- a/PolyFun/PFunctor/Dynamical/Responder/Parallel/VerifiedCoherence.lean
+++ b/PolyFun/PFunctor/Dynamical/Responder/Parallel/VerifiedCoherence.lean
@@ -1,0 +1,1137 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+
+public import PolyFun.PFunctor.Dynamical.Responder.Parallel.VerifiedAssociativity
+
+/-!
+# Proof-relevant coherence of verified parallel responder behavior
+
+Verified presentation homomorphisms lift the ordinary parallel unit, symmetry,
+and associativity laws to `Type`-valued displayed responder evidence. Internal
+raw responder presentations are reconciled with the canonical state-free API;
+only the canonical zero evidence and final transported laws are public.
+-/
+
+@[expose] public section
+
+universe uA₁ uA₂ uA₃ uB uC₁ uD₁ uC₂ uD₂ uC₃ uD₃ uLift
+
+namespace PFunctor
+namespace Responder
+
+variable {P : PFunctor.{uA₁, uB}} {Q : PFunctor.{uA₂, uB}}
+
+
+/-- The displayed braiding is a verified presentation homomorphism between
+the two raw parallel responder presentations. -/
+private def parallelCommVerifiedPresentationHom
+    (S : Display.{uA₁, uB, uC₁, uD₁} P)
+    (T : Display.{uA₂, uB, uC₂, uD₂} Q) :
+    VerifiedPresentationHom (Display.parallelSum S T)
+      (Responder.parallel (Responder.terminal (P := P))
+        (Responder.terminal (P := Q)))
+      (fun state => Display.M (Display.responder S) state.1 ×
+        Display.M (Display.responder T) state.2)
+      (parallelCoalgebra (Responder.terminal (P := P))
+        (Responder.terminal (P := Q))
+        (Display.M (Display.responder S))
+        (Display.M (Display.responder T))
+        (Display.Coalgebra.terminal (Display.responder S))
+        (Display.Coalgebra.terminal (Display.responder T)))
+      (Responder.reindex
+        (PFunctor.Handler.ofLens (PFunctor.Lens.parallelSumComm P Q))
+        (Responder.parallel (Responder.terminal (P := Q))
+          (Responder.terminal (P := P))))
+      (fun state => Display.M (Display.responder T) state.1 ×
+        Display.M (Display.responder S) state.2)
+      (Responder.reindexCoalgebra (Display.parallelSum S T)
+        (Display.parallelSum T S)
+        (PFunctor.Handler.ofLens (PFunctor.Lens.parallelSumComm P Q))
+        (Display.Lens.parallelSumComm S T).toHandler
+        (Responder.parallel (Responder.terminal (P := Q))
+          (Responder.terminal (P := P)))
+        (parallelCoalgebra (Responder.terminal (P := Q))
+          (Responder.terminal (P := P))
+          (Display.M (Display.responder T))
+          (Display.M (Display.responder S))
+          (Display.Coalgebra.terminal (Display.responder T))
+          (Display.Coalgebra.terminal (Display.responder S)))) where
+  toState state := state.swap
+  toWitness _ witness := witness.swap
+  map_step := by
+    intro state witness
+    rcases state with ⟨left, right⟩
+    rcases witness with ⟨displayedLeft, displayedRight⟩
+    have hBase := behavior_eq_of_responderMap
+      (Responder.reindex
+        (PFunctor.Handler.ofLens (PFunctor.Lens.parallelSumComm P Q))
+        (Responder.parallel (Responder.terminal (P := Q))
+          (Responder.terminal (P := P))))
+      (Responder.parallel (Responder.terminal (P := P))
+        (Responder.terminal (P := Q)))
+      Prod.swap
+      (by
+        intro state operation
+        rw [Responder.answer_reindex, runFree_ofLens]
+        cases operation <;> rfl)
+      (by
+        intro state operation
+        rw [Responder.next_reindex, runFree_ofLens]
+        cases operation <;> rfl)
+      (left, right)
+    dsimp [verifiedTotalStep, VerifiedPresentationHom.totalMap]
+    apply Sigma.ext_iff.mpr
+    constructor
+    · apply Sigma.ext_iff.mpr
+      constructor
+      · exact hBase
+      · apply Function.hfunext rfl
+        intro operation operation' hOperation
+        cases hOperation
+        apply Function.hfunext rfl
+        intro contract contract' hContract
+        cases hContract
+        cases operation <;> rfl
+    · apply Function.hfunext
+      · apply congrArg
+          (Display.mStep
+            (Display.responder (Display.parallelSum S T))).sigmaPFunctor.B
+        apply Sigma.ext_iff.mpr
+        constructor
+        · exact hBase
+        · apply Function.hfunext rfl
+          intro operation operation' hOperation
+          cases hOperation
+          apply Function.hfunext rfl
+          intro contract contract' hContract
+          cases hContract
+          cases operation <;> rfl
+      · intro direction direction' hDirection
+        cases hDirection
+        rcases direction with ⟨⟨operation, trivialDirection⟩, contract⟩
+        cases trivialDirection
+        cases operation <;> rfl
+
+private theorem verifiedBehavior_parallel_comm_presented
+    (S : Display.{uA₁, uB, uC₁, uD₁} P)
+    (T : Display.{uA₂, uB, uC₂, uD₂} Q)
+    (left : PFunctor.M (P ⊸ X.{uA₁, uB}))
+    (displayedLeft : Display.M (Display.responder S) left)
+    (right : PFunctor.M (Q ⊸ X.{uA₂, uB}))
+    (displayedRight : Display.M (Display.responder T) right) :
+    Display.M.transport
+        ((parallelCommVerifiedPresentationHom S T).behavior_eq
+          (left, right) (displayedLeft, displayedRight))
+        (verifiedBehavior (Display.parallelSum S T)
+          (Responder.reindex
+            (PFunctor.Handler.ofLens (PFunctor.Lens.parallelSumComm P Q))
+            (Responder.parallel (Responder.terminal (P := Q))
+              (Responder.terminal (P := P))))
+          (fun state => Display.M (Display.responder T) state.1 ×
+            Display.M (Display.responder S) state.2)
+          (Responder.reindexCoalgebra (Display.parallelSum S T)
+            (Display.parallelSum T S)
+            (PFunctor.Handler.ofLens (PFunctor.Lens.parallelSumComm P Q))
+            (Display.Lens.parallelSumComm S T).toHandler
+            (Responder.parallel (Responder.terminal (P := Q))
+              (Responder.terminal (P := P)))
+            (parallelCoalgebra (Responder.terminal (P := Q))
+              (Responder.terminal (P := P))
+              (Display.M (Display.responder T))
+              (Display.M (Display.responder S))
+              (Display.Coalgebra.terminal (Display.responder T))
+              (Display.Coalgebra.terminal (Display.responder S))))
+          (right, left) (displayedRight, displayedLeft)) =
+      parallelVerifiedBehavior S T left displayedLeft right displayedRight := by
+  exact (parallelCommVerifiedPresentationHom S T).verifiedBehavior_naturality
+    (left, right) (displayedLeft, displayedRight)
+
+
+/-- The unique proof-relevant coalgebra over the empty responder. -/
+def zeroDisplayedCoalgebra :
+    Display.Coalgebra
+      (Display.responder (Display.zero :
+        Display (0 : PFunctor.{uA₁, uB})))
+      (Responder.zero : Responder PUnit.{1}
+        (0 : PFunctor.{uA₁, uB})).out
+      (fun _ => PUnit.{1}) :=
+  (Display.responderCoalgebraEquiv
+    (Display.zero : Display (0 : PFunctor.{uA₁, uB}))
+    (Responder.zero : Responder PUnit.{1}
+      (0 : PFunctor.{uA₁, uB}))
+    (fun _ => PUnit.{1})).symm
+    fun _ _ query => PEmpty.elim query
+
+/-- Canonical verified behavior of the empty interface. -/
+def zeroVerifiedBehavior :
+    Display.M
+      (Display.responder (Display.zero :
+        Display (0 : PFunctor.{uA₁, uB})))
+      ((Responder.zero : Responder PUnit.{1}
+        (0 : PFunctor.{uA₁, uB})).behavior PUnit.unit) :=
+  verifiedBehavior
+    (Display.zero : Display (0 : PFunctor.{uA₁, uB}))
+    (Responder.zero : Responder PUnit.{1}
+      (0 : PFunctor.{uA₁, uB}))
+    (fun _ => PUnit.{1}) zeroDisplayedCoalgebra PUnit.unit PUnit.unit
+
+/-- The displayed right unitor is a verified presentation homomorphism
+between raw responder presentations. -/
+private def parallelZeroRightVerifiedPresentationHom
+    (S : Display.{uA₁, uB, uC₁, uD₁} P) :
+    VerifiedPresentationHom
+      (Display.parallelSum S
+        (Display.zero : Display (0 : PFunctor.{uA₂, uB})))
+      (Responder.parallel (Responder.terminal (P := P))
+        (Responder.zero : Responder PUnit.{1}
+          (0 : PFunctor.{uA₂, uB})))
+      (fun state => Display.M (Display.responder S) state.1 × PUnit)
+      (parallelCoalgebra (Responder.terminal (P := P))
+        (Responder.zero : Responder PUnit.{1}
+          (0 : PFunctor.{uA₂, uB}))
+        (Display.M (Display.responder S)) (fun _ => PUnit)
+        (Display.Coalgebra.terminal (Display.responder S))
+        zeroDisplayedCoalgebra)
+      (Responder.reindex
+        (PFunctor.Handler.ofLens
+          (PFunctor.Lens.parallelSumZero P :
+            PFunctor.Lens (P ∥ (0 : PFunctor.{uA₂, uB})) P))
+        (Responder.terminal (P := P)))
+      (Display.M (Display.responder S))
+      (Responder.reindexCoalgebra
+        (Display.parallelSum S
+          (Display.zero : Display (0 : PFunctor.{uA₂, uB}))) S
+        (PFunctor.Handler.ofLens
+          (PFunctor.Lens.parallelSumZero P :
+            PFunctor.Lens (P ∥ (0 : PFunctor.{uA₂, uB})) P))
+        (Display.Lens.parallelSumZero S).toHandler
+        (Responder.terminal (P := P))
+        (Display.Coalgebra.terminal (Display.responder S))) where
+  toState state := state.1
+  toWitness _ witness := witness.1
+  map_step := by
+    intro state witness
+    rcases state with ⟨left, emptyState⟩
+    rcases emptyState with ⟨⟩
+    rcases witness with ⟨displayedLeft, emptyWitness⟩
+    rcases emptyWitness with ⟨⟩
+    have hBase := behavior_eq_of_responderMap
+      (Responder.reindex
+        (PFunctor.Handler.ofLens
+          (PFunctor.Lens.parallelSumZero P :
+            PFunctor.Lens (P ∥ (0 : PFunctor.{uA₂, uB})) P))
+        (Responder.terminal (P := P)))
+      (Responder.parallel (Responder.terminal (P := P))
+        (Responder.zero : Responder PUnit.{1}
+          (0 : PFunctor.{uA₂, uB})))
+      Prod.fst
+      (by
+        intro state operation
+        rw [Responder.answer_reindex, runFree_ofLens]
+        cases operation with
+        | left operation => rfl
+        | right impossible => exact PEmpty.elim impossible
+        | both operation impossible => exact PEmpty.elim impossible)
+      (by
+        intro state operation
+        rw [Responder.next_reindex, runFree_ofLens]
+        cases operation with
+        | left operation => rfl
+        | right impossible => exact PEmpty.elim impossible
+        | both operation impossible => exact PEmpty.elim impossible)
+      (left, PUnit.unit)
+    dsimp [verifiedTotalStep, VerifiedPresentationHom.totalMap]
+    apply Sigma.ext_iff.mpr
+    constructor
+    · apply Sigma.ext_iff.mpr
+      constructor
+      · exact hBase
+      · apply Function.hfunext rfl
+        intro operation operation' hOperation
+        cases hOperation
+        apply Function.hfunext rfl
+        intro contract contract' hContract
+        cases hContract
+        cases operation with
+        | left operation => rfl
+        | right impossible => exact PEmpty.elim impossible
+        | both operation impossible => exact PEmpty.elim impossible
+    · apply Function.hfunext
+      · apply congrArg
+          (Display.mStep (Display.responder
+            (Display.parallelSum S
+              (Display.zero : Display
+                (0 : PFunctor.{uA₂, uB}))))).sigmaPFunctor.B
+        apply Sigma.ext_iff.mpr
+        constructor
+        · exact hBase
+        · apply Function.hfunext rfl
+          intro operation operation' hOperation
+          cases hOperation
+          apply Function.hfunext rfl
+          intro contract contract' hContract
+          cases hContract
+          cases operation with
+          | left operation => rfl
+          | right impossible => exact PEmpty.elim impossible
+          | both operation impossible => exact PEmpty.elim impossible
+      · intro direction direction' hDirection
+        cases hDirection
+        rcases direction with ⟨⟨operation, trivialDirection⟩, contract⟩
+        cases trivialDirection
+        cases operation with
+        | left operation => rfl
+        | right impossible => exact PEmpty.elim impossible
+        | both operation impossible => exact PEmpty.elim impossible
+
+private theorem verifiedBehavior_parallel_zero_right_presented
+    (S : Display.{uA₁, uB, uC₁, uD₁} P)
+    (left : PFunctor.M (P ⊸ X.{uA₁, uB}))
+    (displayedLeft : Display.M (Display.responder S) left) :
+    Display.M.transport
+        ((parallelZeroRightVerifiedPresentationHom S).behavior_eq
+          (left, PUnit.unit) (displayedLeft, PUnit.unit))
+        (verifiedBehavior
+          (Display.parallelSum S
+            (Display.zero : Display (0 : PFunctor.{uA₂, uB})))
+          (Responder.reindex
+            (PFunctor.Handler.ofLens
+              (PFunctor.Lens.parallelSumZero P :
+                PFunctor.Lens (P ∥ (0 : PFunctor.{uA₂, uB})) P))
+            (Responder.terminal (P := P)))
+          (Display.M (Display.responder S))
+          (Responder.reindexCoalgebra
+            (Display.parallelSum S
+              (Display.zero : Display (0 : PFunctor.{uA₂, uB}))) S
+            (PFunctor.Handler.ofLens
+              (PFunctor.Lens.parallelSumZero P :
+                PFunctor.Lens (P ∥ (0 : PFunctor.{uA₂, uB})) P))
+            (Display.Lens.parallelSumZero S).toHandler
+            (Responder.terminal (P := P))
+            (Display.Coalgebra.terminal (Display.responder S)))
+          left displayedLeft) =
+      verifiedBehavior
+        (Display.parallelSum S
+          (Display.zero : Display (0 : PFunctor.{uA₂, uB})))
+        (Responder.parallel (Responder.terminal (P := P))
+          (Responder.zero : Responder PUnit.{1}
+            (0 : PFunctor.{uA₂, uB})))
+        (fun state => Display.M (Display.responder S) state.1 × PUnit)
+        (parallelCoalgebra (Responder.terminal (P := P))
+          (Responder.zero : Responder PUnit.{1}
+            (0 : PFunctor.{uA₂, uB}))
+          (Display.M (Display.responder S)) (fun _ => PUnit)
+          (Display.Coalgebra.terminal (Display.responder S))
+          zeroDisplayedCoalgebra)
+        (left, PUnit.unit) (displayedLeft, PUnit.unit) := by
+  exact (parallelZeroRightVerifiedPresentationHom S).verifiedBehavior_naturality
+    (left, PUnit.unit) (displayedLeft, PUnit.unit)
+
+/-- Replacing the operational presentation of the empty responder by its
+terminal state-free presentation preserves the complete verified parallel
+step.  This is the second presentation map needed by the public right-unit
+law: `parallelVerifiedBehavior` uses terminal presentations on both sides,
+whereas `parallelZeroRightVerifiedPresentationHom` deliberately exposes the raw
+empty responder. -/
+private def parallelZeroRightPresentationHom
+    (S : Display.{uA₁, uB, uC₁, uD₁} P) :
+    VerifiedPresentationHom
+      (Display.parallelSum S
+        (Display.zero : Display (0 : PFunctor.{uA₂, uB})))
+      (Responder.parallel (Responder.terminal (P := P))
+        (Responder.zero : Responder PUnit.{1}
+          (0 : PFunctor.{uA₂, uB})))
+      (fun state => Display.M (Display.responder S) state.1 × PUnit)
+      (parallelCoalgebra (Responder.terminal (P := P))
+        (Responder.zero : Responder PUnit.{1}
+          (0 : PFunctor.{uA₂, uB}))
+        (Display.M (Display.responder S)) (fun _ => PUnit)
+        (Display.Coalgebra.terminal (Display.responder S))
+        zeroDisplayedCoalgebra)
+      (Responder.parallel (Responder.terminal (P := P))
+        (Responder.terminal (P := (0 : PFunctor.{uA₂, uB}))))
+      (fun state => Display.M (Display.responder S) state.1 ×
+        Display.M
+          (Display.responder
+            (Display.zero : Display (0 : PFunctor.{uA₂, uB})))
+          state.2)
+      (parallelCoalgebra (Responder.terminal (P := P))
+        (Responder.terminal (P := (0 : PFunctor.{uA₂, uB})))
+        (Display.M (Display.responder S))
+        (Display.M
+          (Display.responder
+            (Display.zero : Display (0 : PFunctor.{uA₂, uB}))))
+        (Display.Coalgebra.terminal (Display.responder S))
+        (Display.Coalgebra.terminal
+          (Display.responder
+            (Display.zero : Display (0 : PFunctor.{uA₂, uB}))))) where
+  toState state := (state.1,
+    (Responder.zero : Responder PUnit.{1}
+      (0 : PFunctor.{uA₂, uB})).behavior state.2)
+  toWitness _ witness := (witness.1, zeroVerifiedBehavior)
+  map_step := by
+    intro state witness
+    rcases state with ⟨left, emptyState⟩
+    rcases emptyState with ⟨⟩
+    rcases witness with ⟨displayedLeft, emptyWitness⟩
+    rcases emptyWitness with ⟨⟩
+    have hBase := behavior_eq_of_responderMap
+      (Responder.parallel (Responder.terminal (P := P))
+        (Responder.terminal (P := (0 : PFunctor.{uA₂, uB}))))
+      (Responder.parallel (Responder.terminal (P := P))
+        (Responder.zero : Responder PUnit.{1}
+          (0 : PFunctor.{uA₂, uB})))
+      (fun state => (state.1,
+        (Responder.zero : Responder PUnit.{1}
+          (0 : PFunctor.{uA₂, uB})).behavior state.2))
+      (by
+        intro state operation
+        cases operation with
+        | left operation => rfl
+        | right impossible => exact PEmpty.elim impossible
+        | both operation impossible => exact PEmpty.elim impossible)
+      (by
+        intro state operation
+        cases operation with
+        | left operation => rfl
+        | right impossible => exact PEmpty.elim impossible
+        | both operation impossible => exact PEmpty.elim impossible)
+      (left, PUnit.unit)
+    dsimp [verifiedTotalStep, VerifiedPresentationHom.totalMap]
+    apply Sigma.ext_iff.mpr
+    constructor
+    · apply Sigma.ext_iff.mpr
+      constructor
+      · exact hBase
+      · apply Function.hfunext rfl
+        intro operation operation' hOperation
+        cases hOperation
+        apply Function.hfunext rfl
+        intro contract contract' hContract
+        cases hContract
+        cases operation with
+        | left operation => rfl
+        | right impossible => exact PEmpty.elim impossible
+        | both operation impossible => exact PEmpty.elim impossible
+    · apply Function.hfunext
+      · apply congrArg
+          (Display.mStep (Display.responder
+            (Display.parallelSum S
+              (Display.zero : Display
+                (0 : PFunctor.{uA₂, uB}))))).sigmaPFunctor.B
+        apply Sigma.ext_iff.mpr
+        constructor
+        · exact hBase
+        · apply Function.hfunext rfl
+          intro operation operation' hOperation
+          cases hOperation
+          apply Function.hfunext rfl
+          intro contract contract' hContract
+          cases hContract
+          cases operation with
+          | left operation => rfl
+          | right impossible => exact PEmpty.elim impossible
+          | both operation impossible => exact PEmpty.elim impossible
+      · intro direction direction' hDirection
+        cases hDirection
+        rcases direction with ⟨⟨operation, trivialDirection⟩, contract⟩
+        cases trivialDirection
+        cases operation with
+        | left operation => rfl
+        | right impossible => exact PEmpty.elim impossible
+        | both operation impossible => exact PEmpty.elim impossible
+
+private theorem verifiedBehavior_parallel_zero_right_presentation
+    (S : Display.{uA₁, uB, uC₁, uD₁} P)
+    (left : PFunctor.M (P ⊸ X.{uA₁, uB}))
+    (displayedLeft : Display.M (Display.responder S) left) :
+    Display.M.transport
+        ((parallelZeroRightPresentationHom S).behavior_eq
+          (left, PUnit.unit) (displayedLeft, PUnit.unit))
+        (parallelVerifiedBehavior S
+          (Display.zero : Display (0 : PFunctor.{uA₂, uB}))
+          left displayedLeft
+          ((Responder.zero : Responder PUnit.{1}
+            (0 : PFunctor.{uA₂, uB})).behavior PUnit.unit)
+          zeroVerifiedBehavior) =
+      verifiedBehavior
+        (Display.parallelSum S
+          (Display.zero : Display (0 : PFunctor.{uA₂, uB})))
+        (Responder.parallel (Responder.terminal (P := P))
+          (Responder.zero : Responder PUnit.{1}
+            (0 : PFunctor.{uA₂, uB})))
+        (fun state => Display.M (Display.responder S) state.1 × PUnit)
+        (parallelCoalgebra (Responder.terminal (P := P))
+          (Responder.zero : Responder PUnit.{1}
+            (0 : PFunctor.{uA₂, uB}))
+          (Display.M (Display.responder S)) (fun _ => PUnit)
+          (Display.Coalgebra.terminal (Display.responder S))
+          zeroDisplayedCoalgebra)
+        (left, PUnit.unit) (displayedLeft, PUnit.unit) := by
+  exact (parallelZeroRightPresentationHom S).verifiedBehavior_naturality
+    (left, PUnit.unit) (displayedLeft, PUnit.unit)
+
+/-- The displayed left unitor as a verified map between raw responder
+presentations. -/
+private def parallelZeroLeftVerifiedPresentationHom
+    (S : Display.{uA₁, uB, uC₁, uD₁} P) :
+    VerifiedPresentationHom
+      (Display.parallelSum
+        (Display.zero : Display (0 : PFunctor.{uA₂, uB})) S)
+      (Responder.parallel
+        (Responder.zero : Responder PUnit.{1}
+          (0 : PFunctor.{uA₂, uB}))
+        (Responder.terminal (P := P)))
+      (fun state => PUnit × Display.M (Display.responder S) state.2)
+      (parallelCoalgebra
+        (Responder.zero : Responder PUnit.{1}
+          (0 : PFunctor.{uA₂, uB}))
+        (Responder.terminal (P := P))
+        (fun _ => PUnit) (Display.M (Display.responder S))
+        zeroDisplayedCoalgebra
+        (Display.Coalgebra.terminal (Display.responder S)))
+      (Responder.reindex
+        (PFunctor.Handler.ofLens
+          (PFunctor.Lens.zeroParallelSum P :
+            PFunctor.Lens ((0 : PFunctor.{uA₂, uB}) ∥ P) P))
+        (Responder.terminal (P := P)))
+      (Display.M (Display.responder S))
+      (Responder.reindexCoalgebra
+        (Display.parallelSum
+          (Display.zero : Display (0 : PFunctor.{uA₂, uB})) S) S
+        (PFunctor.Handler.ofLens
+          (PFunctor.Lens.zeroParallelSum P :
+            PFunctor.Lens ((0 : PFunctor.{uA₂, uB}) ∥ P) P))
+        (Display.Lens.zeroParallelSum S).toHandler
+        (Responder.terminal (P := P))
+        (Display.Coalgebra.terminal (Display.responder S))) where
+  toState state := state.2
+  toWitness _ witness := witness.2
+  map_step := by
+    intro state witness
+    rcases state with ⟨emptyState, right⟩
+    rcases emptyState with ⟨⟩
+    rcases witness with ⟨emptyWitness, displayedRight⟩
+    rcases emptyWitness with ⟨⟩
+    have hBase := behavior_eq_of_responderMap
+      (Responder.reindex
+        (PFunctor.Handler.ofLens
+          (PFunctor.Lens.zeroParallelSum P :
+            PFunctor.Lens ((0 : PFunctor.{uA₂, uB}) ∥ P) P))
+        (Responder.terminal (P := P)))
+      (Responder.parallel
+        (Responder.zero : Responder PUnit.{1}
+          (0 : PFunctor.{uA₂, uB}))
+        (Responder.terminal (P := P)))
+      Prod.snd
+      (by
+        intro state operation
+        rw [Responder.answer_reindex, runFree_ofLens]
+        cases operation with
+        | left impossible => exact PEmpty.elim impossible
+        | right operation => rfl
+        | both impossible operation => exact PEmpty.elim impossible)
+      (by
+        intro state operation
+        rw [Responder.next_reindex, runFree_ofLens]
+        cases operation with
+        | left impossible => exact PEmpty.elim impossible
+        | right operation => rfl
+        | both impossible operation => exact PEmpty.elim impossible)
+      (PUnit.unit, right)
+    dsimp [verifiedTotalStep, VerifiedPresentationHom.totalMap]
+    apply Sigma.ext_iff.mpr
+    constructor
+    · apply Sigma.ext_iff.mpr
+      constructor
+      · exact hBase
+      · apply Function.hfunext rfl
+        intro operation operation' hOperation
+        cases hOperation
+        apply Function.hfunext rfl
+        intro contract contract' hContract
+        cases hContract
+        cases operation with
+        | left impossible => exact PEmpty.elim impossible
+        | right operation => rfl
+        | both impossible operation => exact PEmpty.elim impossible
+    · apply Function.hfunext
+      · apply congrArg
+          (Display.mStep (Display.responder
+            (Display.parallelSum
+              (Display.zero : Display
+                (0 : PFunctor.{uA₂, uB})) S))).sigmaPFunctor.B
+        apply Sigma.ext_iff.mpr
+        constructor
+        · exact hBase
+        · apply Function.hfunext rfl
+          intro operation operation' hOperation
+          cases hOperation
+          apply Function.hfunext rfl
+          intro contract contract' hContract
+          cases hContract
+          cases operation with
+          | left impossible => exact PEmpty.elim impossible
+          | right operation => rfl
+          | both impossible operation => exact PEmpty.elim impossible
+      · intro direction direction' hDirection
+        cases hDirection
+        rcases direction with ⟨⟨operation, trivialDirection⟩, contract⟩
+        cases trivialDirection
+        cases operation with
+        | left impossible => exact PEmpty.elim impossible
+        | right operation => rfl
+        | both impossible operation => exact PEmpty.elim impossible
+
+private theorem verifiedBehavior_parallel_zero_left_presented
+    (S : Display.{uA₁, uB, uC₁, uD₁} P)
+    (right : PFunctor.M (P ⊸ X.{uA₁, uB}))
+    (displayedRight : Display.M (Display.responder S) right) :
+    Display.M.transport
+        ((parallelZeroLeftVerifiedPresentationHom S).behavior_eq
+          (PUnit.unit, right) (PUnit.unit, displayedRight))
+        (verifiedBehavior
+          (Display.parallelSum
+            (Display.zero : Display (0 : PFunctor.{uA₂, uB})) S)
+          (Responder.reindex
+            (PFunctor.Handler.ofLens
+              (PFunctor.Lens.zeroParallelSum P :
+                PFunctor.Lens ((0 : PFunctor.{uA₂, uB}) ∥ P) P))
+            (Responder.terminal (P := P)))
+          (Display.M (Display.responder S))
+          (Responder.reindexCoalgebra
+            (Display.parallelSum
+              (Display.zero : Display (0 : PFunctor.{uA₂, uB})) S) S
+            (PFunctor.Handler.ofLens
+              (PFunctor.Lens.zeroParallelSum P :
+                PFunctor.Lens ((0 : PFunctor.{uA₂, uB}) ∥ P) P))
+            (Display.Lens.zeroParallelSum S).toHandler
+            (Responder.terminal (P := P))
+            (Display.Coalgebra.terminal (Display.responder S)))
+          right displayedRight) =
+      verifiedBehavior
+        (Display.parallelSum
+          (Display.zero : Display (0 : PFunctor.{uA₂, uB})) S)
+        (Responder.parallel
+          (Responder.zero : Responder PUnit.{1}
+            (0 : PFunctor.{uA₂, uB}))
+          (Responder.terminal (P := P)))
+        (fun state => PUnit × Display.M (Display.responder S) state.2)
+        (parallelCoalgebra
+          (Responder.zero : Responder PUnit.{1}
+            (0 : PFunctor.{uA₂, uB}))
+          (Responder.terminal (P := P))
+          (fun _ => PUnit) (Display.M (Display.responder S))
+          zeroDisplayedCoalgebra
+          (Display.Coalgebra.terminal (Display.responder S)))
+        (PUnit.unit, right) (PUnit.unit, displayedRight) := by
+  exact (parallelZeroLeftVerifiedPresentationHom S).verifiedBehavior_naturality
+    (PUnit.unit, right) (PUnit.unit, displayedRight)
+
+/-- Presentation change from the raw empty responder on the left to the
+terminal empty behavior used by `parallelVerifiedBehavior`. -/
+private def parallelZeroLeftPresentationHom
+    (S : Display.{uA₁, uB, uC₁, uD₁} P) :
+    VerifiedPresentationHom
+      (Display.parallelSum
+        (Display.zero : Display (0 : PFunctor.{uA₂, uB})) S)
+      (Responder.parallel
+        (Responder.zero : Responder PUnit.{1}
+          (0 : PFunctor.{uA₂, uB}))
+        (Responder.terminal (P := P)))
+      (fun state => PUnit × Display.M (Display.responder S) state.2)
+      (parallelCoalgebra
+        (Responder.zero : Responder PUnit.{1}
+          (0 : PFunctor.{uA₂, uB}))
+        (Responder.terminal (P := P))
+        (fun _ => PUnit) (Display.M (Display.responder S))
+        zeroDisplayedCoalgebra
+        (Display.Coalgebra.terminal (Display.responder S)))
+      (Responder.parallel
+        (Responder.terminal (P := (0 : PFunctor.{uA₂, uB})))
+        (Responder.terminal (P := P)))
+      (fun state =>
+        Display.M
+          (Display.responder
+            (Display.zero : Display (0 : PFunctor.{uA₂, uB}))) state.1 ×
+        Display.M (Display.responder S) state.2)
+      (parallelCoalgebra
+        (Responder.terminal (P := (0 : PFunctor.{uA₂, uB})))
+        (Responder.terminal (P := P))
+        (Display.M
+          (Display.responder
+            (Display.zero : Display (0 : PFunctor.{uA₂, uB}))))
+        (Display.M (Display.responder S))
+        (Display.Coalgebra.terminal
+          (Display.responder
+            (Display.zero : Display (0 : PFunctor.{uA₂, uB}))))
+        (Display.Coalgebra.terminal (Display.responder S))) where
+  toState state :=
+    ((Responder.zero : Responder PUnit.{1}
+      (0 : PFunctor.{uA₂, uB})).behavior state.1, state.2)
+  toWitness _ witness := (zeroVerifiedBehavior, witness.2)
+  map_step := by
+    intro state witness
+    rcases state with ⟨emptyState, right⟩
+    rcases emptyState with ⟨⟩
+    rcases witness with ⟨emptyWitness, displayedRight⟩
+    rcases emptyWitness with ⟨⟩
+    have hBase := behavior_eq_of_responderMap
+      (Responder.parallel
+        (Responder.terminal (P := (0 : PFunctor.{uA₂, uB})))
+        (Responder.terminal (P := P)))
+      (Responder.parallel
+        (Responder.zero : Responder PUnit.{1}
+          (0 : PFunctor.{uA₂, uB}))
+        (Responder.terminal (P := P)))
+      (fun state =>
+        ((Responder.zero : Responder PUnit.{1}
+          (0 : PFunctor.{uA₂, uB})).behavior state.1, state.2))
+      (by
+        intro state operation
+        cases operation with
+        | left impossible => exact PEmpty.elim impossible
+        | right operation => rfl
+        | both impossible operation => exact PEmpty.elim impossible)
+      (by
+        intro state operation
+        cases operation with
+        | left impossible => exact PEmpty.elim impossible
+        | right operation => rfl
+        | both impossible operation => exact PEmpty.elim impossible)
+      (PUnit.unit, right)
+    dsimp [verifiedTotalStep, VerifiedPresentationHom.totalMap]
+    apply Sigma.ext_iff.mpr
+    constructor
+    · apply Sigma.ext_iff.mpr
+      constructor
+      · exact hBase
+      · apply Function.hfunext rfl
+        intro operation operation' hOperation
+        cases hOperation
+        apply Function.hfunext rfl
+        intro contract contract' hContract
+        cases hContract
+        cases operation with
+        | left impossible => exact PEmpty.elim impossible
+        | right operation => rfl
+        | both impossible operation => exact PEmpty.elim impossible
+    · apply Function.hfunext
+      · apply congrArg
+          (Display.mStep (Display.responder
+            (Display.parallelSum
+              (Display.zero : Display
+                (0 : PFunctor.{uA₂, uB})) S))).sigmaPFunctor.B
+        apply Sigma.ext_iff.mpr
+        constructor
+        · exact hBase
+        · apply Function.hfunext rfl
+          intro operation operation' hOperation
+          cases hOperation
+          apply Function.hfunext rfl
+          intro contract contract' hContract
+          cases hContract
+          cases operation with
+          | left impossible => exact PEmpty.elim impossible
+          | right operation => rfl
+          | both impossible operation => exact PEmpty.elim impossible
+      · intro direction direction' hDirection
+        cases hDirection
+        rcases direction with ⟨⟨operation, trivialDirection⟩, contract⟩
+        cases trivialDirection
+        cases operation with
+        | left impossible => exact PEmpty.elim impossible
+        | right operation => rfl
+        | both impossible operation => exact PEmpty.elim impossible
+
+private theorem verifiedBehavior_parallel_zero_left_presentation
+    (S : Display.{uA₁, uB, uC₁, uD₁} P)
+    (right : PFunctor.M (P ⊸ X.{uA₁, uB}))
+    (displayedRight : Display.M (Display.responder S) right) :
+    Display.M.transport
+        ((parallelZeroLeftPresentationHom S).behavior_eq
+          (PUnit.unit, right) (PUnit.unit, displayedRight))
+        (parallelVerifiedBehavior
+          (Display.zero : Display (0 : PFunctor.{uA₂, uB})) S
+          ((Responder.zero : Responder PUnit.{1}
+            (0 : PFunctor.{uA₂, uB})).behavior PUnit.unit)
+          zeroVerifiedBehavior right displayedRight) =
+      verifiedBehavior
+        (Display.parallelSum
+          (Display.zero : Display (0 : PFunctor.{uA₂, uB})) S)
+        (Responder.parallel
+          (Responder.zero : Responder PUnit.{1}
+            (0 : PFunctor.{uA₂, uB}))
+          (Responder.terminal (P := P)))
+        (fun state => PUnit × Display.M (Display.responder S) state.2)
+        (parallelCoalgebra
+          (Responder.zero : Responder PUnit.{1}
+            (0 : PFunctor.{uA₂, uB}))
+          (Responder.terminal (P := P))
+          (fun _ => PUnit) (Display.M (Display.responder S))
+          zeroDisplayedCoalgebra
+          (Display.Coalgebra.terminal (Display.responder S)))
+        (PUnit.unit, right) (PUnit.unit, displayedRight) := by
+  exact (parallelZeroLeftPresentationHom S).verifiedBehavior_naturality
+      (PUnit.unit, right) (PUnit.unit, displayedRight)
+
+
+/-- Verified parallel behavior is symmetric after the single canonical
+transport along the ordinary braiding law. -/
+theorem mapVerifiedBehavior_parallel_comm
+    (S : Display.{uA₁, uB, uC₁, uD₁} P)
+    (T : Display.{uA₂, uB, uC₂, uD₂} Q)
+    (left : PFunctor.M (P ⊸ X.{uA₁, uB}))
+    (displayedLeft : Display.M (Display.responder S) left)
+    (right : PFunctor.M (Q ⊸ X.{uA₂, uB}))
+    (displayedRight : Display.M (Display.responder T) right) :
+    Display.M.transport (mapBehavior_parallel_comm left right)
+        (mapVerifiedBehavior (Display.Lens.parallelSumComm S T)
+          (parallelBehavior right left)
+          (parallelVerifiedBehavior T S right displayedRight
+            left displayedLeft)) =
+      parallelVerifiedBehavior S T left displayedLeft right displayedRight := by
+  let swapped := Responder.parallel (Responder.terminal (P := Q))
+    (Responder.terminal (P := P))
+  let swappedWitness := fun state :
+      PFunctor.M (Q ⊸ X.{uA₂, uB}) ×
+        PFunctor.M (P ⊸ X.{uA₁, uB}) =>
+    Display.M (Display.responder T) state.1 ×
+      Display.M (Display.responder S) state.2
+  let displayedSwapped := parallelCoalgebra
+    (Responder.terminal (P := Q)) (Responder.terminal (P := P))
+    (Display.M (Display.responder T))
+    (Display.M (Display.responder S))
+    (Display.Coalgebra.terminal (Display.responder T))
+    (Display.Coalgebra.terminal (Display.responder S))
+  let sourceDisplayed := parallelVerifiedBehavior T S right displayedRight
+    left displayedLeft
+  let mappedDisplayed := mapVerifiedBehavior
+    (Display.Lens.parallelSumComm S T)
+    (parallelBehavior right left) sourceDisplayed
+  let rawMapped := verifiedBehavior (Display.parallelSum S T)
+    (Responder.reindex
+      (PFunctor.Handler.ofLens (PFunctor.Lens.parallelSumComm P Q)) swapped)
+    swappedWitness
+    (Responder.reindexCoalgebra (Display.parallelSum S T)
+      (Display.parallelSum T S)
+      (PFunctor.Handler.ofLens (PFunctor.Lens.parallelSumComm P Q))
+      (Display.Lens.parallelSumComm S T).toHandler
+      swapped displayedSwapped)
+    (right, left) (displayedRight, displayedLeft)
+  let presentationEq := reindexBehavior_behavior
+    (PFunctor.Handler.ofLens (PFunctor.Lens.parallelSumComm P Q))
+    swapped (right, left)
+  have hPresentation :
+      Display.M.transport presentationEq mappedDisplayed = rawMapped := by
+    exact reindexVerifiedBehavior_verifiedBehavior
+      (PFunctor.Handler.ofLens (PFunctor.Lens.parallelSumComm P Q))
+      (Display.Lens.parallelSumComm S T).toHandler
+      swapped swappedWitness displayedSwapped
+      (right, left) (displayedRight, displayedLeft)
+  let rawEq := (parallelCommVerifiedPresentationHom S T).behavior_eq
+    (left, right) (displayedLeft, displayedRight)
+  have hRaw : Display.M.transport rawEq rawMapped =
+      parallelVerifiedBehavior S T left displayedLeft right displayedRight := by
+    exact verifiedBehavior_parallel_comm_presented S T
+      left displayedLeft right displayedRight
+  have hChain :
+      Display.M.transport (presentationEq.trans rawEq) mappedDisplayed =
+        parallelVerifiedBehavior S T left displayedLeft right displayedRight := by
+    calc
+      Display.M.transport (presentationEq.trans rawEq) mappedDisplayed =
+          Display.M.transport rawEq
+            (Display.M.transport presentationEq mappedDisplayed) :=
+        (Display.M.transport_trans presentationEq rawEq mappedDisplayed).symm
+      _ = Display.M.transport rawEq rawMapped :=
+        congrArg (Display.M.transport rawEq) hPresentation
+      _ = _ := hRaw
+  exact (Display.M.transport_proof_irrel
+    (mapBehavior_parallel_comm left right)
+    (presentationEq.trans rawEq) mappedDisplayed).trans hChain
+
+/-- The empty displayed interface is a right unit for verified state-free
+parallel behavior.  The statement exposes only the canonical ordinary
+right-unitor equality; the proof factors through the raw empty-responder
+presentation and discharges both presentation changes internally. -/
+theorem mapVerifiedBehavior_parallel_zero_right
+    (S : Display.{uA₁, uB, uC₁, uD₁} P)
+    (left : PFunctor.M (P ⊸ X.{uA₁, uB}))
+    (displayedLeft : Display.M (Display.responder S) left) :
+    Display.M.transport (mapBehavior_parallel_zero_right left)
+        (mapVerifiedBehavior (Display.Lens.parallelSumZero S)
+          left displayedLeft) =
+      parallelVerifiedBehavior S
+        (Display.zero : Display.{uA₂, uB, uC₂, uD₂}
+          (0 : PFunctor.{uA₂, uB}))
+        left displayedLeft
+        ((Responder.zero : Responder PUnit.{1}
+          (0 : PFunctor.{uA₂, uB})).behavior PUnit.unit)
+        zeroVerifiedBehavior := by
+  let empty := (Responder.zero : Responder PUnit.{1}
+    (0 : PFunctor.{uA₂, uB}))
+  let raw := Responder.parallel (Responder.terminal (P := P)) empty
+  let rawWitness := fun state :
+      PFunctor.M (P ⊸ X.{uA₁, uB}) × PUnit =>
+    Display.M (Display.responder S) state.1 × PUnit
+  let displayedRaw := parallelCoalgebra
+    (Responder.terminal (P := P)) empty
+    (Display.M (Display.responder S)) (fun _ => PUnit)
+    (Display.Coalgebra.terminal (Display.responder S))
+    zeroDisplayedCoalgebra
+  let mappedDisplayed := mapVerifiedBehavior
+    (Display.Lens.parallelSumZero S) left displayedLeft
+  let rawMapped := verifiedBehavior
+    (Display.parallelSum S
+      (Display.zero : Display.{uA₂, uB, uC₂, uD₂}
+        (0 : PFunctor.{uA₂, uB})))
+    (Responder.reindex
+      (PFunctor.Handler.ofLens
+        (PFunctor.Lens.parallelSumZero P :
+          PFunctor.Lens (P ∥ (0 : PFunctor.{uA₂, uB})) P))
+      (Responder.terminal (P := P)))
+    (Display.M (Display.responder S))
+    (Responder.reindexCoalgebra
+      (Display.parallelSum S
+        (Display.zero : Display.{uA₂, uB, uC₂, uD₂}
+          (0 : PFunctor.{uA₂, uB}))) S
+      (PFunctor.Handler.ofLens
+        (PFunctor.Lens.parallelSumZero P :
+          PFunctor.Lens (P ∥ (0 : PFunctor.{uA₂, uB})) P))
+      (Display.Lens.parallelSumZero S).toHandler
+      (Responder.terminal (P := P))
+      (Display.Coalgebra.terminal (Display.responder S)))
+    left displayedLeft
+  let rawDisplayed := verifiedBehavior
+    (Display.parallelSum S
+      (Display.zero : Display.{uA₂, uB, uC₂, uD₂}
+        (0 : PFunctor.{uA₂, uB})))
+    raw rawWitness displayedRaw
+    (left, PUnit.unit) (displayedLeft, PUnit.unit)
+  let publicDisplayed := parallelVerifiedBehavior S
+    (Display.zero : Display.{uA₂, uB, uC₂, uD₂}
+      (0 : PFunctor.{uA₂, uB}))
+    left displayedLeft (empty.behavior PUnit.unit) zeroVerifiedBehavior
+  let presentationEq :
+      mapBehavior
+          (PFunctor.Lens.parallelSumZero P :
+            PFunctor.Lens (P ∥ (0 : PFunctor.{uA₂, uB})) P)
+          left =
+        (Responder.reindex
+          (PFunctor.Handler.ofLens
+            (PFunctor.Lens.parallelSumZero P :
+              PFunctor.Lens (P ∥ (0 : PFunctor.{uA₂, uB})) P))
+          (Responder.terminal (P := P))).behavior left := by
+    simpa only [mapBehavior, terminal_behavior] using
+      reindexBehavior_behavior
+        (PFunctor.Handler.ofLens
+          (PFunctor.Lens.parallelSumZero P :
+            PFunctor.Lens (P ∥ (0 : PFunctor.{uA₂, uB})) P))
+        (Responder.terminal (P := P)) left
+  have hPresentation :
+      Display.M.transport presentationEq mappedDisplayed = rawMapped := by
+    change Display.M.transport presentationEq mappedDisplayed =
+      mappedDisplayed
+    exact (Display.M.transport_proof_irrel presentationEq rfl
+      mappedDisplayed).trans (Display.M.transport_rfl mappedDisplayed)
+  let rawEq :=
+    (parallelZeroRightVerifiedPresentationHom.{uA₁, uA₂, uB, uC₁, uD₁,
+      uC₂, uD₂}
+      S).behavior_eq
+    (left, PUnit.unit) (displayedLeft, PUnit.unit)
+  have hRaw : Display.M.transport rawEq rawMapped = rawDisplayed := by
+    exact verifiedBehavior_parallel_zero_right_presented.{uA₁, uA₂, uB,
+      uC₁, uD₁, uC₂, uD₂, 0, 0} S left displayedLeft
+  let terminalEq :=
+    (parallelZeroRightPresentationHom.{uA₁, uA₂, uB,
+      uC₁, uD₁, uC₂, uD₂} S).behavior_eq
+      (left, PUnit.unit) (displayedLeft, PUnit.unit)
+  have hTerminal :
+      Display.M.transport terminalEq publicDisplayed = rawDisplayed := by
+    exact verifiedBehavior_parallel_zero_right_presentation.{uA₁, uA₂,
+      uB, uC₁, uD₁, uC₂, uD₂, 0, 0} S left displayedLeft
+  have hRawToPublic :
+      Display.M.transport terminalEq.symm rawDisplayed = publicDisplayed := by
+    calc
+      Display.M.transport terminalEq.symm rawDisplayed =
+          Display.M.transport terminalEq.symm
+            (Display.M.transport terminalEq publicDisplayed) :=
+        congrArg (Display.M.transport terminalEq.symm) hTerminal.symm
+      _ = publicDisplayed :=
+        Display.M.transport_symm_transport terminalEq publicDisplayed
+  have hChain :
+      Display.M.transport
+          ((presentationEq.trans rawEq).trans terminalEq.symm)
+          mappedDisplayed = publicDisplayed := by
+    calc
+      Display.M.transport
+          ((presentationEq.trans rawEq).trans terminalEq.symm)
+          mappedDisplayed =
+          Display.M.transport terminalEq.symm
+            (Display.M.transport (presentationEq.trans rawEq)
+              mappedDisplayed) :=
+        (Display.M.transport_trans (presentationEq.trans rawEq)
+          terminalEq.symm mappedDisplayed).symm
+      _ = Display.M.transport terminalEq.symm
+          (Display.M.transport rawEq
+            (Display.M.transport presentationEq mappedDisplayed)) :=
+        congrArg (Display.M.transport terminalEq.symm)
+          (Display.M.transport_trans presentationEq rawEq
+            mappedDisplayed).symm
+      _ = Display.M.transport terminalEq.symm
+          (Display.M.transport rawEq rawMapped) :=
+        congrArg (fun displayed =>
+          Display.M.transport terminalEq.symm
+            (Display.M.transport rawEq displayed)) hPresentation
+      _ = Display.M.transport terminalEq.symm rawDisplayed :=
+        congrArg (Display.M.transport terminalEq.symm) hRaw
+      _ = publicDisplayed := hRawToPublic
+  exact (Display.M.transport_proof_irrel
+    (mapBehavior_parallel_zero_right left)
+    ((presentationEq.trans rawEq).trans terminalEq.symm)
+    mappedDisplayed).trans hChain
+
+/-- The empty displayed interface is a left unit for verified state-free
+parallel behavior. -/
+theorem mapVerifiedBehavior_parallel_zero_left
+    (S : Display.{uA₁, uB, uC₁, uD₁} P)
+    (right : PFunctor.M (P ⊸ X.{uA₁, uB}))
+    (displayedRight : Display.M (Display.responder S) right) :
+    Display.M.transport (mapBehavior_parallel_zero_left right)
+        (mapVerifiedBehavior (Display.Lens.zeroParallelSum S)
+          right displayedRight) =
+      parallelVerifiedBehavior
+        (Display.zero : Display.{uA₂, uB, uC₂, uD₂}
+          (0 : PFunctor.{uA₂, uB})) S
+        ((Responder.zero : Responder PUnit.{1}
+          (0 : PFunctor.{uA₂, uB})).behavior PUnit.unit)
+        zeroVerifiedBehavior right displayedRight := by
+  let empty := (Responder.zero : Responder PUnit.{1}
+    (0 : PFunctor.{uA₂, uB}))
+  let raw := Responder.parallel empty (Responder.terminal (P := P))
+  let rawWitness := fun state :
+      PUnit × PFunctor.M (P ⊸ X.{uA₁, uB}) =>
+    PUnit × Display.M (Display.responder S) state.2
+  let displayedRaw := parallelCoalgebra empty
+    (Responder.terminal (P := P))
+    (fun _ => PUnit) (Display.M (Display.responder S))
+    zeroDisplayedCoalgebra
+    (Display.Coalgebra.terminal (Display.responder S))
+  let mappedDisplayed := mapVerifiedBehavior
+    (Display.Lens.zeroParallelSum S) right displayedRight
+  let rawMapped := verifiedBehavior
+    (Display.parallelSum
+      (Display.zero : Display.{uA₂, uB, uC₂, uD₂}
+        (0 : PFunctor.{uA₂, uB})) S)
+    (Responder.reindex
+      (PFunctor.Handler.ofLens
+        (PFunctor.Lens.zeroParallelSum P :
+          PFunctor.Lens ((0 : PFunctor.{uA₂, uB}) ∥ P) P))
+      (Responder.terminal (P := P)))
+    (Display.M (Display.responder S))
+    (Responder.reindexCoalgebra
+      (Display.parallelSum
+        (Display.zero : Display.{uA₂, uB, uC₂, uD₂}
+          (0 : PFunctor.{uA₂, uB})) S) S
+      (PFunctor.Handler.ofLens
+        (PFunctor.Lens.zeroParallelSum P :
+          PFunctor.Lens ((0 : PFunctor.{uA₂, uB}) ∥ P) P))
+      (Display.Lens.zeroParallelSum S).toHandler
+      (Responder.terminal (P := P))
+      (Display.Coalgebra.terminal (Display.responder S)))
+    right displayedRight
+  let rawDisplayed := verifiedBehavior
+    (Display.parallelSum
+      (Display.zero : Display.{uA₂, uB, uC₂, uD₂}
+        (0 : PFunctor.{uA₂, uB})) S)
+    raw rawWitness displayedRaw
+    (PUnit.unit, right) (PUnit.unit, displayedRight)
+  let publicDisplayed := parallelVerifiedBehavior
+    (Display.zero : Display.{uA₂, uB, uC₂, uD₂}
+      (0 : PFunctor.{uA₂, uB})) S
+    (empty.behavior PUnit.unit) zeroVerifiedBehavior right displayedRight
+  let presentationEq :
+      mapBehavior
+          (PFunctor.Lens.zeroParallelSum P :
+            PFunctor.Lens ((0 : PFunctor.{uA₂, uB}) ∥ P) P)
+          right =
+        (Responder.reindex
+          (PFunctor.Handler.ofLens
+            (PFunctor.Lens.zeroParallelSum P :
+              PFunctor.Lens ((0 : PFunctor.{uA₂, uB}) ∥ P) P))
+          (Responder.terminal (P := P))).behavior right := by
+    simpa only [mapBehavior, terminal_behavior] using
+      reindexBehavior_behavior
+        (PFunctor.Handler.ofLens
+          (PFunctor.Lens.zeroParallelSum P :
+            PFunctor.Lens ((0 : PFunctor.{uA₂, uB}) ∥ P) P))
+        (Responder.terminal (P := P)) right
+  have hPresentation :
+      Display.M.transport presentationEq mappedDisplayed = rawMapped := by
+    change Display.M.transport presentationEq mappedDisplayed =
+      mappedDisplayed
+    exact (Display.M.transport_proof_irrel presentationEq rfl
+      mappedDisplayed).trans (Display.M.transport_rfl mappedDisplayed)
+  let rawEq :=
+    (parallelZeroLeftVerifiedPresentationHom.{uA₁, uA₂, uB, uC₁, uD₁,
+      uC₂, uD₂} S).behavior_eq
+      (PUnit.unit, right) (PUnit.unit, displayedRight)
+  have hRaw : Display.M.transport rawEq rawMapped = rawDisplayed := by
+    exact verifiedBehavior_parallel_zero_left_presented.{uA₁, uA₂, uB,
+      uC₁, uD₁, uC₂, uD₂, 0, 0} S right displayedRight
+  let terminalEq :=
+    (parallelZeroLeftPresentationHom.{uA₁, uA₂, uB,
+      uC₁, uD₁, uC₂, uD₂} S).behavior_eq
+      (PUnit.unit, right) (PUnit.unit, displayedRight)
+  have hTerminal :
+      Display.M.transport terminalEq publicDisplayed = rawDisplayed := by
+    exact verifiedBehavior_parallel_zero_left_presentation.{uA₁, uA₂,
+      uB, uC₁, uD₁, uC₂, uD₂, 0, 0} S right displayedRight
+  have hRawToPublic :
+      Display.M.transport terminalEq.symm rawDisplayed = publicDisplayed := by
+    calc
+      Display.M.transport terminalEq.symm rawDisplayed =
+          Display.M.transport terminalEq.symm
+            (Display.M.transport terminalEq publicDisplayed) :=
+        congrArg (Display.M.transport terminalEq.symm) hTerminal.symm
+      _ = publicDisplayed :=
+        Display.M.transport_symm_transport terminalEq publicDisplayed
+  have hChain :
+      Display.M.transport
+          ((presentationEq.trans rawEq).trans terminalEq.symm)
+          mappedDisplayed = publicDisplayed := by
+    calc
+      Display.M.transport
+          ((presentationEq.trans rawEq).trans terminalEq.symm)
+          mappedDisplayed =
+          Display.M.transport terminalEq.symm
+            (Display.M.transport (presentationEq.trans rawEq)
+              mappedDisplayed) :=
+        (Display.M.transport_trans (presentationEq.trans rawEq)
+          terminalEq.symm mappedDisplayed).symm
+      _ = Display.M.transport terminalEq.symm
+          (Display.M.transport rawEq
+            (Display.M.transport presentationEq mappedDisplayed)) :=
+        congrArg (Display.M.transport terminalEq.symm)
+          (Display.M.transport_trans presentationEq rawEq
+            mappedDisplayed).symm
+      _ = Display.M.transport terminalEq.symm
+          (Display.M.transport rawEq rawMapped) :=
+        congrArg (fun displayed =>
+          Display.M.transport terminalEq.symm
+            (Display.M.transport rawEq displayed)) hPresentation
+      _ = Display.M.transport terminalEq.symm rawDisplayed :=
+        congrArg (Display.M.transport terminalEq.symm) hRaw
+      _ = publicDisplayed := hRawToPublic
+  exact (Display.M.transport_proof_irrel
+    (mapBehavior_parallel_zero_left right)
+    ((presentationEq.trans rawEq).trans terminalEq.symm)
+    mappedDisplayed).trans hChain
+
+end Responder
+end PFunctor

--- a/PolyFunTest/PFunctor/ParallelVerifiedCoherence.lean
+++ b/PolyFunTest/PFunctor/ParallelVerifiedCoherence.lean
@@ -1,0 +1,164 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+
+public import PolyFun.PFunctor.Dynamical.Responder.Parallel.VerifiedCoherence
+
+/-!
+# Regression tests for proof-relevant parallel coherence
+
+The displays below have genuinely answer-dependent postcondition types.  This
+prevents symmetry, unit, and associativity laws from passing by silently
+erasing or swapping displayed evidence.
+-/
+
+@[expose] public section
+
+namespace PFunctor.ParallelVerifiedCoherenceCanary
+
+abbrev Left : PFunctor.{0, 0} := ⟨Bool, fun _ => Bool⟩
+
+abbrev Right : PFunctor.{0, 0} := ⟨PUnit, fun _ => Nat⟩
+
+def leftResponder : Responder Nat Left :=
+  Responder.mk' (fun _ query => !query) (fun state _ => state + 1)
+
+def rightResponder : Responder Nat Right :=
+  Responder.mk' (fun state _ => state) (fun state _ => state + 10)
+
+def leftDisplay : Display Left where
+  position operation := if operation then Nat else Bool
+  direction _ _ answer := if answer then Fin 2 else Fin 3
+
+def rightDisplay : Display Right where
+  position _ := String
+  direction _ _ answer := Fin (answer + 1)
+
+def leftPost (answer : Bool) : if answer then Fin 2 else Fin 3 := by
+  cases answer <;> exact ⟨0, Nat.zero_lt_succ _⟩
+
+def rightPost (answer : Nat) : Fin (answer + 1) :=
+  ⟨0, Nat.zero_lt_succ _⟩
+
+def leftInvariant (state : Nat) : Type := Fin (state + 1)
+
+def rightInvariant (state : Nat) : Type := PLift (state = state)
+
+def leftCoalgebra :
+    Display.Coalgebra (Display.responder leftDisplay)
+      leftResponder.out leftInvariant :=
+  (Display.responderCoalgebraEquiv leftDisplay
+    leftResponder leftInvariant).symm fun state _ operation _ => by
+      refine ⟨?_, ⟨0, Nat.zero_lt_succ _⟩⟩
+      change (if !operation then Fin 2 else Fin 3)
+      exact leftPost (!operation)
+
+def rightCoalgebra :
+    Display.Coalgebra (Display.responder rightDisplay)
+      rightResponder.out rightInvariant :=
+  (Display.responderCoalgebraEquiv rightDisplay
+    rightResponder rightInvariant).symm fun state _ _ _ => by
+      exact ⟨rightPost state, ⟨rfl⟩⟩
+
+def leftVerified :
+    Display.M (Display.responder leftDisplay) (leftResponder.behavior 0) :=
+  Responder.verifiedBehavior leftDisplay leftResponder leftInvariant
+    leftCoalgebra 0 ⟨0, Nat.zero_lt_succ _⟩
+
+def rightVerified :
+    Display.M (Display.responder rightDisplay) (rightResponder.behavior 5) :=
+  Responder.verifiedBehavior rightDisplay rightResponder rightInvariant
+    rightCoalgebra 5 ⟨rfl⟩
+
+def parallelVerified :
+    Display.M (Display.responder (Display.parallelSum leftDisplay rightDisplay))
+      (Responder.parallelBehavior
+        (leftResponder.behavior 0) (rightResponder.behavior 5)) :=
+  Responder.parallelVerifiedBehavior leftDisplay rightDisplay
+    (leftResponder.behavior 0) leftVerified
+    (rightResponder.behavior 5) rightVerified
+
+def leftContract : leftDisplay.position true := by
+  change Nat
+  exact 5
+
+def rightContract : rightDisplay.position PUnit.unit :=
+  "right"
+
+example :
+    (Responder.respondDisplayed
+      (Display.parallelSum leftDisplay rightDisplay)
+      parallelVerified (.both true PUnit.unit)
+      (leftContract, rightContract)).1 =
+        (leftPost false, rightPost 5) := by
+  rfl
+
+example :
+    Display.M.transport
+        (Responder.mapBehavior_parallel_comm
+          (leftResponder.behavior 0) (rightResponder.behavior 5))
+      (Responder.mapVerifiedBehavior
+        (Display.Lens.parallelSumComm leftDisplay rightDisplay)
+        (Responder.parallelBehavior
+          (rightResponder.behavior 5) (leftResponder.behavior 0))
+        (Responder.parallelVerifiedBehavior rightDisplay leftDisplay
+          (rightResponder.behavior 5) rightVerified
+          (leftResponder.behavior 0) leftVerified)) =
+      parallelVerified :=
+  Responder.mapVerifiedBehavior_parallel_comm _ _ _ _ _ _
+
+example :
+    Display.M.transport
+        (Responder.mapBehavior_parallel_zero_right (leftResponder.behavior 0))
+      (Responder.mapVerifiedBehavior
+        (Display.Lens.parallelSumZero leftDisplay)
+        (leftResponder.behavior 0) leftVerified) =
+      Responder.parallelVerifiedBehavior leftDisplay Display.zero
+        (leftResponder.behavior 0) leftVerified
+        Responder.zeroBehavior Responder.zeroVerifiedBehavior :=
+  Responder.mapVerifiedBehavior_parallel_zero_right _ _ _
+
+example :
+    Display.M.transport
+        (Responder.mapBehavior_parallel_zero_left (leftResponder.behavior 0))
+      (Responder.mapVerifiedBehavior
+        (Display.Lens.zeroParallelSum leftDisplay)
+        (leftResponder.behavior 0) leftVerified) =
+      Responder.parallelVerifiedBehavior Display.zero leftDisplay
+        Responder.zeroBehavior Responder.zeroVerifiedBehavior
+        (leftResponder.behavior 0) leftVerified :=
+  Responder.mapVerifiedBehavior_parallel_zero_left _ _ _
+
+example :
+    Display.M.transport
+        (Responder.mapBehavior_parallel_assoc
+          (leftResponder.behavior 0) (rightResponder.behavior 5)
+          (leftResponder.behavior 0))
+      (Responder.mapVerifiedBehavior
+        (Display.Lens.parallelSumAssoc leftDisplay rightDisplay leftDisplay)
+        (Responder.parallelBehavior (leftResponder.behavior 0)
+          (Responder.parallelBehavior
+            (rightResponder.behavior 5) (leftResponder.behavior 0)))
+        (Responder.parallelVerifiedBehavior leftDisplay
+          (Display.parallelSum rightDisplay leftDisplay)
+          (leftResponder.behavior 0) leftVerified
+          (Responder.parallelBehavior
+            (rightResponder.behavior 5) (leftResponder.behavior 0))
+          (Responder.parallelVerifiedBehavior rightDisplay leftDisplay
+            (rightResponder.behavior 5) rightVerified
+            (leftResponder.behavior 0) leftVerified))) =
+      Responder.parallelVerifiedBehavior
+        (Display.parallelSum leftDisplay rightDisplay) leftDisplay
+        (Responder.parallelBehavior
+          (leftResponder.behavior 0) (rightResponder.behavior 5))
+        (Responder.parallelVerifiedBehavior leftDisplay rightDisplay
+          (leftResponder.behavior 0) leftVerified
+          (rightResponder.behavior 5) rightVerified)
+        (leftResponder.behavior 0) leftVerified :=
+  Responder.mapVerifiedBehavior_parallel_assoc _ _ _ _ _ _ _ _ _
+
+end PFunctor.ParallelVerifiedCoherenceCanary

--- a/docs/wiki/pfunctor.md
+++ b/docs/wiki/pfunctor.md
@@ -167,6 +167,8 @@ carrier varies.
 | [`PolyFun/PFunctor/Dynamical/Responder/Parallel/Compatibility.lean`](../../PolyFun/PFunctor/Dynamical/Responder/Parallel/Compatibility.lean) | Compatibility of sum restriction, free execution, and handler reindexing with parallel responders. |
 | [`PolyFun/PFunctor/Dynamical/Responder/Parallel/VerifiedPresentation.lean`](../../PolyFun/PFunctor/Dynamical/Responder/Parallel/VerifiedPresentation.lean) | Componentwise parallel composition of verified presentation homomorphisms, with identity and interchange laws. |
 | [`PolyFun/PFunctor/Dynamical/Responder/Parallel/Coherence.lean`](../../PolyFun/PFunctor/Dynamical/Responder/Parallel/Coherence.lean) | Ordinary state-free parallel behavior coherence under symmetry, units, and associativity. |
+| [`PolyFun/PFunctor/Dynamical/Responder/Parallel/VerifiedAssociativity.lean`](../../PolyFun/PFunctor/Dynamical/Responder/Parallel/VerifiedAssociativity.lean) | Proof-relevant associativity first at explicit verified presentations and then at canonical state-free semantics. |
+| [`PolyFun/PFunctor/Dynamical/Responder/Parallel/VerifiedCoherence.lean`](../../PolyFun/PFunctor/Dynamical/Responder/Parallel/VerifiedCoherence.lean) | Proof-relevant symmetry and unit coherence, plus the canonical empty displayed behavior. |
 
 Displayed responder coalgebras preserve proof-relevant evidence over one
 responder. They are distinct from `DynSystem.SafetyRefinement`, whose policy is

--- a/docs/wiki/repo-map.md
+++ b/docs/wiki/repo-map.md
@@ -136,6 +136,11 @@ PFunctor/Dynamical/Responder/{VerifiedPresentation, Parallel/Behavior}
 PFunctor/{Free/Parallel, Dynamical/Responder/Lens,
   Dynamical/Responder/Parallel/Behavior}
   -> PFunctor/Dynamical/Responder/Parallel/Coherence
+PFunctor/{Display/Parallel/Lens,
+  Dynamical/Responder/Parallel/Coherence,
+  Dynamical/Responder/Parallel/VerifiedPresentation}
+  -> PFunctor/Dynamical/Responder/Parallel/VerifiedAssociativity
+  -> PFunctor/Dynamical/Responder/Parallel/VerifiedCoherence
 PFunctor/{Display/Category, PatternRunsOnMatter/Applications,
   Dynamical/Responder/Behavior} -> PFunctor/PatternRunsOnMatter/Display
 


### PR DESCRIPTION
## Motivation and stack context

This is replacement slice 7/8 for frozen PR #89. It transports the structural laws from #96 through the full proof-relevant responder presentation, including dependent postconditions and continuations.

Base: `agent/aberle-g6f-parallel-coherence` at exact `31338030a73fca7953199f07401070b2e984e173`.

## What this PR does

- Constructs the displayed associator as a verified presentation homomorphism between explicit three-responder presentations.
- Proves the state-free verified associativity theorem by transporting through those presentations rather than relying on an opaque coinductive coincidence.
- Adds proof-relevant coherence for parallel braiding, right and left zero/unit interfaces, and associativity.
- Preserves complete verified steps: ordinary answers/children, dependent displayed postconditions, and verified continuations.
- Keeps position, direction, state, and witness universes independent.

The direct `Display.Parallel.Lens` import belongs here: this module actually consumes `Display.Lens.parallelSumAssoc`. #96 intentionally no longer exposes that dependency transitively.

## Deliberately not included

- No new packaged symmetric-monoidal category instance; this PR proves the concrete coherence interface required by the paper and downstream bridges.
- No application wiring/reconstruction theorem; those are #98.
- No additional paper aliases or duplicate verified-behavior structures.

## Implementation and review findings

`VerifiedCoherence.lean` is byte-identical to frozen #89. `VerifiedAssociativity.lean` differs only by the direct import required by the corrected ownership boundary. The sole independent audit checked associator and transport directions, witnesses/universes, private-helper consumers, trust footprint, frozen-source correspondence, and committed nonconstant postcondition canaries; it reports zero P0–P3 findings.

## Validation

- Exact head: `f5d989ba8f9f1d30fca8791286a5d2b90d426b9b`
- Exact base/merge-base: `31338030a73fca7953199f07401070b2e984e173`
- Full `./scripts/validate.sh --lint --test`: passed (8,874 build jobs, 213 imports, 2,036 tests, docs/lint)
- Focused test build: 1,824 jobs, warnings as errors
- Hosted style/summary checks passed; no review threads; worktree clean

## Merge order

Merge after #96 and before #98. Full chain: #91 → #92 → #93 → #94 → #95 → #96 → #97 → #98.
