### PR TITLE
refactor(interaction): split TypeTree branching classes

### DIFF
--- a/PolyFun/Interaction/Basic/TypeTreeFintype.lean
+++ b/PolyFun/Interaction/Basic/TypeTreeFintype.lean
@@ -7,36 +7,37 @@ import PolyFun.Interaction.Basic.TypeTree
 import Mathlib.Data.Fintype.Basic
 
 /-!
-# Finite-branching ornament on interaction type trees
+# Branching ornaments on interaction type trees
 
-`Interaction.TypeTree.Fintype spec` is the recursive typeclass-level ornament
-asserting that every move space appearing in `spec : TypeTree.{0}` carries
-`Fintype` and `Nonempty` instances.
+`Interaction.TypeTree.Fintype tree` and `Interaction.TypeTree.Nonempty tree`
+are recursive typeclass-level ornaments asserting, respectively, that every
+move space in `tree` is finite or nonempty.
 
-This is the tree-shaped analog of `OracleSpec.Fintype extends PFunctor.Fintype`:
-`OracleSpec` has one layer of positions (a single polynomial functor), so a
-single `PFunctor.Fintype` witness suffices. `TypeTree` is a tree of nodes, so the
-ornament recurses into every subtree.
+Keeping the properties separate follows `PFunctor.Fintype` and
+`OracleSpec.Fintype`: finiteness does not imply that a move is available.
+`TypeTree` has many layers of positions, so each ornament recurses into every
+subtree.
 
-A `TypeTree.Fintype spec` instance is the data needed to derive a canonical
-uniform sampler `TypeTree.Sampler.uniform : Sampler ProbComp spec` built by
-uniform selection at each node (see `PolyFun.Interaction.UC.Runtime`).
+Together, `TypeTree.Fintype tree` and `TypeTree.Nonempty tree` provide the
+assumptions needed by downstream uniform samplers. PolyFun itself remains
+independent of any probability monad.
 -/
+
+universe u
 
 namespace Interaction
 
 /-- Recursive finite-branching ornament on an interaction type tree.
 
-The `.done` case holds vacuously. At a `.node X rest` the ornament
-bundles `Fintype` and `Nonempty` witnesses for the move space `X`
-together with a per-branch ornament on every continuation `rest x`.
-Typeclass synthesis builds these up structurally from concrete `spec`
-trees via the companion instances below, the same way
+The `.done` case holds vacuously. At a `.node X rest`, the ornament
+stores a `Fintype X` witness together with a per-branch ornament on every
+continuation `rest x`. Typeclass synthesis builds these structurally from
+concrete trees via the companion instances below, the same way
 `OracleSpec.Fintype` synthesizes from `PFunctor.Fintype`. -/
-protected class inductive TypeTree.Fintype : TypeTree.{0} → Type 1 where
+protected class inductive TypeTree.Fintype : TypeTree.{u} → Type (u + 1) where
   | done : TypeTree.Fintype TypeTree.done
-  | node {X : Type} (hFin : Fintype X) (hNon : Nonempty X)
-      {rest : X → TypeTree.{0}} (hRec : ∀ x, TypeTree.Fintype (rest x)) :
+  | node {X : Type u} (hFin : Fintype X)
+      {rest : X → TypeTree.{u}} (hRec : ∀ x, TypeTree.Fintype (rest x)) :
       TypeTree.Fintype (TypeTree.node X rest)
 
 namespace TypeTree.Fintype
@@ -45,32 +46,64 @@ namespace TypeTree.Fintype
 instance instDone : TypeTree.Fintype TypeTree.done := .done
 
 /-- Canonical `TypeTree.Fintype` instance for a node: synthesizes from
-`Fintype X`, `Nonempty X`, and a per-branch ornament. -/
-instance instNode {X : Type} [hFin : Fintype X] [hNon : Nonempty X]
-    {rest : X → TypeTree.{0}} [hRec : ∀ x, TypeTree.Fintype (rest x)] :
+`Fintype X` and a per-branch ornament. -/
+instance instNode {X : Type u} [hFin : Fintype X]
+    {rest : X → TypeTree.{u}} [hRec : ∀ x, TypeTree.Fintype (rest x)] :
     TypeTree.Fintype (TypeTree.node X rest) :=
-  .node hFin hNon hRec
+  .node hFin hRec
 
 /-- Extract the `Fintype` instance for the move space of the root node. -/
 @[reducible]
-def rootFintype {X : Type} {rest : X → TypeTree.{0}}
+def rootFintype {X : Type u} {rest : X → TypeTree.{u}}
     (h : TypeTree.Fintype (TypeTree.node X rest)) : Fintype X :=
   match h with
-  | .node hFin _ _ => hFin
-
-/-- Extract the `Nonempty` instance for the move space of the root node. -/
-theorem rootNonempty {X : Type} {rest : X → TypeTree.{0}}
-    (h : TypeTree.Fintype (TypeTree.node X rest)) : Nonempty X :=
-  match h with
-  | .node _ hNon _ => hNon
+  | .node hFin _ => hFin
 
 /-- Extract the ornament for every continuation of the root node. -/
 @[reducible]
-def tail {X : Type} {rest : X → TypeTree.{0}}
+def rest {X : Type u} {rest : X → TypeTree.{u}}
     (h : TypeTree.Fintype (TypeTree.node X rest)) : ∀ x, TypeTree.Fintype (rest x) :=
   match h with
-  | .node _ _ hRec => hRec
+  | .node _ hRec => hRec
 
 end TypeTree.Fintype
+
+/-- Recursive nonempty-branching ornament on an interaction type tree.
+
+The `.done` case holds vacuously. At a `.node X rest`, the ornament stores a
+`Nonempty X` witness and recursively requires every continuation to be
+nonempty-branching. This is separate from `TypeTree.Fintype`: a finite move
+space may be empty. -/
+protected class inductive TypeTree.Nonempty : TypeTree.{u} → Prop where
+  | done : TypeTree.Nonempty TypeTree.done
+  | node {X : Type u} (hNonempty : Nonempty X)
+      {rest : X → TypeTree.{u}} (hRec : ∀ x, TypeTree.Nonempty (rest x)) :
+      TypeTree.Nonempty (TypeTree.node X rest)
+
+namespace TypeTree.Nonempty
+
+/-- Canonical `TypeTree.Nonempty` instance for the terminal tree. -/
+instance instDone : TypeTree.Nonempty TypeTree.done := .done
+
+/-- Canonical `TypeTree.Nonempty` instance for a node: synthesizes from
+`Nonempty X` and a per-branch ornament. -/
+instance instNode {X : Type u} [hNonempty : Nonempty X]
+    {rest : X → TypeTree.{u}} [hRec : ∀ x, TypeTree.Nonempty (rest x)] :
+    TypeTree.Nonempty (TypeTree.node X rest) :=
+  .node hNonempty hRec
+
+/-- Extract the `Nonempty` instance for the move space of the root node. -/
+theorem rootNonempty {X : Type u} {rest : X → TypeTree.{u}}
+    (h : TypeTree.Nonempty (TypeTree.node X rest)) : Nonempty X :=
+  match h with
+  | .node hNonempty _ => hNonempty
+
+/-- Extract the ornament for every continuation of the root node. -/
+theorem rest {X : Type u} {rest : X → TypeTree.{u}}
+    (h : TypeTree.Nonempty (TypeTree.node X rest)) : ∀ x, TypeTree.Nonempty (rest x) :=
+  match h with
+  | .node _ hRec => hRec
+
+end TypeTree.Nonempty
 
 end Interaction

--- a/PolyFunTest/Interaction/Basic/FoundationNormalization.lean
+++ b/PolyFunTest/Interaction/Basic/FoundationNormalization.lean
@@ -5,6 +5,7 @@ Authors: Quang Dao
 -/
 import PolyFun.Interaction.Basic.Chain
 import PolyFun.Interaction.Basic.Telescope
+import PolyFun.Interaction.Basic.TypeTreeFintype
 
 /-!
 # Polynomial normalization regression tests
@@ -15,6 +16,23 @@ canonical polynomial structures used by their implementations.
 
 namespace Interaction
 namespace TypeTree
+
+/-! ## Branching properties remain separate and universe-polymorphic -/
+
+private abbrev FiniteEmptyTree : TypeTree := .node Empty fun x => nomatch x
+
+example : TypeTree.Fintype FiniteEmptyTree :=
+  .node inferInstance fun x => nomatch x
+
+example : ¬ TypeTree.Nonempty FiniteEmptyTree := by
+  intro h
+  exact h.rootNonempty.elim fun x => nomatch x
+
+private abbrev HigherTree : TypeTree.{1} := .node (ULift (Fin 2)) fun _ => .done
+
+example : TypeTree.Fintype HigherTree := inferInstance
+
+example : TypeTree.Nonempty HigherTree := inferInstance
 
 /-! ## Type trees are the free substitution monoid -/
 

--- a/docs/wiki/interaction.md
+++ b/docs/wiki/interaction.md
@@ -514,9 +514,11 @@ consequences:
 
 `TypeTree.Fintype` in
 [`PolyFun/Interaction/Basic/TypeTreeFintype.lean`](../../PolyFun/Interaction/Basic/TypeTreeFintype.lean)
-is the per-tree ornament (recursive `Fintype` + `Nonempty` for every
-move type) that lets users recover canonical uniform samplers
-(`Sampler.uniformI`) without writing one by hand.
+is the recursive finiteness ornament for every move type;
+`TypeTree.Nonempty` independently records that every move type is nonempty.
+Downstream uniform samplers require both properties. Keeping them separate
+matches `PFunctor.Fintype` and does not treat finite branching as evidence that
+a move is available.
 
 PolyFun deliberately stops here: anything that requires a probability
 monad (e.g. `processSemanticsProbComp`), an oracle simulation
@@ -575,8 +577,8 @@ import PolyFun.Interaction.UC.OpenProcessModel
 | `Ownership.lean` | `LocalView` / `LocalRunner` builders for `SyntaxOver` |
 | `MonadDecoration.lean` | `MonadDecoration`, `Strategy.withMonads`, `runWithMonads` |
 | `BundledMonad.lean` | `BundledMonad` (monad packaged for inductive data) |
-| `Sampler.lean` | `TypeTree.Sampler m spec := Decoration (fun X => m X) spec`, `samplePath`, `Sampler.interleave`, `Sampler.uniformI` |
-| `TypeTreeFintype.lean` | `TypeTree.Fintype` per-tree ornament; enables canonical `Sampler.uniformI` |
+| `Sampler.lean` | `TypeTree.Sampler m tree := Decoration (fun X => m X) tree`, `samplePath`, `Sampler.interleave` |
+| `TypeTreeFintype.lean` | Universe-polymorphic `TypeTree.Fintype` and `TypeTree.Nonempty` branching ornaments |
 
 ### `TwoParty/`
 


### PR DESCRIPTION
## Summary

- make `TypeTree.Fintype` mean recursive finiteness only, matching `PFunctor.Fintype` and `OracleSpec.Fintype`
- add a separate recursive `TypeTree.Nonempty` ornament for move availability
- generalize both classes from universe `0` to arbitrary universes
- rename the recursive accessor from `tail` to `rest`, matching `TypeTree.node ... rest`
- add regression canaries for finite-but-empty branching and higher-universe trees
- correct the interaction guide's uniform-sampler boundary

## Why

The existing `TypeTree.Fintype` bundled both `Fintype` and `Nonempty`. That made its name stronger than the analogous `PFunctor.Fintype` and `OracleSpec.Fintype`, and incorrectly made finite branching imply that a move is available. Uniform sampling needs both properties, but they are logically independent and should be stated separately.

This is a source-level API change for downstream uniform samplers: they should require both `TypeTree.Fintype tree` and `TypeTree.Nonempty tree`.

## Validation

- `./scripts/validate.sh --lint --test`
- full library build with warnings as errors
- environment lint
- full `PolyFunTest` build
- import and documentation integrity checks