### PR TITLE
Add generic handler normalization simp set

### DIFF
--- a/PolyFun.lean
+++ b/PolyFun.lean
@@ -191,6 +191,8 @@ import PolyFun.PFunctor.Free.Resumption
 import PolyFun.PFunctor.Free.Universal
 import PolyFun.PFunctor.Handler
 import PolyFun.PFunctor.Handler.Free
+import PolyFun.PFunctor.Handler.Normalization
+import PolyFun.PFunctor.Handler.Normalization.Attr
 import PolyFun.PFunctor.Handler.Stateful
 import PolyFun.PFunctor.InternalHom
 import PolyFun.PFunctor.Lens.Basic

--- a/PolyFun/PFunctor/Handler/Normalization.lean
+++ b/PolyFun/PFunctor/Handler/Normalization.lean
@@ -1,0 +1,47 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+
+public import Mathlib.Control.Monad.Writer
+public import PolyFun.PFunctor.Handler.Normalization.Attr
+
+/-!
+# Handler normalization
+
+The `handler_nf` simp set exposes the next structural layer of a free or
+stateful handler computation. It unfolds `FreeM.liftM`,
+`PFunctor.Handler.Stateful.run`, and the standard `StateT` and `WriterT`
+run operations without importing a tactic framework.
+
+Use `simp only [handler_nf]` when a proof needs a stable, explicit handler
+normal form. Downstream libraries can extend the set with equations for their
+own handler combinators.
+-/
+
+@[expose] public section
+
+attribute [handler_nf]
+  PFunctor.FreeM.liftM_pure
+  PFunctor.FreeM.liftM_lift_bind
+  PFunctor.FreeM.liftM_bind
+  PFunctor.FreeM.liftM_lift
+  PFunctor.Handler.Stateful.run_pure
+  PFunctor.Handler.Stateful.run_lift
+  PFunctor.Handler.Stateful.run_liftBind
+  PFunctor.Handler.Stateful.run_bind
+  PFunctor.Handler.Stateful.reindex_apply
+  StateT.run_bind
+  StateT.run_get
+  StateT.run_set
+  StateT.run_modifyGet
+  StateT.run_pure
+  StateT.run_monadLift
+  WriterT.run_bind
+  WriterT.run_map
+  WriterT.run_liftM
+  WriterT.run_pure
+  WriterT.run_tell

--- a/PolyFun/PFunctor/Handler/Normalization/Attr.lean
+++ b/PolyFun/PFunctor/Handler/Normalization/Attr.lean
@@ -1,0 +1,21 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+
+public import PolyFun.PFunctor.Handler.Stateful
+
+/-!
+# Handler normalization attribute
+
+This module declares the `handler_nf` simp attribute. The structural handler
+rules are registered by `PolyFun.PFunctor.Handler.Normalization`.
+-/
+
+@[expose] public section
+
+/-- Simp set for structural normalization of free and stateful handlers. -/
+register_simp_attr handler_nf

--- a/PolyFunTest/PFunctor/Handler/Normalization.lean
+++ b/PolyFunTest/PFunctor/Handler/Normalization.lean
@@ -1,0 +1,65 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+
+public import PolyFun.PFunctor.Handler.Normalization
+
+/-!
+# Handler normalization examples
+
+Regression canaries for the `handler_nf` simp set. The concrete example uses
+two distinguishable answers and state updates, so swapping the answer and
+state components, choosing the wrong branch, or dropping a state update
+changes the observed result.
+-/
+
+@[expose] public section
+
+namespace PFunctor.Handler.Normalization.Examples
+
+abbrev Query : PFunctor.{0, 0} := monomial Bool Nat
+
+def answerAndAdvance : Handler.Stateful Option Nat Query :=
+  fun query state =>
+    Bool.rec (some (state + 20, state + 2))
+      (some (state + 10, state + 1)) query
+
+def twoQueries : FreeM Query (Nat × Nat) :=
+  FreeM.liftBind true fun first =>
+    FreeM.liftBind false fun second =>
+      pure (first, second)
+
+/-- `handler_nf` normalizes nested free-handler execution through the base
+effect while preserving branch selection and state handoff. -/
+example : answerAndAdvance.run twoQueries 3 = some ((13, 24), 6) := by
+  simp only [handler_nf, twoQueries]
+  rfl
+
+/-- The direct `liftBind` and derived `bind` normalization paths agree. -/
+example {m : Type → Type} [Monad m] [LawfulMonad m] {S α : Type}
+    (h : Handler.Stateful m S Query)
+    (query : Bool) (next : Nat → FreeM Query α) (state : S) :
+    h.run (FreeM.lift query >>= next) state =
+      (h query).run state >>= fun result => h.run (next result.1) result.2 := by
+  simp only [handler_nf]
+
+/-- Transformer run equations are part of the same explicit normal form. -/
+example {m : Type → Type} [Monad m] {S α β : Type} (x : StateT S m α)
+    (next : α → StateT S m β) (state : S) :
+    (x >>= next).run state =
+      x.run state >>= fun result => (next result.1).run result.2 := by
+  simp only [handler_nf]
+
+example {m : Type → Type} {α β ω : Type} [Monad m] [Monoid ω]
+    (x : WriterT ω m α)
+    (next : α → WriterT ω m β) :
+    (x >>= next).run =
+      x.run >>= fun result =>
+        (fun output => (output.1, result.2 * output.2)) <$> (next result.1).run := by
+  simp only [handler_nf]
+
+end PFunctor.Handler.Normalization.Examples

--- a/docs/wiki/repo-map.md
+++ b/docs/wiki/repo-map.md
@@ -48,6 +48,8 @@ PFunctor/Display/Basic
   -> PFunctor/Display/{Chart, Coalgebra, Indexed, Free}
 IPFunctor/M + PFunctor/Display/Indexed -> PFunctor/Display/M
 PFunctor/{Handler, Free/Basic} -> PFunctor/Handler/Free
+  -> PFunctor/Handler/Stateful -> PFunctor/Handler/Normalization/Attr
+  -> PFunctor/Handler/Normalization
 PFunctor/{Display/Free, Handler/Free}
   -> PFunctor/Display/Handler -> PFunctor/Display/Handler/Sigma
   -> PFunctor/Wiring


### PR DESCRIPTION
## Summary

- add a curated `handler_nf` simp set for generic `FreeM` interpretation and `PFunctor.Handler.Stateful.run`
- include the standard `StateT` and `WriterT` run equations needed to expose handler computations
- add producer-level regression canaries for nested stateful execution, FreeM bind normalization, and transformer run shapes
- register the new modules in the generated umbrella and repository dependency map

## Why

VCVio currently combines generic FreeM/handler normalization equations with probability- and oracle-specific rules. The generic equations are owned by PolyFun because they depend only on polynomial free monads, stateful handlers, and ordinary monad transformers. A named simp set lets downstream libraries extend this normalization surface without moving their domain-specific semantics or importing a tactic framework into PolyFun.

The intended normal form removes leading FreeM constructors and transformer operations until calls to the supplied handler and base monad are visible. The PR deliberately adds no tactic syntax and no probability, Loom, or VCVio dependency.

## Validation

- `lake build PolyFun.PFunctor.Handler.Normalization PolyFunTest.PFunctor.Handler.Normalization`
- `./scripts/validate.sh --lint --test`
- `lake exe lint-style`
- generated umbrella import check
- documentation integrity check
- `git diff --check`
