### PR TITLE
refactor: migrate Interaction to Lean module scopes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,13 @@ Update that map when a change adds a module or changes an import boundary.
 New files must respect the documented DAG. Re-exports through
 `PolyFun.lean` are auto-generated; do not hand-edit.
 
+All Lean sources use module mode. In production files, make the intended API
+explicit with `public section` and expose individual reducer bodies only when
+downstream definitional equality needs them. Use `public import` for public
+signature dependencies, plain `import` for implementation details, and
+`import all` for proof modules that need opaque bodies. Broad
+`@[expose] public section` scopes are forbidden in `PolyFun/Interaction/`.
+
 ## Attribution, Headers, And Docstrings
 
 Follow [`CONTRIBUTING.md`](CONTRIBUTING.md) for the repo's explicit
@@ -113,7 +120,8 @@ attribution policy.
 - New Lean files should use the standard copyright / license /
   authors header and a module docstring.
 - For ordinary Lean source files, use the standard prologue layout:
-  header, blank line, imports, blank line, module docstring.
+  header, blank line, `module`, blank line, imports, blank line, module
+  docstring.
 - Docstrings must be intrinsic and descriptive. Cross-reference live
   sibling definitions when helpful, but do not mention removed or
   renamed declarations, change history, or reactive wording such as

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,11 +115,32 @@ When in doubt, prefer:
 - For ordinary Lean source files, use this prologue layout:
   1. copyright / license / authors header
   2. one blank line
-  3. imports
+  3. the `module` command
   4. one blank line
-  5. module docstring
+  5. imports
+  6. one blank line
+  7. module docstring
 
   Keep exactly one blank line between these blocks.
+
+## Module Scopes And Public APIs
+
+Every tracked Lean source in `PolyFun/` and `PolyFunTest/` uses module mode.
+Production modules normally place their exported declarations in a
+`public section`. Test and worked-example modules normally use
+`@[expose] public section`: their definitional regression checks intentionally
+normalize local fixtures, while remaining outside the production library.
+
+- Use `public import` only when declarations from the imported module occur in
+  this module's public signatures or are intentionally re-exported.
+- Use plain `import` for implementation-only dependencies.
+- Use `import all` before the corresponding regular or public import when
+  proofs need opaque declaration bodies from another module.
+- Prefer `@[expose]` on individual definitions whose reduction is part of the
+  public API. Do not use `@[expose] public section` in `PolyFun/Interaction/`.
+
+Run `./scripts/check-modules.sh` after changing module scopes. The full
+validation wrapper runs this check automatically.
 
 ### Section Headers Within A File
 

--- a/PolyFun.lean
+++ b/PolyFun.lean
@@ -1,223 +1,225 @@
-import PolyFun.Control.Bisimulation
-import PolyFun.Control.Coalgebra
-import PolyFun.Control.Comonad.Basic
-import PolyFun.Control.Comonad.Instances
-import PolyFun.Control.LTS.Trace
-import PolyFun.Control.Lawful.Basic
-import PolyFun.Control.Monad.Algebra
-import PolyFun.Control.Monad.Equiv
-import PolyFun.Control.Monad.Free
-import PolyFun.Control.Monad.FreeCont
-import PolyFun.Control.Monad.Hom
-import PolyFun.Control.Monad.Indexed
-import PolyFun.Control.Monad.Iter
-import PolyFun.Control.Trace
-import PolyFun.IPFunctor.Basic
-import PolyFun.IPFunctor.Chart.Basic
-import PolyFun.IPFunctor.Equiv.Basic
-import PolyFun.IPFunctor.Free.Basic
-import PolyFun.IPFunctor.Free.Family
-import PolyFun.IPFunctor.Free.Indexed
-import PolyFun.IPFunctor.Lens.Basic
-import PolyFun.IPFunctor.M
-import PolyFun.IPFunctor.Notation
-import PolyFun.IPFunctor.Notation.Common
-import PolyFun.IPFunctor.Notation.Deterministic
-import PolyFun.IPFunctor.Notation.Indexed
-import PolyFun.ITree.Basic
-import PolyFun.ITree.Bisim.Bind
-import PolyFun.ITree.Bisim.CrossSignature
-import PolyFun.ITree.Bisim.Defs
-import PolyFun.ITree.Bisim.Equiv
-import PolyFun.ITree.Bisim.Iter
-import PolyFun.ITree.Construct
-import PolyFun.ITree.Do
-import PolyFun.ITree.Events.Exception
-import PolyFun.ITree.Events.ExceptionFacts
-import PolyFun.ITree.Events.State
-import PolyFun.ITree.Events.StateFacts
-import PolyFun.ITree.Handler
-import PolyFun.ITree.Rec
-import PolyFun.ITree.Rec.Facts
-import PolyFun.ITree.Resumption
-import PolyFun.ITree.Sim.CrossSignature
-import PolyFun.ITree.Sim.Defs
-import PolyFun.ITree.Sim.Facts
-import PolyFun.ITree.Trace
-import PolyFun.ITree.Unfold
-import PolyFun.Interaction.Basic.Append
-import PolyFun.Interaction.Basic.BundledMonad
-import PolyFun.Interaction.Basic.Chain
-import PolyFun.Interaction.Basic.Chain.Append
-import PolyFun.Interaction.Basic.Decoration
-import PolyFun.Interaction.Basic.Interaction
-import PolyFun.Interaction.Basic.MonadDecoration
-import PolyFun.Interaction.Basic.Node
-import PolyFun.Interaction.Basic.Ownership
-import PolyFun.Interaction.Basic.Replicate
-import PolyFun.Interaction.Basic.Sampler
-import PolyFun.Interaction.Basic.Shape
-import PolyFun.Interaction.Basic.StateChain
-import PolyFun.Interaction.Basic.Strategy
-import PolyFun.Interaction.Basic.StrategyOver
-import PolyFun.Interaction.Basic.Syntax
-import PolyFun.Interaction.Basic.Telescope
-import PolyFun.Interaction.Basic.TypeTree
-import PolyFun.Interaction.Basic.TypeTreeFintype
-import PolyFun.Interaction.Concurrent.Control
-import PolyFun.Interaction.Concurrent.Current
-import PolyFun.Interaction.Concurrent.Equivalence
-import PolyFun.Interaction.Concurrent.Execution
-import PolyFun.Interaction.Concurrent.Fairness
-import PolyFun.Interaction.Concurrent.Frontier
-import PolyFun.Interaction.Concurrent.Independence
-import PolyFun.Interaction.Concurrent.Interleaving
-import PolyFun.Interaction.Concurrent.Liveness
-import PolyFun.Interaction.Concurrent.Machine
-import PolyFun.Interaction.Concurrent.MutualSafetyRefinement
-import PolyFun.Interaction.Concurrent.Observation
-import PolyFun.Interaction.Concurrent.Policy
-import PolyFun.Interaction.Concurrent.Process
-import PolyFun.Interaction.Concurrent.Profile
-import PolyFun.Interaction.Concurrent.Refinement
-import PolyFun.Interaction.Concurrent.Run
-import PolyFun.Interaction.Concurrent.Spec
-import PolyFun.Interaction.Concurrent.Trace
-import PolyFun.Interaction.Concurrent.Tree
-import PolyFun.Interaction.Multiparty.Broadcast
-import PolyFun.Interaction.Multiparty.Core
-import PolyFun.Interaction.Multiparty.Directed
-import PolyFun.Interaction.Multiparty.Observation
-import PolyFun.Interaction.Multiparty.ObservationProfile
-import PolyFun.Interaction.Multiparty.Profile
-import PolyFun.Interaction.TwoParty.Compose
-import PolyFun.Interaction.TwoParty.Decoration
-import PolyFun.Interaction.TwoParty.Refine
-import PolyFun.Interaction.TwoParty.Role
-import PolyFun.Interaction.TwoParty.Strategy
-import PolyFun.Interaction.TwoParty.Swap
-import PolyFun.Interaction.TwoParty.Syntax
-import PolyFun.Interaction.UC.CorruptionModel
-import PolyFun.Interaction.UC.Emulates
-import PolyFun.Interaction.UC.EnvAction
-import PolyFun.Interaction.UC.EnvOpenProcess
-import PolyFun.Interaction.UC.Interface
-import PolyFun.Interaction.UC.Leakage
-import PolyFun.Interaction.UC.MachineId
-import PolyFun.Interaction.UC.MomentaryCorruption
-import PolyFun.Interaction.UC.Notation
-import PolyFun.Interaction.UC.OpenProcess
-import PolyFun.Interaction.UC.OpenProcessModel
-import PolyFun.Interaction.UC.OpenSyntax.Expr
-import PolyFun.Interaction.UC.OpenSyntax.Interp
-import PolyFun.Interaction.UC.OpenSyntax.Raw
-import PolyFun.Interaction.UC.OpenTheory
-import PolyFun.Logic.HEq
-import PolyFun.PFunctor.Adjunctions
-import PolyFun.PFunctor.Basic
-import PolyFun.PFunctor.Bound
-import PolyFun.PFunctor.CartesianClosed
-import PolyFun.PFunctor.Category
-import PolyFun.PFunctor.Chart.Basic
-import PolyFun.PFunctor.Cofree
-import PolyFun.PFunctor.Cofree.FiniteProjection
-import PolyFun.PFunctor.Cofree.LaxMonoidal
-import PolyFun.PFunctor.Cofree.Polynomial
-import PolyFun.PFunctor.Cofree.Universal
-import PolyFun.PFunctor.Comonoid
-import PolyFun.PFunctor.Comonoid.Category
-import PolyFun.PFunctor.Comonoid.Tensor
-import PolyFun.PFunctor.Display
-import PolyFun.PFunctor.Display.Basic
-import PolyFun.PFunctor.Display.Category
-import PolyFun.PFunctor.Display.Chart
-import PolyFun.PFunctor.Display.Coalgebra
-import PolyFun.PFunctor.Display.Free
-import PolyFun.PFunctor.Display.Handler
-import PolyFun.PFunctor.Display.Handler.Sigma
-import PolyFun.PFunctor.Display.Indexed
-import PolyFun.PFunctor.Display.Lens
-import PolyFun.PFunctor.Display.M
-import PolyFun.PFunctor.Display.Parallel
-import PolyFun.PFunctor.Display.Parallel.Free
-import PolyFun.PFunctor.Display.Parallel.Lens
-import PolyFun.PFunctor.Dynamical.Basic
-import PolyFun.PFunctor.Dynamical.Behavior
-import PolyFun.PFunctor.Dynamical.Bisimulation
-import PolyFun.PFunctor.Dynamical.CofreeMate
-import PolyFun.PFunctor.Dynamical.CofreeMate.FiniteProjection
-import PolyFun.PFunctor.Dynamical.Combinators
-import PolyFun.PFunctor.Dynamical.DynComputation
-import PolyFun.PFunctor.Dynamical.DynComputation.Bounded
-import PolyFun.PFunctor.Dynamical.DynComputation.Termination
-import PolyFun.PFunctor.Dynamical.Game
-import PolyFun.PFunctor.Dynamical.Refinement
-import PolyFun.PFunctor.Dynamical.Responder
-import PolyFun.PFunctor.Dynamical.Responder.Behavior
-import PolyFun.PFunctor.Dynamical.Responder.Display
-import PolyFun.PFunctor.Dynamical.Responder.Lens
-import PolyFun.PFunctor.Dynamical.Responder.Parallel
-import PolyFun.PFunctor.Dynamical.Responder.Parallel.Behavior
-import PolyFun.PFunctor.Dynamical.Responder.Parallel.Coherence
-import PolyFun.PFunctor.Dynamical.Responder.Parallel.Compatibility
-import PolyFun.PFunctor.Dynamical.Responder.Parallel.Display
-import PolyFun.PFunctor.Dynamical.Responder.Parallel.DisplayedAssociativity
-import PolyFun.PFunctor.Dynamical.Responder.Parallel.DisplayedCoherence
-import PolyFun.PFunctor.Dynamical.Responder.Parallel.Presentation
-import PolyFun.PFunctor.Dynamical.Responder.Presentation
-import PolyFun.PFunctor.Dynamical.Responder.Reindex
-import PolyFun.PFunctor.Dynamical.Run
-import PolyFun.PFunctor.Dynamical.RunN
-import PolyFun.PFunctor.Dynamical.Safety
-import PolyFun.PFunctor.Dynamical.Simulation
-import PolyFun.PFunctor.Dynamical.Trajectory
-import PolyFun.PFunctor.Equiv.Basic
-import PolyFun.PFunctor.Free.Basic
-import PolyFun.PFunctor.Free.Cursor
-import PolyFun.PFunctor.Free.Cursor.Append
-import PolyFun.PFunctor.Free.Cursor.Fork
-import PolyFun.PFunctor.Free.Cursor.Occurrence
-import PolyFun.PFunctor.Free.Displayed
-import PolyFun.PFunctor.Free.Displayed.Append
-import PolyFun.PFunctor.Free.Displayed.Cursor
-import PolyFun.PFunctor.Free.Displayed.Decoration
-import PolyFun.PFunctor.Free.Displayed.StateChain
-import PolyFun.PFunctor.Free.Parallel
-import PolyFun.PFunctor.Free.Path
-import PolyFun.PFunctor.Free.Path.Execution
-import PolyFun.PFunctor.Free.Polynomial
-import PolyFun.PFunctor.Free.Replicate
-import PolyFun.PFunctor.Free.Resumption
-import PolyFun.PFunctor.Free.Universal
-import PolyFun.PFunctor.Handler
-import PolyFun.PFunctor.Handler.Free
-import PolyFun.PFunctor.Handler.Normalization
-import PolyFun.PFunctor.Handler.Normalization.Attr
-import PolyFun.PFunctor.Handler.Stateful
-import PolyFun.PFunctor.InternalHom
-import PolyFun.PFunctor.Lens.Basic
-import PolyFun.PFunctor.Lens.Cartesian
-import PolyFun.PFunctor.Lens.Composite
-import PolyFun.PFunctor.Lens.Distributivity
-import PolyFun.PFunctor.Lens.Duoidal
-import PolyFun.PFunctor.Lens.Factorization
-import PolyFun.PFunctor.Lens.State
-import PolyFun.PFunctor.M
-import PolyFun.PFunctor.M.Vertex
-import PolyFun.PFunctor.Parallel
-import PolyFun.PFunctor.PatternRunsOnMatter.Applications
-import PolyFun.PFunctor.PatternRunsOnMatter.Basic
-import PolyFun.PFunctor.PatternRunsOnMatter.Display
-import PolyFun.PFunctor.PatternRunsOnMatter.Dynamical
-import PolyFun.PFunctor.PatternRunsOnMatter.Module
-import PolyFun.PFunctor.PatternRunsOnMatter.Operational
-import PolyFun.PFunctor.PatternRunsOnMatter.Parallel
-import PolyFun.PFunctor.PatternRunsOnMatter.Universal
-import PolyFun.PFunctor.Resumption
-import PolyFun.PFunctor.Resumption.Truncate
-import PolyFun.PFunctor.SubstMonoid
-import PolyFun.PFunctor.SubstMonoid.Convolution
-import PolyFun.PFunctor.SubstMonoid.Extension
-import PolyFun.PFunctor.Trace
-import PolyFun.PFunctor.Wiring
-import PolyFun.PFunctor.Wiring.Parallel
+module
+
+public import PolyFun.Control.Bisimulation
+public import PolyFun.Control.Coalgebra
+public import PolyFun.Control.Comonad.Basic
+public import PolyFun.Control.Comonad.Instances
+public import PolyFun.Control.LTS.Trace
+public import PolyFun.Control.Lawful.Basic
+public import PolyFun.Control.Monad.Algebra
+public import PolyFun.Control.Monad.Equiv
+public import PolyFun.Control.Monad.Free
+public import PolyFun.Control.Monad.FreeCont
+public import PolyFun.Control.Monad.Hom
+public import PolyFun.Control.Monad.Indexed
+public import PolyFun.Control.Monad.Iter
+public import PolyFun.Control.Trace
+public import PolyFun.IPFunctor.Basic
+public import PolyFun.IPFunctor.Chart.Basic
+public import PolyFun.IPFunctor.Equiv.Basic
+public import PolyFun.IPFunctor.Free.Basic
+public import PolyFun.IPFunctor.Free.Family
+public import PolyFun.IPFunctor.Free.Indexed
+public import PolyFun.IPFunctor.Lens.Basic
+public import PolyFun.IPFunctor.M
+public import PolyFun.IPFunctor.Notation
+public import PolyFun.IPFunctor.Notation.Common
+public import PolyFun.IPFunctor.Notation.Deterministic
+public import PolyFun.IPFunctor.Notation.Indexed
+public import PolyFun.ITree.Basic
+public import PolyFun.ITree.Bisim.Bind
+public import PolyFun.ITree.Bisim.CrossSignature
+public import PolyFun.ITree.Bisim.Defs
+public import PolyFun.ITree.Bisim.Equiv
+public import PolyFun.ITree.Bisim.Iter
+public import PolyFun.ITree.Construct
+public import PolyFun.ITree.Do
+public import PolyFun.ITree.Events.Exception
+public import PolyFun.ITree.Events.ExceptionFacts
+public import PolyFun.ITree.Events.State
+public import PolyFun.ITree.Events.StateFacts
+public import PolyFun.ITree.Handler
+public import PolyFun.ITree.Rec
+public import PolyFun.ITree.Rec.Facts
+public import PolyFun.ITree.Resumption
+public import PolyFun.ITree.Sim.CrossSignature
+public import PolyFun.ITree.Sim.Defs
+public import PolyFun.ITree.Sim.Facts
+public import PolyFun.ITree.Trace
+public import PolyFun.ITree.Unfold
+public import PolyFun.Interaction.Basic.Append
+public import PolyFun.Interaction.Basic.BundledMonad
+public import PolyFun.Interaction.Basic.Chain
+public import PolyFun.Interaction.Basic.Chain.Append
+public import PolyFun.Interaction.Basic.Decoration
+public import PolyFun.Interaction.Basic.Interaction
+public import PolyFun.Interaction.Basic.MonadDecoration
+public import PolyFun.Interaction.Basic.Node
+public import PolyFun.Interaction.Basic.Ownership
+public import PolyFun.Interaction.Basic.Replicate
+public import PolyFun.Interaction.Basic.Sampler
+public import PolyFun.Interaction.Basic.Shape
+public import PolyFun.Interaction.Basic.StateChain
+public import PolyFun.Interaction.Basic.Strategy
+public import PolyFun.Interaction.Basic.StrategyOver
+public import PolyFun.Interaction.Basic.Syntax
+public import PolyFun.Interaction.Basic.Telescope
+public import PolyFun.Interaction.Basic.TypeTree
+public import PolyFun.Interaction.Basic.TypeTreeFintype
+public import PolyFun.Interaction.Concurrent.Control
+public import PolyFun.Interaction.Concurrent.Current
+public import PolyFun.Interaction.Concurrent.Equivalence
+public import PolyFun.Interaction.Concurrent.Execution
+public import PolyFun.Interaction.Concurrent.Fairness
+public import PolyFun.Interaction.Concurrent.Frontier
+public import PolyFun.Interaction.Concurrent.Independence
+public import PolyFun.Interaction.Concurrent.Interleaving
+public import PolyFun.Interaction.Concurrent.Liveness
+public import PolyFun.Interaction.Concurrent.Machine
+public import PolyFun.Interaction.Concurrent.MutualSafetyRefinement
+public import PolyFun.Interaction.Concurrent.Observation
+public import PolyFun.Interaction.Concurrent.Policy
+public import PolyFun.Interaction.Concurrent.Process
+public import PolyFun.Interaction.Concurrent.Profile
+public import PolyFun.Interaction.Concurrent.Refinement
+public import PolyFun.Interaction.Concurrent.Run
+public import PolyFun.Interaction.Concurrent.Spec
+public import PolyFun.Interaction.Concurrent.Trace
+public import PolyFun.Interaction.Concurrent.Tree
+public import PolyFun.Interaction.Multiparty.Broadcast
+public import PolyFun.Interaction.Multiparty.Core
+public import PolyFun.Interaction.Multiparty.Directed
+public import PolyFun.Interaction.Multiparty.Observation
+public import PolyFun.Interaction.Multiparty.ObservationProfile
+public import PolyFun.Interaction.Multiparty.Profile
+public import PolyFun.Interaction.TwoParty.Compose
+public import PolyFun.Interaction.TwoParty.Decoration
+public import PolyFun.Interaction.TwoParty.Refine
+public import PolyFun.Interaction.TwoParty.Role
+public import PolyFun.Interaction.TwoParty.Strategy
+public import PolyFun.Interaction.TwoParty.Swap
+public import PolyFun.Interaction.TwoParty.Syntax
+public import PolyFun.Interaction.UC.CorruptionModel
+public import PolyFun.Interaction.UC.Emulates
+public import PolyFun.Interaction.UC.EnvAction
+public import PolyFun.Interaction.UC.EnvOpenProcess
+public import PolyFun.Interaction.UC.Interface
+public import PolyFun.Interaction.UC.Leakage
+public import PolyFun.Interaction.UC.MachineId
+public import PolyFun.Interaction.UC.MomentaryCorruption
+public import PolyFun.Interaction.UC.Notation
+public import PolyFun.Interaction.UC.OpenProcess
+public import PolyFun.Interaction.UC.OpenProcessModel
+public import PolyFun.Interaction.UC.OpenSyntax.Expr
+public import PolyFun.Interaction.UC.OpenSyntax.Interp
+public import PolyFun.Interaction.UC.OpenSyntax.Raw
+public import PolyFun.Interaction.UC.OpenTheory
+public import PolyFun.Logic.HEq
+public import PolyFun.PFunctor.Adjunctions
+public import PolyFun.PFunctor.Basic
+public import PolyFun.PFunctor.Bound
+public import PolyFun.PFunctor.CartesianClosed
+public import PolyFun.PFunctor.Category
+public import PolyFun.PFunctor.Chart.Basic
+public import PolyFun.PFunctor.Cofree
+public import PolyFun.PFunctor.Cofree.FiniteProjection
+public import PolyFun.PFunctor.Cofree.LaxMonoidal
+public import PolyFun.PFunctor.Cofree.Polynomial
+public import PolyFun.PFunctor.Cofree.Universal
+public import PolyFun.PFunctor.Comonoid
+public import PolyFun.PFunctor.Comonoid.Category
+public import PolyFun.PFunctor.Comonoid.Tensor
+public import PolyFun.PFunctor.Display
+public import PolyFun.PFunctor.Display.Basic
+public import PolyFun.PFunctor.Display.Category
+public import PolyFun.PFunctor.Display.Chart
+public import PolyFun.PFunctor.Display.Coalgebra
+public import PolyFun.PFunctor.Display.Free
+public import PolyFun.PFunctor.Display.Handler
+public import PolyFun.PFunctor.Display.Handler.Sigma
+public import PolyFun.PFunctor.Display.Indexed
+public import PolyFun.PFunctor.Display.Lens
+public import PolyFun.PFunctor.Display.M
+public import PolyFun.PFunctor.Display.Parallel
+public import PolyFun.PFunctor.Display.Parallel.Free
+public import PolyFun.PFunctor.Display.Parallel.Lens
+public import PolyFun.PFunctor.Dynamical.Basic
+public import PolyFun.PFunctor.Dynamical.Behavior
+public import PolyFun.PFunctor.Dynamical.Bisimulation
+public import PolyFun.PFunctor.Dynamical.CofreeMate
+public import PolyFun.PFunctor.Dynamical.CofreeMate.FiniteProjection
+public import PolyFun.PFunctor.Dynamical.Combinators
+public import PolyFun.PFunctor.Dynamical.DynComputation
+public import PolyFun.PFunctor.Dynamical.DynComputation.Bounded
+public import PolyFun.PFunctor.Dynamical.DynComputation.Termination
+public import PolyFun.PFunctor.Dynamical.Game
+public import PolyFun.PFunctor.Dynamical.Refinement
+public import PolyFun.PFunctor.Dynamical.Responder
+public import PolyFun.PFunctor.Dynamical.Responder.Behavior
+public import PolyFun.PFunctor.Dynamical.Responder.Display
+public import PolyFun.PFunctor.Dynamical.Responder.Lens
+public import PolyFun.PFunctor.Dynamical.Responder.Parallel
+public import PolyFun.PFunctor.Dynamical.Responder.Parallel.Behavior
+public import PolyFun.PFunctor.Dynamical.Responder.Parallel.Coherence
+public import PolyFun.PFunctor.Dynamical.Responder.Parallel.Compatibility
+public import PolyFun.PFunctor.Dynamical.Responder.Parallel.Display
+public import PolyFun.PFunctor.Dynamical.Responder.Parallel.DisplayedAssociativity
+public import PolyFun.PFunctor.Dynamical.Responder.Parallel.DisplayedCoherence
+public import PolyFun.PFunctor.Dynamical.Responder.Parallel.Presentation
+public import PolyFun.PFunctor.Dynamical.Responder.Presentation
+public import PolyFun.PFunctor.Dynamical.Responder.Reindex
+public import PolyFun.PFunctor.Dynamical.Run
+public import PolyFun.PFunctor.Dynamical.RunN
+public import PolyFun.PFunctor.Dynamical.Safety
+public import PolyFun.PFunctor.Dynamical.Simulation
+public import PolyFun.PFunctor.Dynamical.Trajectory
+public import PolyFun.PFunctor.Equiv.Basic
+public import PolyFun.PFunctor.Free.Basic
+public import PolyFun.PFunctor.Free.Cursor
+public import PolyFun.PFunctor.Free.Cursor.Append
+public import PolyFun.PFunctor.Free.Cursor.Fork
+public import PolyFun.PFunctor.Free.Cursor.Occurrence
+public import PolyFun.PFunctor.Free.Displayed
+public import PolyFun.PFunctor.Free.Displayed.Append
+public import PolyFun.PFunctor.Free.Displayed.Cursor
+public import PolyFun.PFunctor.Free.Displayed.Decoration
+public import PolyFun.PFunctor.Free.Displayed.StateChain
+public import PolyFun.PFunctor.Free.Parallel
+public import PolyFun.PFunctor.Free.Path
+public import PolyFun.PFunctor.Free.Path.Execution
+public import PolyFun.PFunctor.Free.Polynomial
+public import PolyFun.PFunctor.Free.Replicate
+public import PolyFun.PFunctor.Free.Resumption
+public import PolyFun.PFunctor.Free.Universal
+public import PolyFun.PFunctor.Handler
+public import PolyFun.PFunctor.Handler.Free
+public import PolyFun.PFunctor.Handler.Normalization
+public import PolyFun.PFunctor.Handler.Normalization.Attr
+public import PolyFun.PFunctor.Handler.Stateful
+public import PolyFun.PFunctor.InternalHom
+public import PolyFun.PFunctor.Lens.Basic
+public import PolyFun.PFunctor.Lens.Cartesian
+public import PolyFun.PFunctor.Lens.Composite
+public import PolyFun.PFunctor.Lens.Distributivity
+public import PolyFun.PFunctor.Lens.Duoidal
+public import PolyFun.PFunctor.Lens.Factorization
+public import PolyFun.PFunctor.Lens.State
+public import PolyFun.PFunctor.M
+public import PolyFun.PFunctor.M.Vertex
+public import PolyFun.PFunctor.Parallel
+public import PolyFun.PFunctor.PatternRunsOnMatter.Applications
+public import PolyFun.PFunctor.PatternRunsOnMatter.Basic
+public import PolyFun.PFunctor.PatternRunsOnMatter.Display
+public import PolyFun.PFunctor.PatternRunsOnMatter.Dynamical
+public import PolyFun.PFunctor.PatternRunsOnMatter.Module
+public import PolyFun.PFunctor.PatternRunsOnMatter.Operational
+public import PolyFun.PFunctor.PatternRunsOnMatter.Parallel
+public import PolyFun.PFunctor.PatternRunsOnMatter.Universal
+public import PolyFun.PFunctor.Resumption
+public import PolyFun.PFunctor.Resumption.Truncate
+public import PolyFun.PFunctor.SubstMonoid
+public import PolyFun.PFunctor.SubstMonoid.Convolution
+public import PolyFun.PFunctor.SubstMonoid.Extension
+public import PolyFun.PFunctor.Trace
+public import PolyFun.PFunctor.Wiring
+public import PolyFun.PFunctor.Wiring.Parallel

--- a/PolyFun/Interaction/Basic/Append.lean
+++ b/PolyFun/Interaction/Basic/Append.lean
@@ -3,9 +3,12 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.Basic.Decoration
-import PolyFun.Interaction.Basic.Strategy
-import PolyFun.PFunctor.Free.Displayed.Append
+
+module
+
+public import PolyFun.Interaction.Basic.Decoration
+public import PolyFun.Interaction.Basic.Strategy
+public import PolyFun.PFunctor.Free.Displayed.Append
 
 /-!
 # Dependent append of interaction type trees
@@ -21,6 +24,8 @@ algebra around this operation:
   `Strategy.compFlat` (flat output via `PFunctor.FreeM.Path.append`).
 - **Decoration / refinement append** and their naturality lemmas.
 -/
+
+public section
 
 universe u v w w₂
 
@@ -39,6 +44,7 @@ output and produces a second-phase strategy whose output family is `F tr₁`.
 This is the preferred composition form: `liftAppend` ensures the output type
 reduces definitionally when combined with `PFunctor.FreeM.Path.append`, which is essential
 for dependent chain composition (see `Strategy.stateChainComp`). -/
+@[expose]
 def Strategy.comp {m : Type u → Type u} [Monad m] :
     (s₁ : TypeTree) → (s₂ : PFunctor.FreeM.Path s₁ → TypeTree) →
     {Mid : PFunctor.FreeM.Path s₁ → Type u} →

--- a/PolyFun/Interaction/Basic/BundledMonad.lean
+++ b/PolyFun/Interaction/Basic/BundledMonad.lean
@@ -4,6 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
 
+module
+
 import Batteries.Tactic.Lint
 
 /-!
@@ -13,6 +15,8 @@ import Batteries.Tactic.Lint
 stored inside inductive types (e.g. per-node monad decorations) where typeclass inference is not
 available. This module is independent of `Interaction.TypeTree`.
 -/
+
+public section
 
 universe u v
 

--- a/PolyFun/Interaction/Basic/Chain.lean
+++ b/PolyFun/Interaction/Basic/Chain.lean
@@ -3,7 +3,10 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.Basic.StateChain
+
+module
+
+public import PolyFun.Interaction.Basic.StateChain
 
 /-!
 # Finite final-sequence approximants (`TypeTree.Chain`)
@@ -54,6 +57,8 @@ The `GrowingMessages` section builds a protocol whose message type grows
 at each step (`Fin 1`, `Fin 2`, …) without mentioning any state type.
 -/
 
+public section
+
 universe u
 
 namespace Interaction
@@ -65,6 +70,7 @@ from the terminal object `PUnit`.
 At a successor level this reduces definitionally to a current `TypeTree` paired
 with one remaining chain for each of its paths. `succEquiv` identifies
 that presentation with `TypeTree.stepPoly.Obj (Chain n)`. -/
+@[expose]
 def Chain : Nat → Type (u + 1)
   | 0 => PUnit
   | n + 1 => (spec : TypeTree) × (Path spec → Chain n)
@@ -83,6 +89,7 @@ def succEquiv (n : Nat) :
 /-- Flatten a finite approximant into a concrete `TypeTree` by iterating the
 multiplication of `TypeTree.substMonoid`. This multiplication is definitionally
 dependent `PFunctor.FreeM.append`. -/
+@[expose]
 def toTypeTree : (n : Nat) → Chain n → TypeTree
   | 0, _ => .done
   | n + 1, ⟨spec, cont⟩ =>
@@ -199,6 +206,7 @@ theorem splitPath_appendPath (n : Nat) (c : Chain (n + 1))
 /-- Output family for strategy composition along a chain. This is the intrinsic analog of
 `Path.stateChainFamily`: a family on the remaining chain is lifted to a family on
 paths of the flattened `TypeTree`. -/
+@[expose]
 def outputFamily
     (Family : {n : Nat} → Chain n → Type u) :
     (n : Nat) → (c : Chain n) → Path (toTypeTree n c) → Type u

--- a/PolyFun/Interaction/Basic/Chain/Append.lean
+++ b/PolyFun/Interaction/Basic/Chain/Append.lean
@@ -3,7 +3,11 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.Basic.Chain
+
+module
+
+import all PolyFun.Interaction.Basic.Chain
+public import PolyFun.Interaction.Basic.Chain
 
 /-!
 # Dependent concatenation of finite interaction chains
@@ -28,6 +32,8 @@ while `toTypeTree` is its operational interpretation; consumers therefore use
 the stable operational equality `toTypeTree_then_assoc`.
 -/
 
+public section
+
 universe u
 
 namespace Interaction
@@ -35,12 +41,13 @@ namespace TypeTree
 namespace Chain
 
 /-- Transport a chain across an equality of its round count. -/
+@[expose]
 def castRounds {m n : Nat} (h : m = n) (c : Chain m) : Chain n :=
   h ▸ c
 
 @[simp]
 theorem castRounds_rfl {m : Nat} (c : Chain m) : castRounds rfl c = c :=
-  rfl
+  by rfl
 
 @[simp]
 theorem castRounds_symm {m n : Nat} (h : m = n) (c : Chain m) :
@@ -63,6 +70,7 @@ theorem toTypeTree_castRounds {m n : Nat} (h : m = n) (c : Chain m) :
   rfl
 
 /-- Append a path-dependent `n`-round suffix to an `m`-round prefix chain. -/
+@[expose]
 def «then» : {m n : Nat} → (c : Chain m) →
     (Path (toTypeTree m c) → Chain n) → Chain (m + n)
   | 0, n, _, k => castRounds (Nat.zero_add n).symm (k ⟨⟩)
@@ -186,13 +194,14 @@ theorem appendThenPath_eq_cast_append {m n : Nat} (c : Chain m)
       Equiv.cast (congrArg Path (toTypeTree_then c k)).symm
         (PFunctor.FreeM.Path.append (toTypeTree m c)
           (fun path => toTypeTree n (k path)) path suffix) :=
-  rfl
+  by rfl
 
 /-! ## Dependent output families and strategies -/
 
 /-- Lift a family indexed separately by a prefix path and its selected suffix
 path to a family on paths through the concatenated chain. This is the
 chain-boundary counterpart of `PFunctor.FreeM.Path.liftAppend`. -/
+@[expose]
 def liftThen {m n : Nat} (c : Chain m)
     (k : Path (toTypeTree m c) → Chain n)
     (Family : (path : Path (toTypeTree m c)) →

--- a/PolyFun/Interaction/Basic/Decoration.lean
+++ b/PolyFun/Interaction/Basic/Decoration.lean
@@ -3,9 +3,12 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.Basic.Node
-import PolyFun.Interaction.Basic.TypeTree
-import PolyFun.PFunctor.Free.Displayed.Decoration
+
+module
+
+public import PolyFun.Interaction.Basic.Node
+public import PolyFun.Interaction.Basic.TypeTree
+public import PolyFun.PFunctor.Free.Displayed.Decoration
 
 /-!
 # Decorations and dependent decorations (`Over`)
@@ -86,6 +89,8 @@ right object when shape and metadata vary together (e.g. for the polynomial
 coalgebraic semantics of `ProcessOver`).
 -/
 
+public section
+
 universe u v w w₂ w₃ w₄ w₅
 
 namespace Interaction
@@ -97,6 +102,7 @@ abbrev Decoration (Γ : Node.Context.{u, v}) (spec : TypeTree) : Type (max u v) 
   PFunctor.FreeM.Displayed.Decoration (P := TypeTree.basePFunctor) (α := PUnit.{u+1}) Γ spec
 
 /-- The unique decoration by the empty node context. -/
+@[expose]
 def Decoration.empty : (spec : TypeTree) → Decoration Node.Context.empty spec
   | .done => PUnit.unit
   | .node _ rest => ⟨PUnit.unit, fun x => Decoration.empty (rest x)⟩
@@ -284,6 +290,7 @@ monads gives `Decorated.shape`. The fiber of `shape` over a fixed
 This is the free monad on `Γ.toPFunctor` at the unit payload. Equivalently
 (by `decoratedEquiv`), it bundles a tree shape `spec : TypeTree` together
 with a `Decoration Γ spec` on it. -/
+@[expose]
 def Decorated (Γ : Node.Context.{u, v}) : Type (max (u+1) v) :=
   PFunctor.FreeM Γ.toPFunctor PUnit.{u+1}
 
@@ -295,6 +302,7 @@ variable {Γ : Node.Context.{u, v}}
 tree shape. This is the lift to free monads of the polynomial lens
 `Γ.toPFunctor → TypeTree.basePFunctor` whose position map is `Sigma.fst` and
 whose child map is the identity. -/
+@[expose]
 def shape : Decorated Γ → TypeTree.{u}
   | .pure _ => TypeTree.done
   | .liftBind ⟨X, _⟩ rest => TypeTree.node X (fun x => Decorated.shape (rest x))
@@ -302,12 +310,14 @@ def shape : Decorated Γ → TypeTree.{u}
 /-- Read off the per-node `Γ`-decoration of a decorated type tree, indexed by
 the tree's underlying `shape`. Together with `shape`, this exhibits the
 fiberwise structure of `Decorated Γ` over `TypeTree`. -/
+@[expose]
 def decoration : (ds : Decorated Γ) → Decoration Γ (Decorated.shape ds)
   | .pure _ => PUnit.unit
   | .liftBind ⟨_, γ⟩ rest => ⟨γ, fun x => Decorated.decoration (rest x)⟩
 
 /-- Pack a tree shape together with a `Γ`-decoration on it into a single
 decorated type tree. Inverse to the pair `(shape, decoration)`. -/
+@[expose]
 def mk : (spec : TypeTree.{u}) → Decoration Γ spec → Decorated Γ
   | .done, _ => PFunctor.FreeM.pure PUnit.unit
   | .node X rest, ⟨γ, dRest⟩ =>

--- a/PolyFun/Interaction/Basic/Interaction.lean
+++ b/PolyFun/Interaction/Basic/Interaction.lean
@@ -3,8 +3,11 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.Basic.Node
-import PolyFun.Interaction.Basic.StrategyOver
+
+module
+
+public import PolyFun.Interaction.Basic.Node
+public import PolyFun.Interaction.Basic.StrategyOver
 
 /-!
 # Generic local execution laws over interaction trees
@@ -29,6 +32,8 @@ Naming note:
 it is the generalized execution notion over node-local data, while
 `Interaction` names the plain specialization with trivial node data.
 -/
+
+public section
 
 universe u a vΓ vΔ vΛ w uA uB uA₂ uB₂ t
 
@@ -78,6 +83,7 @@ Reindex a local execution law contravariantly along a node metadata map.
 If `f : Γ → Δ`, then an execution law for `Δ`-metadata can be reused on
 `Γ`-metadata by first viewing local syntax through `SyntaxOver.comap f`.
 -/
+@[expose]
 def comap {Δ : P.A → Type vΔ} {syn : SyntaxOver l Agent Δ}
     {m : Type (max uB₂ a w) → Type (max uB₂ a w)}
     (f : ∀ pos, Γ pos → Δ pos) (I : InteractionOver l Agent Δ syn m) :
@@ -147,6 +153,7 @@ The local execution structure is the generic `InteractionOver`; this facade only
 keeps the plain-tree path recursion definitionally clean for computation
 lemmas.
 -/
+@[expose]
 def runTypeTree
     [Monad m]
     {spec : TypeTree}

--- a/PolyFun/Interaction/Basic/MonadDecoration.lean
+++ b/PolyFun/Interaction/Basic/MonadDecoration.lean
@@ -3,9 +3,12 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.Basic.BundledMonad
-import PolyFun.Interaction.Basic.Decoration
-import PolyFun.Interaction.Basic.Interaction
+
+module
+
+public import PolyFun.Interaction.Basic.BundledMonad
+public import PolyFun.Interaction.Basic.Decoration
+public import PolyFun.Interaction.Basic.Interaction
 
 /-!
 # Per-node monad decorations
@@ -19,6 +22,8 @@ Use it directly with `StrategyOver` for whole-tree strategies and with
 `InteractionOver.run` through `Strategy.monadicInteraction` for execution in an
 ambient monad.
 -/
+
+public section
 
 universe u uA uB t
 
@@ -42,6 +47,7 @@ bundled monad.
 This is the bridge between ordinary single-monad strategies and strategies
 whose node effects are described by a `MonadDecoration`.
 -/
+@[expose]
 def constant (bm : BundledMonad.{u, u}) :
     (s : PFunctor.FreeM P α) → MonadDecoration.{u} s
   | .pure _ => PUnit.unit
@@ -55,6 +61,7 @@ At each internal node it gives a lift from the source bundled monad to the
 target bundled monad, together with recursive lifts for every continuation
 subtree.
 -/
+@[expose]
 def Hom :
     (s : PFunctor.FreeM P α) → MonadDecoration.{u} s →
       MonadDecoration.{u} s → Type (max uB (u + 1))
@@ -66,6 +73,7 @@ def Hom :
 namespace Hom
 
 /-- Identity homomorphism on a monad decoration. -/
+@[expose]
 def id :
     (s : PFunctor.FreeM P α) → (md : MonadDecoration.{u} s) →
       Hom s md md
@@ -131,6 +139,7 @@ end MonadDecoration
 
 At each node the strategy chooses a move `x` immediately, then supplies the
 continuation in the `BundledMonad` stored by the node decoration. -/
+@[expose]
 def Strategy.monadicSyntax :
     SyntaxOver
       (PFunctor.Lens.id TypeTree.basePFunctor) PUnit (fun (_ : Type u) => BundledMonad.{u, u}) where

--- a/PolyFun/Interaction/Basic/Node.lean
+++ b/PolyFun/Interaction/Basic/Node.lean
@@ -3,8 +3,11 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.PFunctor.Free.Basic
-import Batteries.Tactic.Lint
+
+module
+
+public import PolyFun.PFunctor.Free.Basic
+public import Batteries.Tactic.Lint
 
 /-!
 # Node-local contexts and schemas
@@ -52,6 +55,8 @@ so a decoration by that context provides both pieces of node-local data as one
 semantic object.
 -/
 
+public section
+
 universe u v w w₂ w₃
 
 namespace Interaction
@@ -82,9 +87,11 @@ right notion of morphism for realized node contexts, and it is what
 abbrev ContextHom (Γ : Type u → Type v) (Δ : Type u → Type w) := ∀ X, Γ X → Δ X
 
 /-- Identity morphism on a realized node context. -/
+@[expose]
 def ContextHom.id (Γ : Context) : ContextHom Γ Γ := fun _ x => x
 
 /-- Composition of realized node-context morphisms. -/
+@[expose]
 def ContextHom.comp {Γ : Type u → Type v} {Δ : Type u → Type w} {Λ : Type u → Type w₂}
     (g : ContextHom Δ Λ) (f : ContextHom Γ Δ) : ContextHom Γ Λ :=
   fun X => g X ∘ f X
@@ -95,6 +102,7 @@ The empty node context, carrying no information at any node.
 This is the neutral context used by the plain `Shape` / `Interaction`
 specializations.
 -/
+@[expose]
 def Context.empty : Context := fun _ => PUnit
 
 /--
@@ -113,7 +121,7 @@ recursion of `PFunctor.FreeM.Displayed.Decoration`: a decorated type tree is a f
 of this polynomial, and the existing `Decoration Γ tree` is exactly its fiber
 over the underlying `tree : TypeTree`.
 -/
-@[reducible]
+@[expose, reducible]
 def Context.toPFunctor (Γ : Context.{u, v}) : PFunctor.{max (u+1) v, u} where
   A := Σ X : Type u, Γ X
   B := Sigma.fst
@@ -129,6 +137,7 @@ The new field is allowed to live in a different universe from the existing
 context. This keeps `Context.extend` flexible even though `Schema` itself uses
 one fixed universe parameter for its staged fields.
 -/
+@[expose]
 def Context.extend (Γ : Type u → Type v) (A : ∀ X, Γ X → Type w) : Type u → Type (max v w) :=
   fun X => Σ γ : Γ X, A X γ
 
@@ -138,6 +147,7 @@ Forget the most recently added field of an extended node context.
 This is the canonical projection from `Context.extend Γ A` back to its base
 context `Γ`.
 -/
+@[expose]
 def Context.extendFst (Γ : Type u → Type v) (A : ∀ X, Γ X → Type w) :
     ContextHom (Context.extend Γ A) Γ :=
   fun _ => Sigma.fst
@@ -147,6 +157,7 @@ Map one extended node context to another by:
 * mapping the base context with `f`, and
 * mapping the new dependent field with `g`.
 -/
+@[expose]
 def Context.extendMap
     {Γ : Type u → Type v} {Δ : Type u → Type w}
     {A : ∀ X, Γ X → Type w₂} {B : ∀ X, Δ X → Type w₃}
@@ -171,16 +182,19 @@ genuinely depends on the first. -/
 /--
 The non-dependent product of two realized node contexts. At each move space
 `X`, the value type is `Γ X × Δ X`. -/
+@[expose]
 def Context.prod (Γ : Type u → Type v) (Δ : Type u → Type w) :
     Type u → Type (max v w) :=
   fun X => Γ X × Δ X
 
 /-- First projection out of the non-dependent context product. -/
+@[expose]
 def Context.prodFst (Γ : Type u → Type v) (Δ : Type u → Type w) :
     ContextHom (Context.prod Γ Δ) Γ :=
   fun _ p => p.1
 
 /-- Second projection out of the non-dependent context product. -/
+@[expose]
 def Context.prodSnd (Γ : Type u → Type v) (Δ : Type u → Type w) :
     ContextHom (Context.prod Γ Δ) Δ :=
   fun _ p => p.2
@@ -188,6 +202,7 @@ def Context.prodSnd (Γ : Type u → Type v) (Δ : Type u → Type w) :
 /--
 Pair two context morphisms into a single morphism into the product context.
 This is the universal property of the non-dependent context product. -/
+@[expose]
 def Context.prodPair
     {Γ : Type u → Type v} {Δ₁ : Type u → Type w} {Δ₂ : Type u → Type w₂}
     (f : ContextHom Γ Δ₁) (g : ContextHom Γ Δ₂) :
@@ -196,6 +211,7 @@ def Context.prodPair
 
 /--
 Map both factors of a non-dependent context product. -/
+@[expose]
 def Context.prodMap
     {Γ₁ : Type u → Type v} {Γ₂ : Type u → Type w}
     {Δ₁ : Type u → Type w₂} {Δ₂ : Type u → Type w₃}
@@ -299,6 +315,7 @@ abbrev SchemaMap {Γ Δ : Context} (S : Schema Γ) (T : Schema Δ) :=
   ContextHom S.toContext T.toContext
 
 /-- Identity schema morphism. -/
+@[expose]
 def SchemaMap.id {Γ : Context} (S : Schema Γ) : SchemaMap S S :=
   ContextHom.id _
 
@@ -311,6 +328,7 @@ abbrev SchemaMap.ofContextHom
     (f : ContextHom Γ Δ) : SchemaMap S T := f
 
 /-- Composition of schema morphisms. -/
+@[expose]
 def SchemaMap.comp {Γ Δ Λ : Context}
     {S : Schema Γ} {T : Schema Δ} {U : Schema Λ}
     (g : SchemaMap T U) (f : SchemaMap S T) : SchemaMap S U :=
@@ -330,6 +348,7 @@ If `f : SchemaMap S T` maps the base contexts and `g` maps the newly added
 field over each base value, then `SchemaMap.extend f g` is the induced schema
 morphism between the corresponding one-step schema extensions.
 -/
+@[expose]
 def SchemaMap.extend
     {Γ Δ : Context}
     {S : Schema Γ} {T : Schema Δ}
@@ -397,6 +416,7 @@ The realized context morphism induced by a schema prefix.
 
 This forgets exactly the fields appended after the prefix `S`.
 -/
+@[expose]
 def Prefix.toContextHom :
     {Γ Δ : Context.{u, v}} → {S : Schema Γ} → {T : Schema Δ} →
     Schema.Prefix S T → ContextHom T.toContext S.toContext

--- a/PolyFun/Interaction/Basic/Ownership.lean
+++ b/PolyFun/Interaction/Basic/Ownership.lean
@@ -3,8 +3,11 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.Basic.BundledMonad
-import PolyFun.Interaction.Basic.Syntax
+
+module
+
+public import PolyFun.Interaction.Basic.BundledMonad
+public import PolyFun.Interaction.Basic.Syntax
 
 /-!
 # Ownership-profile local syntax builders
@@ -23,6 +26,8 @@ In particular, this layer is useful for two-party and multiparty interaction
 models where every node has one acting party and the other parties follow the
 chosen move with their passive continuations.
 -/
+
+public section
 
 universe u a vΓ
 
@@ -55,6 +60,7 @@ structure LocalView (Move : Type uB₂) where
   other : (Move → Type w) → Type w
 
 /-- Select the local node shape determined by an ownership perspective. -/
+@[expose]
 def LocalView.node {Move : Type uB₂} (view : LocalView.{uB₂, w} Move) :
     Perspective → (Move → Type w) → Type w
   | .owner, Cont => view.own Cont
@@ -86,6 +92,7 @@ def syntaxOver (perspective : {pos : P.A} → Γ pos → Agent → Perspective)
     (view γ agent).node (perspective γ agent) Cont
 
 /-- Monadic owner/passive syntax over a lens-executed tree. -/
+@[expose]
 def monadicSyntax (perspective : {pos : P.A} → Γ pos → Agent → Perspective)
     (monad : {pos : P.A} → Γ pos → Agent → BundledMonad.{max uB₂ w, max uB₂ w}) :
     SyntaxOver l Agent Γ where
@@ -128,6 +135,7 @@ structure LocalView (X : Type u) where
   other : (X → Type u) → Type u
 
 /-- Select the local node shape determined by an ownership perspective. -/
+@[expose]
 def LocalView.node {X : Type u} (view : LocalView X) : Perspective → (X → Type u) → Type u
   | .owner, Cont => view.own Cont
   | .observer, Cont => view.other Cont
@@ -184,6 +192,7 @@ def syntaxOver (perspective : ∀ {X}, Γ X → Agent → Perspective)
     (view γ agent).node (perspective γ agent) Cont
 
 /-- Monadic owner/passive syntax over plain `TypeTree` trees. -/
+@[expose]
 def monadicSyntax (perspective : ∀ {X}, Γ X → Agent → Perspective)
     (monad : ∀ {X}, Γ X → Agent → BundledMonad.{u, u}) :
     SyntaxOver (PFunctor.Lens.id TypeTree.basePFunctor) Agent Γ where

--- a/PolyFun/Interaction/Basic/Replicate.lean
+++ b/PolyFun/Interaction/Basic/Replicate.lean
@@ -3,8 +3,11 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.Basic.Append
-import PolyFun.PFunctor.Free.Replicate
+
+module
+
+public import PolyFun.Interaction.Basic.Append
+public import PolyFun.PFunctor.Free.Replicate
 
 /-!
 # `TypeTree.replicate` and path operations
@@ -13,6 +16,8 @@ Non-dependent `n`-fold append of the same type tree, with `Path.replicateJoin` /
 replicated decorations/refinements, and `Strategy.iterate`. This is the uniform special case of
 `TypeTree.stateChain` (see `PolyFun.Interaction.Basic.StateChain`).
 -/
+
+public section
 
 universe u v w
 

--- a/PolyFun/Interaction/Basic/Sampler.lean
+++ b/PolyFun/Interaction/Basic/Sampler.lean
@@ -3,7 +3,10 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.Basic.Decoration
+
+module
+
+public import PolyFun.Interaction.Basic.Decoration
 
 /-!
 # Monadic samplers on interaction type trees
@@ -27,6 +30,8 @@ and the sampler's decoration values live at `Type w'`. Probability-monad-specifi
 constructions (e.g., `Sampler.uniform` over a `TypeTree.Fintype` ornament) live in
 the runtime layer where `ProbComp` is in scope.
 -/
+
+public section
 
 universe w w'
 

--- a/PolyFun/Interaction/Basic/Shape.lean
+++ b/PolyFun/Interaction/Basic/Shape.lean
@@ -3,8 +3,12 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.Basic.Node
-import PolyFun.Interaction.Basic.Syntax
+
+module
+
+import all PolyFun.Interaction.Basic.Syntax
+public import PolyFun.Interaction.Basic.Node
+public import PolyFun.Interaction.Basic.Syntax
 
 /-!
 # Functorial local syntax over interaction trees
@@ -32,6 +36,8 @@ refinement of syntax, with plain `Shape` recovered as the trivial-context
 specialization. This differs from `Decoration.Over`, which is literally
 dependent data over a fixed base decoration value.
 -/
+
+public section
 
 universe a vΓ vΔ vΛ w uA uB uA₂ uB₂
 
@@ -82,6 +88,7 @@ Restrict a participant-indexed shape to one fixed agent.
 The resulting singleton-agent shape has the same node objects and continuation
 map as `shape` at `agent`; the dummy `PUnit` agent argument is ignored.
 -/
+@[expose]
 def forAgent (shape : ShapeOver l Agent Γ) (agent : Agent) :
     ShapeOver l PUnit Γ where
   toSyntaxOver := SyntaxOver.forAgent shape.toSyntaxOver agent
@@ -91,6 +98,7 @@ def forAgent (shape : ShapeOver l Agent Γ) (agent : Agent) :
 Reindex a functorial local syntax object contravariantly along a node metadata
 map.
 -/
+@[expose]
 def comap {Δ : P.A → Type vΔ}
     (f : ∀ pos, Γ pos → Δ pos) (shape : ShapeOver l Agent Δ) :
     ShapeOver l Agent Γ where

--- a/PolyFun/Interaction/Basic/StateChain.lean
+++ b/PolyFun/Interaction/Basic/StateChain.lean
@@ -3,8 +3,11 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.Basic.Replicate
-import PolyFun.PFunctor.Free.Displayed.StateChain
+
+module
+
+public import PolyFun.Interaction.Basic.Replicate
+public import PolyFun.PFunctor.Free.Displayed.StateChain
 
 /-!
 # State-indexed dependent chains (`TypeTree.stateChain`)
@@ -21,6 +24,8 @@ This file provides the type-tree-level state chain (`TypeTree.stateChain`), a pa
 For the primary (stateless, continuation-style) chain API see `TypeTree.Chain` in
 `PolyFun.Interaction.Basic.Chain`.
 -/
+
+public section
 
 universe u v w
 
@@ -108,6 +113,7 @@ theorem Path.stateChainSplit_stateChainAppend
 /-- Dependent telescope of per-stage paths: a sequence of individual-stage
 paths where each stage determines the next via `advance`. Mirrors `TypeTree.stateChain`
 at the path level. -/
+@[expose]
 def Path.stateChain (Stage : Nat → Type u) (spec : (i : Nat) → Stage i → TypeTree)
     (advance : (i : Nat) → (s : Stage i) → Path (spec i s) → Stage (i + 1)) :
     (n : Nat) → (i : Nat) → (s : Stage i) → Type u
@@ -243,6 +249,7 @@ at each step. Reduces **definitionally** when the path is built via
 
 This is the canonical output type for `Strategy.stateChainComp` and
 `StrategyOver.TwoParty.Counterpart.stateChainComp`. -/
+@[expose]
 def PFunctor.FreeM.Path.stateChainFamily
     {Stage : Nat → Type u} {spec : (i : Nat) → Stage i → TypeTree}
     {advance : (i : Nat) → (s : Stage i) → Path (spec i s) → Stage (i + 1)}

--- a/PolyFun/Interaction/Basic/Strategy.lean
+++ b/PolyFun/Interaction/Basic/Strategy.lean
@@ -3,7 +3,13 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.Basic.Interaction
+
+module
+
+import all PolyFun.Interaction.Basic.Decoration
+import all PolyFun.Interaction.Basic.StrategyOver
+import all PolyFun.PFunctor.Free.Displayed.Decoration
+public import PolyFun.Interaction.Basic.Interaction
 
 /-!
 # One-player strategies
@@ -21,6 +27,8 @@ Dependent sequential composition `Strategy.comp` requires `PFunctor.FreeM.append
 `PolyFun.Interaction.Basic.Append`.
 -/
 
+public section
+
 universe u
 
 namespace Interaction
@@ -33,6 +41,7 @@ variable {m : Type u → Type u}
 
 At each node the strategy chooses a move `x` and provides the continuation in
 the ambient monad `m`. -/
+@[expose]
 def Strategy.syntax (m : Type u → Type u) :
     SyntaxOver
       (PFunctor.Lens.id TypeTree.basePFunctor) PUnit.{u+1} Node.Context.empty.{u, u} where
@@ -49,6 +58,7 @@ pointwise identification of the correspondingly transported output family.
 
 The explicit family equality keeps dependent path transport localized here;
 callers do not need to unfold the `StrategyOver` representation. -/
+@[expose]
 def Strategy.castSpec {m : Type u → Type u} {source target : TypeTree}
     {Source : Path source → Type u} {Target : Path target → Type u}
     (hSpec : source = target)
@@ -70,6 +80,7 @@ theorem Strategy.castSpec_rfl {m : Type u → Type u} {spec : TypeTree}
   rfl
 
 /-- One-step execution law for ordinary one-player strategies. -/
+@[expose]
 def Strategy.interaction (m : Type u → Type u) [Monad m] :
     InteractionOver
       (PFunctor.Lens.id TypeTree.basePFunctor) PUnit Node.Context.empty (Strategy.syntax m) m where
@@ -79,6 +90,7 @@ def Strategy.interaction (m : Type u → Type u) [Monad m] :
     k node.1 (fun _ => next)
 
 /-- Run the strategy, returning the full path and the dependent output. -/
+@[expose]
 def Strategy.run {m : Type u → Type u} [Monad m] :
     (spec : TypeTree) → {Output : Path spec → Type u} →
     Strategy.Plain m spec Output → m ((tr : Path spec) × Output tr)

--- a/PolyFun/Interaction/Basic/StrategyOver.lean
+++ b/PolyFun/Interaction/Basic/StrategyOver.lean
@@ -3,8 +3,12 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.Basic.Decoration
-import PolyFun.Interaction.Basic.Shape
+
+module
+
+import all PolyFun.Interaction.Basic.Shape
+public import PolyFun.Interaction.Basic.Decoration
+public import PolyFun.Interaction.Basic.Shape
 
 /-!
 # Whole-tree strategies over interaction syntax
@@ -14,6 +18,8 @@ This file turns local syntax into whole-tree strategy families. It sits after
 continuation reindexing, and `StrategyOver` recursively interprets that syntax
 over an entire `FreeM` tree.
 -/
+
+public section
 
 universe u a vΓ vΔ w uA uB uA₂ uB₂ t
 
@@ -34,6 +40,7 @@ At leaves it returns the output family. At a control node it presents the local
 node object supplied by `syn`, whose continuation family is recursively the
 strategy for the abstract branch selected by the lens.
 -/
+@[expose]
 def StrategyOver {l : PFunctor.Lens P Q}
     (syn : SyntaxOver l Agent Γ) :
     (agent : Agent) →

--- a/PolyFun/Interaction/Basic/Syntax.lean
+++ b/PolyFun/Interaction/Basic/Syntax.lean
@@ -3,9 +3,12 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.Basic.TypeTree
-import PolyFun.Interaction.Basic.Node
-import Batteries.Tactic.Lint
+
+module
+
+public import PolyFun.Interaction.Basic.TypeTree
+public import PolyFun.Interaction.Basic.Node
+public import Batteries.Tactic.Lint
 
 /-!
 # Generic local syntax over interaction trees
@@ -45,6 +48,8 @@ Naming note:
 to signal that it is the functorial refinement of syntax, with continuation
 reindexing available as part of the interface.
 -/
+
+public section
 
 universe u a vΓ vΔ vΛ w uA uB uA₂ uB₂ t
 
@@ -89,6 +94,7 @@ Reindex a local syntax object contravariantly along a node metadata map.
 If `f : Γ → Δ`, then any syntax over `Δ` can be viewed as syntax over `Γ` by
 translating the local metadata value before passing it to the original syntax.
 -/
+@[expose]
 def comap {Δ : P.A → Type vΔ}
     (f : ∀ pos, Γ pos → Δ pos) (syn : SyntaxOver l Agent Δ) :
     SyntaxOver l Agent Γ where
@@ -107,6 +113,7 @@ Restrict a participant-indexed syntax to one fixed agent.
 The resulting singleton-agent syntax has the same node objects as `syn` at
 `agent`; the dummy `PUnit` agent argument is ignored.
 -/
+@[expose]
 def forAgent (syn : SyntaxOver l Agent Γ) (agent : Agent) :
     SyntaxOver l PUnit Γ where
   Node _ pos γ Cont := syn.Node agent pos γ Cont

--- a/PolyFun/Interaction/Basic/Telescope.lean
+++ b/PolyFun/Interaction/Basic/Telescope.lean
@@ -3,7 +3,10 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.Basic.Append
+
+module
+
+public import PolyFun.Interaction.Basic.Append
 
 /-!
 # Well-founded stopping trees (`TypeTree.Telescope`)
@@ -40,6 +43,8 @@ initial-algebra universal property. `toTypeTree` is the fold into the algebra
 * Hancock–Setzer (2000), recursion over interaction interfaces.
 * Spivak–Niu (2024), polynomial functors as the algebra of interaction.
 -/
+
+public section
 
 universe u v
 
@@ -79,6 +84,7 @@ abbrev extend (s : St)
 
 /-- The `TypeTree`-valued algebra interpreting a stopping leaf as the substitution
 unit and a transition layer as substitution multiplication. -/
+@[expose]
 def toTypeTreeAlgebra :
     PFunctor.FreeM.StoppingTree.Algebra
       (Obs := fun s => Path (round s)) (step := step) (fun _ => TypeTree) where
@@ -87,6 +93,7 @@ def toTypeTreeAlgebra :
 
 /-- Fold a `Telescope` into a concrete `TypeTree` using the canonical substitution
 monoid: `done` is its unit and `extend` is its multiplication/append. -/
+@[expose]
 def toTypeTree : {s : St} → Telescope round step s → TypeTree :=
   PFunctor.FreeM.StoppingTree.fold toTypeTreeAlgebra
 

--- a/PolyFun/Interaction/Basic/TypeTree.lean
+++ b/PolyFun/Interaction/Basic/TypeTree.lean
@@ -3,7 +3,10 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.PFunctor.Free.Polynomial
+
+module
+
+public import PolyFun.PFunctor.Free.Polynomial
 
 /-!
 # Interaction type trees and paths
@@ -86,6 +89,8 @@ representation.
 * McBride (2010); Dagand–McBride (2014), displayed algebras / ornaments
 -/
 
+public section
+
 universe u
 
 namespace Interaction
@@ -101,7 +106,7 @@ participant chooses a value of some move type, and the continuation is
 selected by that value". It is independent of payload data, controller
 attribution, and execution semantics; those layers refine the same
 polynomial via `Decoration`, `NodeProfile`, and `StepOver`. -/
-@[reducible]
+@[expose, reducible]
 def basePFunctor : PFunctor.{u+1, u} where
   A := Type u
   B := id
@@ -144,7 +149,7 @@ namespace TypeTree
 This is `PFunctor.FreeM.pure ()` at the polynomial substrate; the
 `@[match_pattern]` attribute makes it usable both as a constructor
 term and as a `match` pattern. -/
-@[match_pattern, reducible]
+@[expose, match_pattern, reducible]
 def done : TypeTree := PFunctor.FreeM.pure PUnit.unit
 
 /-- A round of interaction: a value of type `Moves` is exchanged, then
@@ -153,7 +158,7 @@ the protocol continues with `rest x` depending on the chosen move `x`.
 This is `PFunctor.FreeM.liftBind Moves rest` at the polynomial substrate;
 the `@[match_pattern]` attribute makes it usable both as a constructor
 term and as a `match` pattern. -/
-@[match_pattern, reducible]
+@[expose, match_pattern, reducible]
 def node (Moves : Type u) (rest : Moves → TypeTree) : TypeTree :=
   PFunctor.FreeM.liftBind Moves rest
 

--- a/PolyFun/Interaction/Basic/TypeTreeFintype.lean
+++ b/PolyFun/Interaction/Basic/TypeTreeFintype.lean
@@ -3,9 +3,12 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import Mathlib.Data.Fintype.Basic
 
-import PolyFun.Interaction.Basic.TypeTree
+module
+
+public import Mathlib.Data.Fintype.Basic
+
+public import PolyFun.Interaction.Basic.TypeTree
 
 /-!
 # Branching ornaments on interaction type trees
@@ -23,6 +26,8 @@ Together, `TypeTree.Fintype tree` and `TypeTree.Nonempty tree` provide the
 assumptions needed by downstream uniform samplers. PolyFun itself remains
 independent of any probability monad.
 -/
+
+public section
 
 universe u
 
@@ -54,14 +59,14 @@ instance instNode {X : Type u} [hFin : Fintype X]
   .node hFin hRec
 
 /-- Extract the `Fintype` instance for the move space of the root node. -/
-@[reducible]
+@[expose, reducible]
 def rootFintype {X : Type u} {rest : X → TypeTree.{u}}
     (h : TypeTree.Fintype (TypeTree.node X rest)) : Fintype X :=
   match h with
   | .node hFin _ => hFin
 
 /-- Extract the ornament for every continuation of the root node. -/
-@[reducible]
+@[expose, reducible]
 def rest {X : Type u} {rest : X → TypeTree.{u}}
     (h : TypeTree.Fintype (TypeTree.node X rest)) : ∀ x, TypeTree.Fintype (rest x) :=
   match h with

--- a/PolyFun/Interaction/Concurrent/Control.lean
+++ b/PolyFun/Interaction/Concurrent/Control.lean
@@ -3,7 +3,10 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.Concurrent.Frontier
+
+module
+
+public import PolyFun.Interaction.Concurrent.Frontier
 
 /-!
 # Scheduler and control ownership for concurrent interaction
@@ -40,6 +43,8 @@ This is intentionally a control/ownership layer only.
 It does **not** yet prescribe how those parties compute their choices or how
 local endpoint programs should be assembled from that ownership data.
 -/
+
+public section
 
 universe u
 
@@ -87,6 +92,7 @@ This mirrors the residual concurrent spec structurally:
 * atomic node control follows the chosen payload branch;
 * parallel control updates only the side from which the event came.
 -/
+@[expose]
 def residual {Party : Type u} :
     {S : Spec} → Control Party S → (event : Front S) → Control Party (Concurrent.residual event)
   | .done, .done, event => nomatch event
@@ -106,6 +112,7 @@ empty:
 * an atomic node is live;
 * a parallel control tree is live iff either side is live.
 -/
+@[expose]
 def isLive {Party : Type u} : {S : Spec} → Control Party S → Bool
   | .done, .done => false
   | .node _ _, .node _ _ => true
@@ -121,6 +128,7 @@ This returns:
 
 So this records *frontier scheduling ownership*, not payload ownership.
 -/
+@[expose]
 def scheduler? {Party : Type u} : {S : Spec} → Control Party S → Option Party
   | .done, .done => none
   | .node _ _, .node _ _ => none
@@ -141,6 +149,7 @@ This may be:
 So `current?` collapses scheduler choice and payload choice into the one party
 who is currently in control of progress.
 -/
+@[expose]
 def current? {Party : Type u} : {S : Spec} → Control Party S → Option Party
   | .done, .done => none
   | .node _ _, .node owner _ => some owner
@@ -165,6 +174,7 @@ This distinction matters after residual steps such as `.par .done right`,
 where control should immediately collapse to the right subtree rather than
 crediting a vacuous scheduler choice.
 -/
+@[expose]
 def controllers {Party : Type u} :
     {S : Spec} → Control Party S → (event : Front S) → List Party
   | .done, .done, event => nomatch event

--- a/PolyFun/Interaction/Concurrent/Current.lean
+++ b/PolyFun/Interaction/Concurrent/Current.lean
@@ -3,8 +3,11 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.Concurrent.Control
-import PolyFun.Interaction.Concurrent.Profile
+
+module
+
+public import PolyFun.Interaction.Concurrent.Control
+public import PolyFun.Interaction.Concurrent.Profile
 
 /-!
 # Current local views of concurrent frontier events
@@ -35,6 +38,8 @@ At a `par` node, this means:
 So this file gives the first true "who chooses what next, and what does everyone
 else learn?" interface for the concurrent layer.
 -/
+
+public section
 
 universe u
 

--- a/PolyFun/Interaction/Concurrent/Equivalence.lean
+++ b/PolyFun/Interaction/Concurrent/Equivalence.lean
@@ -3,7 +3,11 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.Concurrent.MutualSafetyRefinement
+
+module
+
+import all PolyFun.Interaction.Concurrent.Observation
+public import PolyFun.Interaction.Concurrent.MutualSafetyRefinement
 
 /-!
 # Common concurrent equivalence notions
@@ -33,6 +37,8 @@ generic simulation-level `DynSystem.ForwardSimulation.*_mapRun`, specialized at
 observations directly from an equivalence without first projecting a forward
 simulation.
 -/
+
+public section
 
 universe u v w
 

--- a/PolyFun/Interaction/Concurrent/Execution.lean
+++ b/PolyFun/Interaction/Concurrent/Execution.lean
@@ -3,7 +3,10 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.Concurrent.Process
+
+module
+
+public import PolyFun.Interaction.Concurrent.Process
 
 /-!
 # Finite executions of dynamic concurrent processes
@@ -28,6 +31,8 @@ This file therefore provides two parallel views of finite execution:
 The closed-world `Process` API is recovered as a specialization of these
 generic definitions.
 -/
+
+public section
 
 universe u v w w₂ w₃
 
@@ -83,6 +88,7 @@ namespace Observed
 /--
 The number of visited nodes recorded by an observed sequential path.
 -/
+@[expose]
 def length {Party : Type u} [DecidableEq Party] {me : Party} :
     {spec : Interaction.TypeTree.{w}} →
       {semantics : PFunctor.FreeM.Displayed.Decoration (P := TypeTree.basePFunctor)
@@ -206,6 +212,7 @@ inductive Trace
 namespace Trace
 
 /-- The number of process steps recorded by a finite execution trace. -/
+@[expose]
 def length
     {Γ : Interaction.TypeTree.Node.Context.{w, w₂}}
     {P : Type v} {process : ProcessOver P Γ} :
@@ -320,6 +327,7 @@ inductive ObservedTrace
 namespace ObservedTrace
 
 /-- The number of process steps recorded by an observed trace. -/
+@[expose]
 def length
     {Γ : Interaction.TypeTree.Node.Context.{w, w₂}}
     {Party : Type u} [DecidableEq Party]

--- a/PolyFun/Interaction/Concurrent/Fairness.lean
+++ b/PolyFun/Interaction/Concurrent/Fairness.lean
@@ -3,7 +3,10 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.Concurrent.Run
+
+module
+
+public import PolyFun.Interaction.Concurrent.Run
 
 /-!
 # Fairness of dynamic concurrent runs
@@ -20,6 +23,8 @@ same protocol.
 The closed-world `Process` API is recovered as a specialization of these
 generic definitions.
 -/
+
+public section
 
 universe u v w w₂ w₃
 

--- a/PolyFun/Interaction/Concurrent/Frontier.lean
+++ b/PolyFun/Interaction/Concurrent/Frontier.lean
@@ -3,7 +3,10 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.Concurrent.Spec
+
+module
+
+public import PolyFun.Interaction.Concurrent.Spec
 
 /-!
 # Frontiers and residual concurrent interaction
@@ -28,6 +31,8 @@ recursive alias into `PEmpty` and `Sum`. This keeps the scheduler-facing API
 close to the source syntax and preserves direct pattern matching and
 definitional computation for `residual`.
 -/
+
+public section
 
 universe u
 
@@ -69,6 +74,7 @@ The equations are definitionally the expected ones:
 
 This is the primary execution primitive for schedulers, adversaries, and traces.
 -/
+@[expose]
 def residual : {S : Spec} → Front S → Spec
   | .done, event => nomatch event
   | .node _ rest, .move x => rest x

--- a/PolyFun/Interaction/Concurrent/Independence.lean
+++ b/PolyFun/Interaction/Concurrent/Independence.lean
@@ -3,7 +3,10 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.Concurrent.Frontier
+
+module
+
+public import PolyFun.Interaction.Concurrent.Frontier
 
 /-!
 # Independence and commuting concurrent events
@@ -32,6 +35,8 @@ This is intentionally the minimal true-concurrency layer.
 It does not yet quotient traces by independence, attach fairness assumptions,
 or introduce richer partial-order objects such as pomsets or event structures.
 -/
+
+public section
 
 universe u
 
@@ -95,6 +100,7 @@ the left-hand event of the independence witness `h`.
 So if `h : Independent event₁ event₂`, then `afterLeft h` is an enabled
 frontier event of the residual spec `residual event₁`.
 -/
+@[expose]
 def afterLeft {S : Spec} {event₁ event₂ : Front S} :
     Independent event₁ event₂ → Front (residual event₁)
   | .left_right _ eventRight => .right eventRight
@@ -109,6 +115,7 @@ the right-hand event of the independence witness `h`.
 So if `h : Independent event₁ event₂`, then `afterRight h` is an enabled
 frontier event of the residual spec `residual event₂`.
 -/
+@[expose]
 def afterRight {S : Spec} {event₁ event₂ : Front S} :
     Independent event₁ event₂ → Front (residual event₂)
   | .left_right eventLeft _ => .left eventLeft

--- a/PolyFun/Interaction/Concurrent/Interleaving.lean
+++ b/PolyFun/Interaction/Concurrent/Interleaving.lean
@@ -3,8 +3,11 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.Concurrent.Independence
-import PolyFun.Interaction.Concurrent.Trace
+
+module
+
+public import PolyFun.Interaction.Concurrent.Independence
+public import PolyFun.Interaction.Concurrent.Trace
 
 /-!
 # Interleaving equivalence of concurrent traces
@@ -31,6 +34,8 @@ normal forms, or more elaborate partial-order objects; it only records the
 standard commuting conversion at the trace level.
 -/
 
+public section
+
 universe u
 
 namespace Interaction
@@ -45,6 +50,7 @@ This is the trace-level cast operation needed when two independent frontier
 events commute and therefore produce definitionally different but propositionally
 equal residual specs.
 -/
+@[expose]
 def cast {S T : Spec} (h : S = T) (trace : Trace S) : Trace T :=
   h ▸ trace
 

--- a/PolyFun/Interaction/Concurrent/Liveness.lean
+++ b/PolyFun/Interaction/Concurrent/Liveness.lean
@@ -3,7 +3,10 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.Concurrent.Run
+
+module
+
+public import PolyFun.Interaction.Concurrent.Run
 
 /-!
 # Safety and liveness predicates over concurrent runs
@@ -23,6 +26,8 @@ full temporal-logic syntax, the file defines:
 The closed-world `Process` API is recovered as a specialization of these
 generic definitions.
 -/
+
+public section
 
 universe u v w w₂
 

--- a/PolyFun/Interaction/Concurrent/Machine.lean
+++ b/PolyFun/Interaction/Concurrent/Machine.lean
@@ -3,7 +3,10 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao, Devon Tuma
 -/
-import PolyFun.Interaction.Concurrent.Process
+
+module
+
+public import PolyFun.Interaction.Concurrent.Process
 
 /-!
 # State-indexed concurrent machines
@@ -35,6 +38,8 @@ embeds machine semantics into the general `Concurrent.Process` core.
 This is the natural frontend for transition-system style models, including
 state-heavy distributed and cryptographic protocol semantics.
 -/
+
+public section
 
 universe u v
 
@@ -72,6 +77,7 @@ abbrev step {S : Type v} (machine : Machine.{u, v} S) (σ : S) (e : machine.Enab
 
 /-- Build a machine from its state set, enabled-event family, and successor
 function, using the classical field names. -/
+@[expose]
 def mk' (State : Type v) (Enabled : State → Type u) (step : (σ : State) → Enabled σ → State) :
     Machine.{u, v} State :=
   Enabled ⇆ step

--- a/PolyFun/Interaction/Concurrent/MutualSafetyRefinement.lean
+++ b/PolyFun/Interaction/Concurrent/MutualSafetyRefinement.lean
@@ -3,7 +3,10 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.Concurrent.Refinement
+
+module
+
+public import PolyFun.Interaction.Concurrent.Refinement
 
 /-!
 # MutualSafetyRefinement for dynamic concurrent processes
@@ -30,6 +33,8 @@ the generic dynamical-system notions at the step polynomial. This file adds
 fairness-aware safety-transport theorems phrased through
 `ProcessOver.SafetySpec.Satisfies`.
 -/
+
+public section
 
 universe u v w w₂ w₃
 

--- a/PolyFun/Interaction/Concurrent/Observation.lean
+++ b/PolyFun/Interaction/Concurrent/Observation.lean
@@ -3,7 +3,12 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.Concurrent.Run
+
+module
+
+import all PolyFun.Interaction.Concurrent.Process
+import all PolyFun.Interaction.Concurrent.Run
+public import PolyFun.Interaction.Concurrent.Run
 
 /-!
 # Observation equivalence for concurrent processes
@@ -27,6 +32,8 @@ The resulting API provides:
 
 This is the comparison layer later used by refinement and equivalence results.
 -/
+
+public section
 
 universe u v w
 
@@ -148,9 +155,7 @@ theorem rel_cast {Party : Type u}
     (hL : pL = pL') (hR : pR = pR')
     (leftPrefix : Process.Prefix left pL n)
     (rightPrefix : Process.Prefix right pR n) :
-    Rel rel
-      (cast (by cases hL; rfl) leftPrefix)
-      (cast (by cases hR; rfl) rightPrefix) ↔
+    Rel rel (hL ▸ leftPrefix) (hR ▸ rightPrefix) ↔
       Rel rel leftPrefix rightPrefix := by
   cases hL
   cases hR
@@ -201,6 +206,7 @@ def byEvent {Party : Type u} {P₁ P₂ : Type v} {left : Process P₁ Party} {r
 /--
 Match two paths by equality of stable tickets.
 -/
+@[expose]
 def byTicket {Party : Type u} {P₁ P₂ : Type v} {left : Process P₁ Party} {right : Process P₂ Party}
     {Ticket : Type w} (ticketL : left.Tickets Ticket) (ticketR : right.Tickets Ticket) :
     StepRel left right :=
@@ -213,6 +219,7 @@ to one fixed party.
 This is the relation that identifies executions that are observationally
 indistinguishable to `me` at the step level.
 -/
+@[expose]
 def byObservation {Party : Type u} [DecidableEq Party]
     {P₁ P₂ : Type v} {left : Process P₁ Party} {right : Process P₂ Party} (me : Party) :
     StepRel left right :=

--- a/PolyFun/Interaction/Concurrent/Policy.lean
+++ b/PolyFun/Interaction/Concurrent/Policy.lean
@@ -3,7 +3,10 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.Concurrent.Execution
+
+module
+
+public import PolyFun.Interaction.Concurrent.Execution
 
 /-!
 # Executable step policies for dynamic concurrent processes
@@ -20,6 +23,8 @@ step by step.
 The closed-world `Process` API is recovered as a specialization of these
 generic definitions.
 -/
+
+public section
 
 universe u v w w₂ w₃
 
@@ -119,6 +124,7 @@ namespace Trace
 `respects policy trace` checks whether every step of the finite process
 execution `trace` satisfies the executable step policy `policy`.
 -/
+@[expose]
 def respects
     {Γ : Interaction.TypeTree.Node.Context.{w, w₂}}
     {P : Type v} {process : ProcessOver P Γ}

--- a/PolyFun/Interaction/Concurrent/Process.lean
+++ b/PolyFun/Interaction/Concurrent/Process.lean
@@ -3,14 +3,17 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.Basic.TypeTree
-import PolyFun.Interaction.Basic.Decoration
-import PolyFun.Interaction.Multiparty.Core
-import PolyFun.PFunctor.Dynamical.Combinators
-import PolyFun.PFunctor.Dynamical.Safety
-import PolyFun.PFunctor.Dynamical.Trajectory
-import Mathlib.Data.PFunctor.Univariate.M
-import Batteries.Tactic.Lint
+
+module
+
+public import PolyFun.Interaction.Basic.TypeTree
+public import PolyFun.Interaction.Basic.Decoration
+public import PolyFun.Interaction.Multiparty.Core
+public import PolyFun.PFunctor.Dynamical.Combinators
+public import PolyFun.PFunctor.Dynamical.Safety
+public import PolyFun.PFunctor.Dynamical.Trajectory
+public import Mathlib.Data.PFunctor.Univariate.M
+public import Batteries.Tactic.Lint
 
 /-!
 # Dynamic concurrent processes
@@ -46,6 +49,8 @@ This design stays continuation-first, but is more general than the structural
 tree frontend: cyclic or unbounded behavior is represented by the residual
 state type, while each individual step remains a finite `Interaction.TypeTree`.
 -/
+
+public section
 
 universe u v w w₂ w₃
 
@@ -183,6 +188,7 @@ Map the node-local context carried by a step along a realized context morphism.
 This changes only the metadata decorating the step protocol. The underlying
 sequential interaction tree and the continuation `next` are left unchanged.
 -/
+@[expose]
 def mapContext
     {Γ : Interaction.TypeTree.Node.Context.{w, w₂}}
     {Δ : Interaction.TypeTree.Node.Context.{w, w₃}}
@@ -233,7 +239,7 @@ A direction over such a position is a complete path of `tree`.
 Up to `Interaction.TypeTree.decoratedEquiv`, positions are exactly
 `Interaction.TypeTree.Decorated Γ`, the free term of `Γ.toPFunctor` at the
 unit payload. -/
-@[reducible]
+@[expose, reducible]
 def toPFunctor (Γ : Interaction.TypeTree.Node.Context.{w, w₂}) :
     PFunctor.{max (w+1) w₂, w} where
   A := Σ tree : Interaction.TypeTree.{w}, PFunctor.FreeM.Displayed.Decoration Γ tree
@@ -245,13 +251,13 @@ the step-over structure as a polynomial application.
 The forward direction regroups the `(tree, semantics, next)` fields into
 the polynomial form `(position, continuation)`, and the inverse unpacks
 them again. Both roundtrips are definitionally `rfl`. -/
-@[simps]
+@[expose, simps]
 def equivObj {Γ : Interaction.TypeTree.Node.Context.{w, w₂}} {P : Type v} :
     StepOver.{v, w, w₂} Γ P ≃ (StepOver.toPFunctor Γ).Obj P where
   toFun s := ⟨⟨s.tree, s.semantics⟩, s.next⟩
-  invFun := fun ⟨⟨spec, semantics⟩, next⟩ => ⟨spec, semantics, next⟩
+  invFun s := ⟨s.1.1, s.1.2, s.2⟩
   left_inv _ := rfl
-  right_inv := fun ⟨⟨_, _⟩, _⟩ => rfl
+  right_inv _ := rfl
 
 /-- The position type of `StepOver.toPFunctor Γ` is the same data as a
 `Γ`-decorated type tree, via `Interaction.TypeTree.decoratedEquiv`. This is the
@@ -307,7 +313,7 @@ abbrev Proc {P : Type v} {Γ : Interaction.TypeTree.Node.Context.{w, w₂}}
 the next state: the `StepOver`-shaped view of the coalgebra structure map.
 
 Reducible so that it unfolds during unification and instance search. -/
-@[reducible]
+@[expose, reducible]
 def step {P : Type v} {Γ : Interaction.TypeTree.Node.Context.{w, w₂}}
     (process : ProcessOver.{v, w, w₂} P Γ) (p : process.Proc) :
     StepOver Γ process.Proc :=
@@ -318,7 +324,7 @@ the `StepOver`-shaped constructor inverse to `ProcessOver.step`; both round
 trips hold definitionally (`step_ofStep`, `ofStep_step`).
 
 Reducible so that it unfolds during unification and instance search. -/
-@[reducible]
+@[expose, reducible]
 def ofStep {Γ : Interaction.TypeTree.Node.Context.{w, w₂}}
     (Proc : Type v) (step : Proc → StepOver Γ Proc) : ProcessOver.{v, w, w₂} Proc Γ :=
   PFunctor.DynSystem.mk'
@@ -350,6 +356,7 @@ morphism.
 This changes only the metadata exposed at each step. The residual state space
 and transition structure are preserved.
 -/
+@[expose]
 def mapContext
     {P : Type v}
     {Γ : Interaction.TypeTree.Node.Context.{w, w₂}}
@@ -370,6 +377,7 @@ At each step, a scheduler node chooses left (`true`) or right (`false`), then
 the selected subprocess's step protocol runs with its decoration mapped into
 `Δ`. Only the selected component of the product state advances.
 -/
+@[expose]
 def interleave
     {P₁ P₂ : Type v}
     {Γ₁ Γ₂ Δ : Interaction.TypeTree.Node.Context.{w, w₂}}

--- a/PolyFun/Interaction/Concurrent/Profile.lean
+++ b/PolyFun/Interaction/Concurrent/Profile.lean
@@ -3,8 +3,11 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.Concurrent.Frontier
-import PolyFun.Interaction.Multiparty.Core
+
+module
+
+public import PolyFun.Interaction.Concurrent.Frontier
+public import PolyFun.Interaction.Multiparty.Core
 
 /-!
 # Per-party observation profiles for concurrent interaction
@@ -39,6 +42,8 @@ It does **not** yet introduce:
 
 Those later layers can build on this structural profile API.
 -/
+
+public section
 
 universe u
 
@@ -105,6 +110,7 @@ At a parallel node, current observations are a sum: a scheduled frontier event
 comes from the left or the right component, and the observation records which
 side fired together with the observation from that side.
 -/
+@[expose]
 def ObsType {Party : Type u} (me : Party) :
     {S : Spec} → Profile Party S → Type u
   | .done, .done => PUnit
@@ -121,6 +127,7 @@ This is computed structurally:
 * at a parallel node, tag observations by whether the event came from the left
   or right concurrent component.
 -/
+@[expose]
 def observe {Party : Type u} (me : Party) :
     {S : Spec} → (profile : Profile Party S) → (event : Front S) → ObsType me profile
   | .done, .done, event => nomatch event

--- a/PolyFun/Interaction/Concurrent/Refinement.lean
+++ b/PolyFun/Interaction/Concurrent/Refinement.lean
@@ -3,9 +3,13 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.Concurrent.Liveness
-import PolyFun.Interaction.Concurrent.Observation
-import PolyFun.PFunctor.Dynamical.Refinement
+
+module
+
+import all PolyFun.Interaction.Concurrent.Liveness
+public import PolyFun.Interaction.Concurrent.Liveness
+public import PolyFun.Interaction.Concurrent.Observation
+public import PolyFun.PFunctor.Dynamical.Refinement
 
 /-!
 # Forward refinement for dynamic concurrent processes
@@ -37,6 +41,8 @@ processes directly. This file adds the path-flavoured vocabulary
 (`admissible_mapRun`), the observation-preservation corollaries for the
 concrete `StepRel`s, and the top-level `safe_of_satisfies` transfer.
 -/
+
+public section
 
 universe u v w w₂ w₃
 

--- a/PolyFun/Interaction/Concurrent/Run.lean
+++ b/PolyFun/Interaction/Concurrent/Run.lean
@@ -3,8 +3,11 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.Concurrent.Execution
-import PolyFun.PFunctor.Dynamical.Run
+
+module
+
+public import PolyFun.Interaction.Concurrent.Execution
+public import PolyFun.PFunctor.Dynamical.Run
 
 /-!
 # Finite prefixes and infinite runs of dynamic concurrent processes
@@ -22,6 +25,8 @@ reasoning about ongoing concurrent behavior.
 The closed-world `Process` API is recovered as a specialization of these
 generic definitions.
 -/
+
+public section
 
 universe u v w w₂ w₃
 
@@ -50,6 +55,7 @@ namespace Prefix
 The sequence of current controlling parties exposed by a finite prefix after
 projecting the generic context into `StepContext`.
 -/
+@[expose]
 def currentControllers
     {Γ : Interaction.TypeTree.Node.Context.{w, w₂}}
     {Party : Type u}
@@ -64,6 +70,7 @@ def currentControllers
 The sequence of full controller paths exposed by a finite prefix after
 projecting the generic context into `StepContext`.
 -/
+@[expose]
 def controllerPaths
     {Γ : Interaction.TypeTree.Node.Context.{w, w₂}}
     {Party : Type u}
@@ -235,6 +242,7 @@ def currentController?
 
 /-- The current controlling parties exposed along the first `n` executed steps
 of the run `run`. -/
+@[expose]
 def currentControllersUpTo
     {Γ : Interaction.TypeTree.Node.Context.{w, w₂}}
     {Party : Type u}
@@ -258,6 +266,7 @@ def controllerPath
 
 /-- The full controller paths exposed along the first `n` executed steps of the
 run `run`. -/
+@[expose]
 def controllerPathsUpTo
     {Γ : Interaction.TypeTree.Node.Context.{w, w₂}}
     {Party : Type u}
@@ -463,6 +472,7 @@ namespace Prefix
 
 /-- The sequence of current controlling parties exposed by a finite closed-world
 prefix. -/
+@[expose]
 def currentControllers {Party : Type u} {P : Type v} {process : Process P Party} :
     {p : process.Proc} → {n : Nat} → Prefix process p n → List (Option Party)
   | _, _, .nil => []
@@ -471,6 +481,7 @@ def currentControllers {Party : Type u} {P : Type v} {process : Process P Party}
 
 /-- The sequence of full controller paths exposed by a finite closed-world
 prefix. -/
+@[expose]
 def controllerPaths {Party : Type u} {P : Type v} {process : Process P Party} :
     {p : process.Proc} → {n : Nat} → Prefix process p n → List (List Party)
   | _, _, .nil => []
@@ -562,6 +573,7 @@ def currentController? {Party : Type u} {P : Type v} {process : Process P Party}
 
 /-- The current controlling parties exposed along the first `n` executed steps
 of a closed-world run. -/
+@[expose]
 def currentControllersUpTo {Party : Type u} {P : Type v} {process : Process P Party}
     (run : Run process) : Nat → List (Option Party)
   | 0 => []
@@ -574,6 +586,7 @@ def controllerPath {Party : Type u} {P : Type v} {process : Process P Party}
 
 /-- The full controller paths exposed along the first `n` executed steps of a
 closed-world run. -/
+@[expose]
 def controllerPathsUpTo {Party : Type u} {P : Type v} {process : Process P Party}
     (run : Run process) : Nat → List (List Party)
   | 0 => []

--- a/PolyFun/Interaction/Concurrent/Spec.lean
+++ b/PolyFun/Interaction/Concurrent/Spec.lean
@@ -3,7 +3,10 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.Basic.TypeTree
+
+module
+
+public import PolyFun.Interaction.Basic.TypeTree
 
 /-!
 # Concurrent interaction specifications
@@ -33,6 +36,8 @@ The guiding idea is the same as in the sequential layer:
 the "state" of a concurrent interaction is its current residual continuation,
 not an external mutable store.
 -/
+
+public section
 
 universe u
 
@@ -80,6 +85,7 @@ Unlike syntactic equality with `.done`, this detects quiescent residuals such
 as `.par .done .done`, which expose no frontier events even though they are not
 literally the terminal constructor.
 -/
+@[expose]
 def isLive : Concurrent.Spec → Bool
   | .done => false
   | .node _ _ => true
@@ -92,6 +98,7 @@ one-thread fragment with no use of `par`.
 This is the canonical embedding of sequential type trees into the concurrent
 source language.
 -/
+@[expose]
 def ofSequential : Interaction.TypeTree → Concurrent.Spec
   | .done => .done
   | .node Moves rest => .node Moves (fun x => ofSequential (rest x))

--- a/PolyFun/Interaction/Concurrent/Trace.lean
+++ b/PolyFun/Interaction/Concurrent/Trace.lean
@@ -3,7 +3,10 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.Concurrent.Frontier
+
+module
+
+public import PolyFun.Interaction.Concurrent.Frontier
 
 /-!
 # Structural frontier traces
@@ -29,6 +32,8 @@ If a later true-concurrency layer adds independence or partial-order
 semantics, those refinements should be layered over these structural
 linearizations rather than replacing the basic tree frontend story here.
 -/
+
+public section
 
 universe u
 
@@ -67,6 +72,7 @@ def doneOfNotLive {S : Spec} (h : S.isLive = false) : Trace S :=
   .done (isEmpty_of_not_live h)
 
 /-- The number of frontier events in a finite concurrent trace. -/
+@[expose]
 def length : {S : Spec} → Trace S → Nat
   | _, .done _ => 0
   | _, .step _ tail => tail.length.succ

--- a/PolyFun/Interaction/Concurrent/Tree.lean
+++ b/PolyFun/Interaction/Concurrent/Tree.lean
@@ -3,9 +3,12 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.Concurrent.Current
-import PolyFun.Interaction.Concurrent.Execution
-import PolyFun.Interaction.Concurrent.Trace
+
+module
+
+public import PolyFun.Interaction.Concurrent.Current
+public import PolyFun.Interaction.Concurrent.Execution
+public import PolyFun.Interaction.Concurrent.Trace
 
 /-!
 # Structural-tree frontend for dynamic processes
@@ -26,6 +29,8 @@ single move type `Front S`, but its node semantics record:
 So the structural tree language remains an important source language, but the
 dynamic process core is now the semantic center.
 -/
+
+public section
 
 universe u
 
@@ -59,6 +64,7 @@ controller-path contribution of each move is exactly
 `Control.controllers st.control`, and the local view of that move is exactly
 `Current.view me st.control st.profile`.
 -/
+@[expose]
 def currentStep {Party : Type u} [DecidableEq Party] (st : State Party) :
     Step Party (State Party) :=
   { tree := .node (Front st.spec) (fun _ => .done)
@@ -84,6 +90,7 @@ def eventOfPath {Party : Type u} [DecidableEq Party] (st : State Party) :
 `pathOfEvent st event` re-expresses a structural frontier event as the
 corresponding one-step process path.
 -/
+@[expose]
 def pathOfEvent {Party : Type u} [DecidableEq Party] (st : State Party) :
     Front st.spec → PFunctor.FreeM.Path st.currentStep.tree
   | event => ⟨event, PUnit.unit⟩
@@ -97,6 +104,7 @@ end State
 Each process state is one packaged structural residual state, and each process
 step is the current frontier interaction produced by `State.currentStep`.
 -/
+@[expose]
 def toProcess {Party : Type u} [DecidableEq Party] : Process (State Party) Party :=
   ProcessOver.ofStep (State Party) State.currentStep
 

--- a/PolyFun/Interaction/Multiparty/Broadcast.lean
+++ b/PolyFun/Interaction/Multiparty/Broadcast.lean
@@ -3,7 +3,10 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.Multiparty.Core
+
+module
+
+public import PolyFun.Interaction.Multiparty.Core
 
 /-!
 # Broadcast / public-path multiparty interaction
@@ -24,6 +27,8 @@ For concrete finite party types, resolvers are intended to be written by
 pattern matching. This preserves the strongest definitional behavior of the
 resulting endpoint types.
 -/
+
+public section
 
 universe u
 

--- a/PolyFun/Interaction/Multiparty/Core.lean
+++ b/PolyFun/Interaction/Multiparty/Core.lean
@@ -3,10 +3,14 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.Basic.Decoration
-import PolyFun.Interaction.Basic.StrategyOver
-import PolyFun.Interaction.Basic.TypeTree
-import PolyFun.Interaction.Multiparty.Observation
+
+module
+
+import all PolyFun.Interaction.Multiparty.Observation
+public import PolyFun.Interaction.Basic.Decoration
+public import PolyFun.Interaction.Basic.StrategyOver
+public import PolyFun.Interaction.Basic.TypeTree
+public import PolyFun.Interaction.Multiparty.Observation
 
 /-!
 # View modes: per-participant local-view shapes for multiparty interactions
@@ -128,6 +132,8 @@ structure. The multiparty layer only describes how one fixed participant
 locally sees each node of such a type tree.
 -/
 
+public section
+
 universe u v
 
 namespace Interaction
@@ -207,6 +213,7 @@ Reading by cases:
 This packages the information content of a `ViewMode` independently from the
 more structured endpoint semantics of `ViewMode.Action`.
 -/
+@[expose]
 def ObsType {X : Type u} : ViewMode X → Type u
   | .pick => X
   | .observe => X
@@ -223,6 +230,7 @@ information that is revealed:
 * `hidden` reveals nothing;
 * `react ⟨_, toObs⟩` reveals `toObs x`.
 -/
+@[expose]
 def obsOf {X : Type u} : (view : ViewMode X) → X → view.ObsType
   | .pick, x => x
   | .observe, x => x
@@ -248,6 +256,7 @@ Interpretation by cases:
 This is the native multiparty analogue of `Interaction.Role.Action` from the
 two-party layer, extended by hidden and partial-observation cases.
 -/
+@[expose]
 def Action {X : Type u} (view : ViewMode X) (m : Type u → Type u)
     (Cont : X → Type u) : Type u :=
   match view with
@@ -274,6 +283,7 @@ in observation content. The "this party authors the move" semantics that one
 might expect from `.pick` lives instead in
 `Concurrent.NodeAuthority.controllers`.
 -/
+@[expose]
 def toObservation {X : Type u} : ViewMode X → Observation X
   | .pick => Observation.top X
   | .observe => Observation.top X
@@ -344,6 +354,7 @@ corresponding `.react` (those constructors carry operational shape
 information that the kernel form deliberately discards, but their
 information content is preserved as `Observation.top` / `Observation.bot`).
 -/
+@[expose]
 def toViewMode {X : Type u} (k : Observation X) : ViewMode X :=
   .react k
 

--- a/PolyFun/Interaction/Multiparty/Directed.lean
+++ b/PolyFun/Interaction/Multiparty/Directed.lean
@@ -3,7 +3,10 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.Multiparty.Core
+
+module
+
+public import PolyFun.Interaction.Multiparty.Core
 
 /-!
 # Directed point-to-point multiparty interaction
@@ -23,6 +26,8 @@ Unlike the broadcast model, only one non-sender party receives the chosen move,
 and the remaining parties need not even learn which branch was taken at that
 step.
 -/
+
+public section
 
 universe u
 

--- a/PolyFun/Interaction/Multiparty/Observation.lean
+++ b/PolyFun/Interaction/Multiparty/Observation.lean
@@ -3,10 +3,13 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import Mathlib.Order.BoundedOrder.Basic
-import Mathlib.Order.Lattice
 
-import PolyFun.Interaction.Basic.TypeTree
+module
+
+public import Mathlib.Order.BoundedOrder.Basic
+public import Mathlib.Order.Lattice
+
+public import PolyFun.Interaction.Basic.TypeTree
 
 /-!
 # Observations: the information lattice of a single move
@@ -99,6 +102,8 @@ operational refinement and its `rfl`-friendly action shapes live in
 `Multiparty/Core.lean` (`ViewMode`); this file only knows the universal form.
 -/
 
+public section
+
 universe u v
 
 namespace Interaction
@@ -116,7 +121,7 @@ this exposes `Observation X` as the index type
 polynomial functor: the universal "observations of `X`" container. An
 element of the polynomial is precisely a chosen codomain together with a
 projection from `X` into it. -/
-@[reducible]
+@[expose, reducible]
 def basePFunctor (X : Type u) : PFunctor.{u + 1, u} where
   A := Type u
   B := (X → ·)

--- a/PolyFun/Interaction/Multiparty/ObservationProfile.lean
+++ b/PolyFun/Interaction/Multiparty/ObservationProfile.lean
@@ -3,7 +3,10 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.Multiparty.Profile
+
+module
+
+public import PolyFun.Interaction.Multiparty.Profile
 
 /-!
 # Observation-form profiles for compositional reasoning about disclosure
@@ -59,6 +62,8 @@ the joint indistinguishability relation, and the underlying `Refines` is
 only a preorder (not antisymmetric).
 -/
 
+public section
+
 universe u v
 
 namespace Interaction
@@ -107,6 +112,7 @@ either build a mixed profile that uses `ViewMode` directly for those
 parties, or compose the observation profile with a separate operational
 decoration downstream.
 -/
+@[expose]
 def toViewProfile (k : ObservationProfile Party X) : ViewProfile Party X :=
   fun p => Observation.toViewMode (k p)
 

--- a/PolyFun/Interaction/Multiparty/Profile.lean
+++ b/PolyFun/Interaction/Multiparty/Profile.lean
@@ -3,7 +3,10 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.Multiparty.Core
+
+module
+
+public import PolyFun.Interaction.Multiparty.Core
 
 /-!
 # Per-party local-view profiles for multiparty interaction
@@ -21,6 +24,8 @@ This is the most direct structured way to describe multiparty nodes with:
 * parties that observe only a kernel of the move (`ViewMode.react ⟨..⟩`); and
 * parties that observe nothing at all (`ViewMode.hidden`).
 -/
+
+public section
 
 universe u
 

--- a/PolyFun/Interaction/TwoParty/Compose.lean
+++ b/PolyFun/Interaction/TwoParty/Compose.lean
@@ -3,14 +3,18 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import Mathlib.Control.Monad.Basic
-import Mathlib.Data.Sigma.Basic
-import PolyFun.Control.Lawful.Basic
-import PolyFun.Interaction.Basic.Append
-import PolyFun.Interaction.Basic.Replicate
-import PolyFun.Interaction.Basic.StateChain
-import PolyFun.Interaction.TwoParty.Decoration
-import PolyFun.Interaction.TwoParty.Strategy
+
+module
+
+import all PolyFun.Interaction.TwoParty.Decoration
+public import Mathlib.Control.Monad.Basic
+public import Mathlib.Data.Sigma.Basic
+public import PolyFun.Control.Lawful.Basic
+public import PolyFun.Interaction.Basic.Append
+public import PolyFun.Interaction.Basic.Replicate
+public import PolyFun.Interaction.Basic.StateChain
+public import PolyFun.Interaction.TwoParty.Decoration
+public import PolyFun.Interaction.TwoParty.Strategy
 
 /-!
 # Composing two-party protocols
@@ -25,6 +29,8 @@ for the output type (factored form). The flat variants (`compFlat`,
 `StrategyOver.TwoParty.Counterpart.appendFlat`) take a single output
 family on the combined path.
 -/
+
+public section
 
 open LawfulMonad
 

--- a/PolyFun/Interaction/TwoParty/Decoration.lean
+++ b/PolyFun/Interaction/TwoParty/Decoration.lean
@@ -3,11 +3,15 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.Basic.TypeTree
-import PolyFun.Interaction.Basic.Decoration
-import PolyFun.Interaction.Basic.MonadDecoration
-import PolyFun.Interaction.TwoParty.Role
-import Batteries.Tactic.Lint
+
+module
+
+import all PolyFun.Interaction.Basic.MonadDecoration
+public import PolyFun.Interaction.Basic.TypeTree
+public import PolyFun.Interaction.Basic.Decoration
+public import PolyFun.Interaction.Basic.MonadDecoration
+public import PolyFun.Interaction.TwoParty.Role
+public import Batteries.Tactic.Lint
 
 /-!
 # Role decorations and common role-based node contexts
@@ -32,6 +36,8 @@ realized node contexts, because `BundledMonad` lives in a higher universe than `
 These contexts are ordinary inputs to `StrategyOver`: roles say who owns the
 move, and monad decorations say which node effect is used by each participant.
 -/
+
+public section
 
 universe u uA uB t
 
@@ -99,6 +105,7 @@ def RoleDecorationOver.swap {s : PFunctor.FreeM P α} (roles : RoleDecorationOve
 namespace RoleDecorationOver
 
 /-- View a generic monad decoration as one displayed layer over a role decoration. -/
+@[expose]
 def monadsOver :
     (s : PFunctor.FreeM P α) → (roles : RoleDecorationOver (P := P) s) →
     (md : MonadDecoration (P := P) (α := α) s) →
@@ -229,6 +236,7 @@ def RoleDecoration.swap {spec : TypeTree} (roles : RoleDecoration spec) :
 namespace RoleDecoration
 
 /-- View a plain monad decoration as one displayed layer over an existing role decoration. -/
+@[expose]
 def monadsOver :
     (spec : TypeTree.{u}) → (roles : RoleDecoration spec) → (md : TypeTree.MonadDecoration spec) →
     Decoration.Over (fun _ => Role) (fun _ (_ : Role) => BundledMonad.{u, u}) spec roles
@@ -237,6 +245,7 @@ def monadsOver :
       ⟨bm, fun x => monadsOver (rest x) (rRest x) (mRest x)⟩
 
 /-- Pack roles together with one bundled monad per node into `RoleMonadContext`. -/
+@[expose]
 def withMonads {spec : TypeTree.{u}}
     (roles : RoleDecoration spec) (md : TypeTree.MonadDecoration spec) :
     Decoration RoleMonadContext spec :=
@@ -253,6 +262,9 @@ theorem withMonads_constant_eq_map
       Decoration.map (RoleContext.withMonad bm) spec roles
   | .done, _ => rfl
   | .node _ rest, ⟨role, rRest⟩ => by
+      simp only [RoleDecoration.withMonads, RoleDecoration.monadsOver,
+        TypeTree.MonadDecoration.constant, MonadDecoration.constant,
+        Decoration.ofOver]
       change
         (⟨⟨role, bm⟩,
           fun x =>

--- a/PolyFun/Interaction/TwoParty/Refine.lean
+++ b/PolyFun/Interaction/TwoParty/Refine.lean
@@ -3,13 +3,16 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import Mathlib.Logic.Equiv.Defs
 
-import PolyFun.Interaction.Basic.Append
-import PolyFun.Interaction.Basic.Replicate
-import PolyFun.Interaction.Basic.StateChain
-import PolyFun.Interaction.TwoParty.Decoration
-import PolyFun.Interaction.TwoParty.Role
+module
+
+public import Mathlib.Logic.Equiv.Defs
+
+public import PolyFun.Interaction.Basic.Append
+public import PolyFun.Interaction.Basic.Replicate
+public import PolyFun.Interaction.Basic.StateChain
+public import PolyFun.Interaction.TwoParty.Decoration
+public import PolyFun.Interaction.TwoParty.Role
 
 /-!
 # Role-aware refinement and bridge to `Decoration.Over`
@@ -18,6 +21,8 @@ import PolyFun.Interaction.TwoParty.Role
 to `Decoration.Over` with fiber `Role.SenderData` is an equivalence; `map` laws commute with
 `append`, `replicate`, and `stateChain`.
 -/
+
+public section
 
 universe u v w w₂
 
@@ -28,7 +33,7 @@ namespace TwoParty
 open TwoParty
 
 /-- Role-aware displayed data: `S X` at sender nodes; `∀` recursion at receiver nodes. -/
-@[reducible] def Role.Refine (S : Type u → Type v) :
+@[expose, reducible] def Role.Refine (S : Type u → Type v) :
     (spec : TypeTree.{u}) → RoleDecoration spec → Type (max u v)
   | .done, _ => PUnit
   | .node X rest, ⟨.sender, rRest⟩ =>
@@ -50,6 +55,7 @@ def map {S : Type u → Type v} {T : Type u → Type w}
       fun x => map f (rest x) (rRest x) (rr x)
 
 /-- Append refinements over appended role decorations. -/
+@[expose]
 def append {S : Type u → Type v}
     {s₁ : TypeTree} {s₂ : PFunctor.FreeM.Path s₁ → TypeTree}
     {r₁ : RoleDecoration s₁}
@@ -95,6 +101,7 @@ end Role.Refine
 namespace Role
 
 /-- Fiber `S X` at sender and `PUnit` at receiver (for the `Decoration.Over` bridge). -/
+@[expose]
 def SenderData (S : Type u → Type v) (X : Type u) : Role → Type v
   | .sender => S X
   | .receiver => PUnit
@@ -204,6 +211,7 @@ theorem map_stateChain {S T : Type u → Type v} (f : ∀ X, S X → T X)
 /-- Present a role refinement as a displayed decoration, attaching the sender
 data at each node to the underlying role decoration. Inverse to
 `ofDecorationOver`. -/
+@[expose]
 def toDecorationOver {S : Type u → Type v} :
     (spec : TypeTree) → (roles : RoleDecoration spec) →
     Role.Refine S spec roles →
@@ -216,6 +224,7 @@ def toDecorationOver {S : Type u → Type v} :
 
 /-- Recover a role refinement from a displayed decoration carrying the sender
 data over the role decoration. Inverse to `toDecorationOver`. -/
+@[expose]
 def ofDecorationOver {S : Type u → Type v} :
     (spec : TypeTree) → (roles : RoleDecoration spec) →
     Decoration.Over (fun _ => Role) (fun X r => Role.SenderData S X r) spec roles →

--- a/PolyFun/Interaction/TwoParty/Role.lean
+++ b/PolyFun/Interaction/TwoParty/Role.lean
@@ -4,6 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
 
+module
+
 /-!
 # Sender / receiver roles
 
@@ -11,6 +13,8 @@ Authors: Quang Dao
 `Action` and `Dual` package the active/passive node shapes for the focal side
 and its environment; `interact` runs one round.
 -/
+
+public section
 
 universe u
 
@@ -31,6 +35,7 @@ def swap : Role → Role
 
 /-- Focal party's action type: when acting, the focal party may use effects to
 choose the next move itself; when observing, it responds to any received move. -/
+@[expose]
 def Action (role : Role) (m : Type u → Type u) (X : Type u) (Cont : X → Type u) : Type u :=
   match role with
   | .sender => m ((x : X) × Cont x)
@@ -38,6 +43,7 @@ def Action (role : Role) (m : Type u → Type u) (X : Type u) (Cont : X → Type
 
 /-- Environment / dual view: sender branch observes the chosen move and may
 continue effectfully; receiver branch samples the move and continuation. -/
+@[expose]
 def Dual (role : Role) (m : Type u → Type u) (X : Type u) (Cont : X → Type u) : Type u :=
   match role with
   | .sender => (x : X) → m (Cont x)

--- a/PolyFun/Interaction/TwoParty/Strategy.lean
+++ b/PolyFun/Interaction/TwoParty/Strategy.lean
@@ -3,15 +3,23 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.Basic.Decoration
-import PolyFun.Interaction.Basic.Interaction
-import PolyFun.Interaction.Basic.MonadDecoration
-import PolyFun.Interaction.Basic.Ownership
-import PolyFun.Interaction.Basic.Shape
-import PolyFun.Interaction.Basic.Syntax
-import PolyFun.Interaction.Basic.TypeTree
-import PolyFun.Interaction.TwoParty.Decoration
-import PolyFun.Interaction.TwoParty.Syntax
+
+module
+
+import all PolyFun.Interaction.Basic.Interaction
+import all PolyFun.Interaction.Basic.Ownership
+import all PolyFun.Interaction.Basic.StrategyOver
+import all PolyFun.Interaction.TwoParty.Decoration
+import all PolyFun.Interaction.TwoParty.Syntax
+public import PolyFun.Interaction.Basic.Decoration
+public import PolyFun.Interaction.Basic.Interaction
+public import PolyFun.Interaction.Basic.MonadDecoration
+public import PolyFun.Interaction.Basic.Ownership
+public import PolyFun.Interaction.Basic.Shape
+public import PolyFun.Interaction.Basic.Syntax
+public import PolyFun.Interaction.Basic.TypeTree
+public import PolyFun.Interaction.TwoParty.Decoration
+public import PolyFun.Interaction.TwoParty.Syntax
 
 /-!
 # Role-dependent strategies and counterparts
@@ -38,6 +46,8 @@ This is the structure needed for replay against a prescribed public path
 while keeping execution itself in the ordinary two-party model.
 -/
 
+public section
+
 universe u
 
 namespace Interaction
@@ -49,6 +59,7 @@ open TwoParty
 
 /-- The ordinary paired two-party local syntax specialized to plain type trees,
 using the identity lens on `TypeTree.basePFunctor` and roles as node metadata. -/
+@[expose]
 def _root_.Interaction.SyntaxOver.TwoParty.pairedTypeTree (m : Type u → Type u) :
     SyntaxOver
       (PFunctor.Lens.id TypeTree.basePFunctor) Participant.{u} (fun _ => Role) :=
@@ -96,6 +107,7 @@ theorem _root_.Interaction.SyntaxOver.TwoParty.pairedTypeTree_eq_ownerBased
         simp [PFunctor.Lens.id, TypeTree.Ownership.LocalView.node, perspective, typeTreePerspective]
 
 /-- Functorial shape for the ordinary paired two-party syntax over plain type trees. -/
+@[expose]
 def _root_.Interaction.ShapeOver.TwoParty.pairedTypeTree (m : Type u → Type u) [Functor m] :
     ShapeOver
       (PFunctor.Lens.id TypeTree.basePFunctor) Participant.{u} (fun _ => Role) :=
@@ -109,6 +121,7 @@ supplies the move and continuation, while the focal participant observes it.
 Together with `InteractionOver.run`, this is the canonical whole-protocol runner
 for two-party role-decorated strategies.
 -/
+@[expose]
 def _root_.Interaction.InteractionOver.TwoParty.pairedTypeTree (m : Type u → Type u) [Monad m] :
     InteractionOver
       (PFunctor.Lens.id TypeTree.basePFunctor) Participant.{u} (fun _ => Role)
@@ -118,12 +131,14 @@ def _root_.Interaction.InteractionOver.TwoParty.pairedTypeTree (m : Type u → T
 /-- The paired role/monad two-party local syntax specialized to plain type trees,
 using the identity lens on `TypeTree.basePFunctor` and `RolePairedMonadContext`
 as node metadata. -/
+@[expose]
 def _root_.Interaction.SyntaxOver.TwoParty.pairedMonadicTypeTree :
     SyntaxOver
       (PFunctor.Lens.id TypeTree.basePFunctor) Participant.{u} RolePairedMonadContext :=
   SyntaxOver.TwoParty.pairedMonadic (PFunctor.Lens.id TypeTree.basePFunctor)
 
 /-- Functorial shape for paired role/monad two-party syntax over plain type trees. -/
+@[expose]
 def _root_.Interaction.ShapeOver.TwoParty.pairedMonadicTypeTree :
     ShapeOver
       (PFunctor.Lens.id TypeTree.basePFunctor) Participant.{u} RolePairedMonadContext :=
@@ -137,6 +152,7 @@ At sender nodes the focal participant owns the move and returns a message
 together with the continuation in the node monad. At receiver nodes it observes
 the counterpart's message and returns the continuation in the node monad.
 -/
+@[expose]
 def _root_.Interaction.SyntaxOver.TwoParty.Focal.monadicTypeTree :
     SyntaxOver
       (PFunctor.Lens.id TypeTree.basePFunctor) PUnit RoleMonadContext :=
@@ -152,6 +168,7 @@ The local node syntax is `SyntaxOver.TwoParty.Focal.monadicTypeTree`; the map op
 only recursive continuations, leaving the role, node monad, and selected move
 unchanged.
 -/
+@[expose]
 def _root_.Interaction.ShapeOver.TwoParty.Focal.monadicTypeTree :
     ShapeOver
       (PFunctor.Lens.id TypeTree.basePFunctor) PUnit RoleMonadContext :=
@@ -167,6 +184,7 @@ At sender nodes the counterpart observes the focal participant's move. At
 receiver nodes it owns the move and returns a message together with the
 continuation in the node monad.
 -/
+@[expose]
 def _root_.Interaction.SyntaxOver.TwoParty.Counterpart.monadicTypeTree :
     SyntaxOver
       (PFunctor.Lens.id TypeTree.basePFunctor) PUnit RoleMonadContext :=
@@ -182,6 +200,7 @@ The local node syntax is `SyntaxOver.TwoParty.Counterpart.monadicTypeTree`; the 
 transports only recursive continuations, preserving the role, node monad, and
 message/challenge choice.
 -/
+@[expose]
 def _root_.Interaction.ShapeOver.TwoParty.Counterpart.monadicTypeTree :
     ShapeOver
       (PFunctor.Lens.id TypeTree.basePFunctor) PUnit RoleMonadContext :=
@@ -305,6 +324,7 @@ separately.
 
 This is exactly the extra structure needed to replay a prescribed path
 through the verifier. -/
+@[expose]
 def counterpartSyntax (m : Type u → Type u) :
     SyntaxOver
       (PFunctor.Lens.id TypeTree.basePFunctor) PUnit (fun _ => Role) :=
@@ -451,6 +471,7 @@ The focal participant carries `OutputP`, while the counterpart carries
 `OutputC`. Naming this family gives the runner, profiles, and computation
 rules a single canonical shape for participant outputs, which keeps dependent
 function arguments definitionally aligned. -/
+@[expose]
 def participantOutputFamily
     {spec : TypeTree} (OutputP OutputC : PFunctor.FreeM.Path spec → Type u)
     (agent : Participant.{u}) (tr : PFunctor.FreeM.Path spec) : Type u :=
@@ -460,6 +481,7 @@ def participantOutputFamily
 
 /-- Collect the two participant-indexed outputs into the result pair of a
 two-party run. -/
+@[expose]
 def collectParticipantOutputs
     {spec : TypeTree} {OutputP OutputC : PFunctor.FreeM.Path spec → Type u} :
     (tr : PFunctor.FreeM.Path spec) →
@@ -469,6 +491,7 @@ def collectParticipantOutputs
 
 /-- Assemble the focal strategy and counterpart strategy into a
 participant-indexed profile for the generic runner. -/
+@[expose]
 def participantProfile
     {m : Type u → Type u} {spec : TypeTree} {roles : RoleDecoration spec}
     {OutputP OutputC : PFunctor.FreeM.Path spec → Type u}
@@ -488,6 +511,7 @@ This is the generic `InteractionOver.run` specialized to
 `SyntaxOver.TwoParty.pairedTypeTree`, with the two participant fibers assembled
 by `participantProfile` and collected by `collectParticipantOutputs`.
 -/
+@[expose]
 def run {m : Type u → Type u} [Monad m]
     (spec : TypeTree) (roles : RoleDecoration spec)
     {OutputP : PFunctor.FreeM.Path spec → Type u}
@@ -790,6 +814,7 @@ def _root_.Interaction.StrategyOver.TwoParty.Focal.ofConstantMonads
 View an ordinary single-monad role strategy as a strategy over a constant monad
 decoration.
 -/
+@[expose]
 def _root_.Interaction.StrategyOver.TwoParty.Focal.toConstantMonadsHom
     {m : Type u → Type u} [Monad m] [LawfulFunctor m] :
     StrategyOver.ShapeContextHom

--- a/PolyFun/Interaction/TwoParty/Swap.lean
+++ b/PolyFun/Interaction/TwoParty/Swap.lean
@@ -3,11 +3,16 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.Basic.Append
-import PolyFun.Interaction.Basic.Decoration
-import PolyFun.Interaction.Basic.TypeTree
-import PolyFun.Interaction.TwoParty.Decoration
-import PolyFun.Interaction.TwoParty.Role
+
+module
+
+import all PolyFun.Interaction.TwoParty.Decoration
+import all PolyFun.Interaction.TwoParty.Role
+public import PolyFun.Interaction.Basic.Append
+public import PolyFun.Interaction.Basic.Decoration
+public import PolyFun.Interaction.Basic.TypeTree
+public import PolyFun.Interaction.TwoParty.Decoration
+public import PolyFun.Interaction.TwoParty.Role
 
 /-!
 # Swapping roles
@@ -15,6 +20,8 @@ import PolyFun.Interaction.TwoParty.Role
 Involutivity of `Role.swap`, compatibility with `RoleDecoration.map`, and interaction with
 appended role decorations.
 -/
+
+public section
 
 universe u
 

--- a/PolyFun/Interaction/TwoParty/Syntax.lean
+++ b/PolyFun/Interaction/TwoParty/Syntax.lean
@@ -3,11 +3,14 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.Basic.Interaction
-import PolyFun.Interaction.Basic.Ownership
-import PolyFun.Interaction.Basic.Shape
-import PolyFun.Interaction.TwoParty.Decoration
-import PolyFun.Interaction.TwoParty.Role
+
+module
+
+public import PolyFun.Interaction.Basic.Interaction
+public import PolyFun.Interaction.Basic.Ownership
+public import PolyFun.Interaction.Basic.Shape
+public import PolyFun.Interaction.TwoParty.Decoration
+public import PolyFun.Interaction.TwoParty.Role
 
 /-!
 # Two-party syntax over lens-executed trees
@@ -19,7 +22,7 @@ It intentionally does not define another recursive strategy hierarchy:
 whole-tree participant types are always obtained from `StrategyOver`.
 -/
 
-@[expose] public section
+public section
 
 universe u uA uB uA₂ uB₂ w
 
@@ -38,6 +41,7 @@ inductive Participant : Type u where
   deriving DecidableEq
 
 /-- Ownership perspective induced by a sender/receiver role. -/
+@[expose]
 def perspective : Role → Participant → Ownership.Perspective
   | .sender, .focal => .owner
   | .sender, .counterpart => .observer
@@ -45,6 +49,7 @@ def perspective : Role → Participant → Ownership.Perspective
   | .receiver, .counterpart => .owner
 
 /-- TypeTree-facing form of `perspective`, using the plain `TypeTree.Ownership` perspective type. -/
+@[expose]
 def typeTreePerspective (role : Role) (agent : Participant) : TypeTree.Ownership.Perspective :=
   match perspective role agent with
   | .owner => .owner
@@ -56,6 +61,7 @@ by an unbundled effect-like type constructor.
 This is weaker than `SyntaxOver.TwoParty.monadic`: it records the same owner/observer node
 shapes but does not require a `Monad` instance for `m`. Execution laws can add
 that instance only at the point where effects are actually run. -/
+@[expose]
 def _root_.Interaction.SyntaxOver.TwoParty.paired (m : Type uB₂ → Type uB₂) :
     SyntaxOver l Participant (fun _ : P.A => Role) where
   Node agent pos role Cont :=
@@ -66,6 +72,7 @@ def _root_.Interaction.SyntaxOver.TwoParty.paired (m : Type uB₂ → Type uB₂
     | .counterpart, .receiver => m ((d : Q.B (l.toFunA pos)) × Cont d)
 
 /-- Functorial shape for `SyntaxOver.TwoParty.paired`. -/
+@[expose]
 def _root_.Interaction.ShapeOver.TwoParty.paired (m : Type uB₂ → Type uB₂) [Functor m] :
     Interaction.ShapeOver l Participant (fun _ : P.A => Role) where
   toSyntaxOver := (SyntaxOver.TwoParty.paired l m :
@@ -96,6 +103,7 @@ def _root_.Interaction.ShapeOver.TwoParty.paired (m : Type uB₂ → Type uB₂)
 At sender nodes, the focal participant chooses the runtime direction. At
 receiver nodes, the counterpart chooses it. The other participant follows the
 chosen direction with its observer continuation. -/
+@[expose]
 def _root_.Interaction.InteractionOver.TwoParty.paired
     (m : Type uB₂ → Type uB₂) [Monad m] :
     InteractionOver l Participant.{uB₂} (fun _ : P.A => Role)
@@ -128,6 +136,7 @@ def _root_.Interaction.InteractionOver.TwoParty.paired
           | .counterpart => cCont)
 
 /-- Two-party monadic syntax over an arbitrary lens-executed control tree. -/
+@[expose]
 def _root_.Interaction.SyntaxOver.TwoParty.monadic
     (monad : (pos : P.A) → Role → Participant → BundledMonad.{max uB₂ w, max uB₂ w}) :
     SyntaxOver l Participant (fun _ : P.A => Role) :=
@@ -179,6 +188,7 @@ def _root_.Interaction.ShapeOver.TwoParty.monadic
               ((d : Q.B (l.toFunA pos)) × B d))
 
 /-- Two-party syntax over a paired focal/counterpart monad context. -/
+@[expose]
 def _root_.Interaction.SyntaxOver.TwoParty.pairedMonadic :
     SyntaxOver l Participant
       (RolePairedMonadContextOver.{uB₂, uA, uB} P) where
@@ -194,6 +204,7 @@ def _root_.Interaction.SyntaxOver.TwoParty.pairedMonadic :
         bmC.M ((d : Q.B (l.toFunA pos)) × Cont d)
 
 /-- Functorial shape for `SyntaxOver.TwoParty.pairedMonadic`. -/
+@[expose]
 def _root_.Interaction.ShapeOver.TwoParty.pairedMonadic :
     Interaction.ShapeOver l Participant
       (RolePairedMonadContextOver.{uB₂, uA, uB} P) where
@@ -264,6 +275,7 @@ Sender nodes observe the focal side's move. Receiver nodes expose the sampler
 and challenge-indexed continuation separately, which supports replay against a
 prescribed public path.
 -/
+@[expose]
 def _root_.Interaction.SyntaxOver.TwoParty.PublicCoinCounterpart.counterpart
     (m : Type uB₂ → Type uB₂) :
     SyntaxOver l PUnit (fun _ : P.A => Role) where

--- a/PolyFun/Interaction/UC/CorruptionModel.lean
+++ b/PolyFun/Interaction/UC/CorruptionModel.lean
@@ -3,7 +3,10 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.UC.EnvOpenProcess
+
+module
+
+public import PolyFun.Interaction.UC.EnvOpenProcess
 
 /-!
 # Corruption models as bundled environment alphabets
@@ -74,6 +77,8 @@ proof / lemma that is generic over the corruption model" — declare
 `(M : CorruptionModel)` and use `M.Event`, `M.State`, `M.envAction`,
 `M.Process Party Δ`.
 -/
+
+public section
 
 universe u v w'
 

--- a/PolyFun/Interaction/UC/Emulates.lean
+++ b/PolyFun/Interaction/UC/Emulates.lean
@@ -3,7 +3,11 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.UC.OpenTheory
+
+module
+
+import all PolyFun.Interaction.UC.Interface
+public import PolyFun.Interaction.UC.OpenTheory
 
 /-!
 # Contextual emulation and UC security
@@ -70,6 +74,8 @@ because the triangle inequality only gives `2ε`) cannot be packaged as
 distance is closed under sums and is a genuine equivalence), not at the
 fixed-`ε` level.
 -/
+
+public section
 
 universe u
 

--- a/PolyFun/Interaction/UC/EnvAction.lean
+++ b/PolyFun/Interaction/UC/EnvAction.lean
@@ -3,6 +3,9 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
+
+module
+
 import Mathlib.Init
 
 /-!
@@ -90,6 +93,8 @@ instantiation (corruption with refresh-based healing) lives in
 `MomentaryCorruption.lean`.
 -/
 
+public section
+
 universe u v w
 
 namespace Interaction
@@ -144,6 +149,7 @@ ever fire.
 Useful as the default for processes that do not care about
 environment-driven dynamics.
 -/
+@[expose]
 def empty [Pure m] (X : Type v) : EnvAction m Empty X where
   react e _ := e.elim
 
@@ -155,6 +161,7 @@ This is the canonical "passive observer" reaction, useful when a
 process participates in an alphabet (so its `EnvAction` slot is
 non-trivially typed) but its state has no per-event update.
 -/
+@[expose]
 def passive [Pure m] (Event : Type u) (X : Type v) : EnvAction m Event X where
   react _ x := pure x
 
@@ -167,6 +174,7 @@ routing it through `g` to obtain `s' : Event'` and applying the
 original reaction. This is the contravariant action on the alphabet
 that lets coarser alphabets be embedded into finer ones.
 -/
+@[expose]
 def comap [Pure m] {Event Event' : Type u} {X : Type v}
     (g : Event → Event') (e : EnvAction m Event' X) : EnvAction m Event X where
   react s x := e.react (g s) x

--- a/PolyFun/Interaction/UC/EnvOpenProcess.lean
+++ b/PolyFun/Interaction/UC/EnvOpenProcess.lean
@@ -3,8 +3,11 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.UC.OpenProcess
-import PolyFun.Interaction.UC.EnvAction
+
+module
+
+public import PolyFun.Interaction.UC.OpenProcess
+public import PolyFun.Interaction.UC.EnvAction
 
 /-!
 # Open processes paired with an environment-event channel
@@ -79,6 +82,8 @@ The canonical CJSV22 instantiation `MomentaryCorruption.Process`
 value) lives in `MomentaryCorruption.lean`.
 -/
 
+public section
+
 universe u uE v w w'
 
 namespace Interaction
@@ -129,7 +134,7 @@ Forget the environment channel and view as a plain `OpenProcess`.
 This is the canonical projection: it drops the env action and retains
 only the open-process boundary surface.
 -/
-@[reducible]
+@[expose, reducible]
 def toOpenProcess (E : EnvOpenProcess.{u, uE, v, w, w'} m Party Δ Event State) :
     OpenProcess.{u, v, w, w'} m Party Δ := E.process
 
@@ -140,6 +145,7 @@ underlying `EnvAction.react`.
 Provided as a top-level projection so that downstream consumers can
 write `E.react e s` without unfolding the wrapper.
 -/
+@[expose]
 def react (E : EnvOpenProcess.{u, uE, v, w, w'} m Party Δ Event State)
     (e : Event) (s : State) : m State :=
   E.envAction.react e s
@@ -158,6 +164,7 @@ events ever fire.
 This is the canonical no-op wrapping: every existing `OpenProcess`
 embeds into `EnvOpenProcess _ _ Empty State` for any `State`.
 -/
+@[expose]
 def ofOpenProcess (P : OpenProcess.{u, v, w, w'} m Party Δ) (S : Type w) :
     EnvOpenProcess.{u, 0, v, w, w'} m Party Δ Empty S where
   process := P
@@ -179,6 +186,7 @@ Useful when a process needs to participate in a non-trivial alphabet
 (so its env-channel slot must be inhabited at the chosen `Event` /
 `State` types) but its own state is unaffected by every event.
 -/
+@[expose]
 def passive (P : OpenProcess.{u, v, w, w'} m Party Δ) (Event : Type uE) (S : Type w) :
     EnvOpenProcess.{u, uE, v, w, w'} m Party Δ Event S where
   process := P
@@ -211,6 +219,7 @@ tracks broadcast events).
 
 The underlying open process is unchanged.
 -/
+@[expose]
 def comapEvent {Event' : Type uE} (g : Event → Event')
     (E : EnvOpenProcess.{u, uE, v, w, w'} m Party Δ Event' State) :
     EnvOpenProcess.{u, uE, v, w, w'} m Party Δ Event State where
@@ -246,6 +255,7 @@ Used when the same open process needs to be paired with a different env
 channel (e.g. lifting from the canonical `MomentaryCorruption.react`
 reaction to a richer simulator-controlled reaction with its own state).
 -/
+@[expose]
 def withEnvAction {Event' : Type uE} {State' : Type w}
     (E : EnvOpenProcess.{u, uE, v, w, w'} m Party Δ Event State)
     (ea : EnvAction m Event' State') :
@@ -277,6 +287,7 @@ The env action is independent of the port boundary, so it is carried
 through unchanged. This is the env-channel-aware analogue of
 `OpenProcess.mapBoundary`.
 -/
+@[expose]
 def mapBoundary {Δ₁ Δ₂ : PortBoundary} (φ : PortBoundary.Hom Δ₁ Δ₂)
     (E : EnvOpenProcess.{u, uE, v, w, w'} m Party Δ₁ Event State) :
     EnvOpenProcess.{u, uE, v, w, w'} m Party Δ₂ Event State where

--- a/PolyFun/Interaction/UC/Interface.lean
+++ b/PolyFun/Interaction/UC/Interface.lean
@@ -3,10 +3,13 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.PFunctor.Chart.Basic
-import PolyFun.PFunctor.Equiv.Basic
-import PolyFun.PFunctor.Lens.Basic
-import Batteries.Tactic.Lint
+
+module
+
+public import PolyFun.PFunctor.Chart.Basic
+public import PolyFun.PFunctor.Equiv.Basic
+public import PolyFun.PFunctor.Lens.Basic
+public import Batteries.Tactic.Lint
 
 /-!
 # UC interfaces and open boundaries
@@ -75,6 +78,8 @@ re-introducing their own packet/interface vocabulary.
   Interaction — the composition product, charts, lenses, and monoidal
   structures on polynomial functors used throughout this file
 -/
+
+public section
 
 universe uA uB vA vB wA wB
 
@@ -514,6 +519,7 @@ Left inclusion into a disjoint sum of interfaces.
 
 Maps a packet on `I₁` to the left summand of `sum I₁ I₂`.
 -/
+@[expose]
 def inl (I₁ : Interface.{uA, uB}) (I₂ : Interface.{vA, uB}) : Hom I₁ (Interface.sum I₁ I₂) where
   toFunA := Sum.inl
   toFunB _ m := m
@@ -523,6 +529,7 @@ Right inclusion into a disjoint sum of interfaces.
 
 Maps a packet on `I₂` to the right summand of `sum I₁ I₂`.
 -/
+@[expose]
 def inr (I₁ : Interface.{uA, uB}) (I₂ : Interface.{vA, uB}) : Hom I₂ (Interface.sum I₁ I₂) where
   toFunA := Sum.inr
   toFunB _ m := m
@@ -733,6 +740,7 @@ namespace PortBoundary
 /--
 The empty open boundary: no inputs and no outputs.
 -/
+@[expose]
 def empty : PortBoundary :=
   ⟨Interface.empty, Interface.empty⟩
 
@@ -742,6 +750,7 @@ Swap the direction of a boundary.
 This is the structural operation underlying plugging:
 the outputs expected by one side become inputs for the other, and vice versa.
 -/
+@[expose]
 def swap (Δ : PortBoundary) : PortBoundary :=
   ⟨Δ.Out, Δ.In⟩
 
@@ -751,6 +760,7 @@ Side-by-side composition of open boundaries.
 Inputs and outputs are combined by disjoint sum, so the resulting boundary
 exposes both components in parallel.
 -/
+@[expose]
 def tensor (Δ₁ Δ₂ : PortBoundary) : PortBoundary :=
   ⟨Interface.sum Δ₁.In Δ₂.In, Interface.sum Δ₁.Out Δ₂.Out⟩
 
@@ -796,6 +806,7 @@ Combine two boundary adaptations side by side.
 This is the boundary-level companion to `PortBoundary.tensor`: the left and
 right adaptations act independently on the corresponding summands.
 -/
+@[expose]
 def tensor {Δ₁ Δ₂ Δ₁' Δ₂' : PortBoundary} (f₁ : Hom Δ₁ Δ₁') (f₂ : Hom Δ₂ Δ₂') :
     Hom (PortBoundary.tensor Δ₁ Δ₂) (PortBoundary.tensor Δ₁' Δ₂') where
   onIn := Interface.Hom.sum f₁.onIn f₂.onIn
@@ -807,12 +818,14 @@ Swap the direction of a boundary adaptation.
 This is the structural boundary-level counterpart of `PortBoundary.swap`:
 incoming and outgoing interface maps exchange roles.
 -/
+@[expose]
 def swap {Δ₁ Δ₂ : PortBoundary} (f : Hom Δ₁ Δ₂) :
     Hom (PortBoundary.swap Δ₂) (PortBoundary.swap Δ₁) where
   onIn := f.onOut
   onOut := f.onIn
 
 /-- The identity boundary adaptation. -/
+@[expose]
 def id (Δ : PortBoundary) : Hom Δ Δ where
   onIn := Interface.Hom.id Δ.In
   onOut := Interface.Hom.id Δ.Out
@@ -822,6 +835,7 @@ Compose two boundary adaptations.
 
 `comp g f` first adapts `Δ₁` to `Δ₂`, then adapts `Δ₂` to `Δ₃`.
 -/
+@[expose]
 def comp {Δ₁ Δ₂ Δ₃ : PortBoundary} (g : Hom Δ₂ Δ₃) (f : Hom Δ₁ Δ₂) : Hom Δ₁ Δ₃ where
   onIn := Interface.Hom.comp f.onIn g.onIn
   onOut := Interface.Hom.comp g.onOut f.onOut

--- a/PolyFun/Interaction/UC/Leakage.lean
+++ b/PolyFun/Interaction/UC/Leakage.lean
@@ -4,6 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
 
+module
+
 /-!
 # Leakage observation models
 
@@ -64,6 +66,8 @@ adversary blind). Forcing every protocol to declare what it leaks
 turns the equivocability obligation into a missing-instance error
 rather than a meta-theoretic side condition.
 -/
+
+public section
 
 universe u
 

--- a/PolyFun/Interaction/UC/MachineId.lean
+++ b/PolyFun/Interaction/UC/MachineId.lean
@@ -3,7 +3,10 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.UC.OpenProcess
+
+module
+
+public import PolyFun.Interaction.UC.OpenProcess
 
 /-!
 # Machine identity for UC composition
@@ -64,6 +67,8 @@ against the runtime. Consumers that need the contract enforced should
 filter incoming routed packets explicitly through `allowed` at the
 appropriate boundary surface.
 -/
+
+public section
 
 universe u v w w'
 
@@ -190,7 +195,7 @@ Useful for protocols whose security does not depend on per-machine input
 filtering, and as the canonical baseline against which more restrictive
 instances are compared.
 -/
-@[reducible]
+@[expose, reducible]
 def allowAll (P : OpenProcess.{u, v, w, w'} m Party Δ) : HasAccessControl P where
   allowed _ := true
 
@@ -213,7 +218,7 @@ senders whose session identifier is also `s`. Combined with a sender-aware
 emit (delivered by F2), this recovers the full structural same-session
 discipline.
 -/
-@[reducible]
+@[expose, reducible]
 def MachineProcess.allowSameSession
     {Sid Pid : Type u} {m : Type w → Type w'} {Δ : PortBoundary} [DecidableEq Sid]
     (owner : MachineId Sid Pid)

--- a/PolyFun/Interaction/UC/MomentaryCorruption.lean
+++ b/PolyFun/Interaction/UC/MomentaryCorruption.lean
@@ -3,10 +3,13 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.UC.CorruptionModel
-import PolyFun.Interaction.UC.EnvAction
-import PolyFun.Interaction.UC.EnvOpenProcess
-import PolyFun.Interaction.UC.MachineId
+
+module
+
+public import PolyFun.Interaction.UC.CorruptionModel
+public import PolyFun.Interaction.UC.EnvAction
+public import PolyFun.Interaction.UC.EnvOpenProcess
+public import PolyFun.Interaction.UC.MachineId
 
 /-!
 # Momentary corruption: the CJSV22 corruption model
@@ -82,6 +85,8 @@ The deterministic state updates require `[DecidableEq Sid]
 themselves do not.
 -/
 
+public section
+
 universe v w'
 
 namespace Interaction
@@ -119,6 +124,7 @@ namespace Alphabet
 variable {Sid Pid : Type}
 
 /-- The machine targeted by an event. -/
+@[expose]
 def target : Alphabet Sid Pid → MachineId Sid Pid
   | .compromise m => m
   | .refresh m    => m
@@ -190,6 +196,7 @@ variable {Sid Pid : Type}
 The fully-honest initial state: nothing corrupted, nothing
 compromised, every machine at epoch zero.
 -/
+@[expose]
 def init : State Sid Pid := {}
 
 instance : Inhabited (State Sid Pid) := ⟨init⟩
@@ -214,6 +221,7 @@ This is a deterministic update, so the value lives in the
 underlying `State`; the canonical `EnvAction` reaction wraps it
 via `pure`.
 -/
+@[expose]
 def applyCompromise (m : MachineId Sid Pid) (cs : State Sid Pid) : State Sid Pid where
   corrupted := Function.update cs.corrupted m true
   compromised := fun m' e' =>
@@ -230,6 +238,7 @@ this is the structural ingredient that lets the model derive PCS
 (post-compromise security) as a healing theorem rather than as an
 axiom.
 -/
+@[expose]
 def applyRefresh (m : MachineId Sid Pid) (cs : State Sid Pid) : State Sid Pid where
   corrupted := Function.update cs.corrupted m false
   compromised := cs.compromised
@@ -304,12 +313,14 @@ The reaction is monad-parametric: any `[Pure m]` works, and
 deterministic protocols typically use `m := Id` while crypto-flavored
 consumers instantiate `m := ProbComp`.
 -/
+@[expose]
 def react (s : Alphabet Sid Pid) (cs : State Sid Pid) : m (State Sid Pid) :=
   match s with
   | .compromise m₀ => pure (State.applyCompromise m₀ cs)
   | .refresh m₀    => pure (State.applyRefresh m₀ cs)
 
 /-- The canonical momentary-corruption `EnvAction`. -/
+@[expose]
 def envAction : EnvAction m (Alphabet Sid Pid) (State Sid Pid) where
   react := react
 
@@ -332,6 +343,7 @@ the `CorruptionModel` API — for instance, when stating a lemma
 that is generic over corruption models but instantiated to the
 momentary case at a use site.
 -/
+@[expose]
 def model (Sid Pid : Type) [DecidableEq Sid] [DecidableEq Pid] (m : Type → Type w') [Pure m] :
     CorruptionModel m where
   Event := Alphabet Sid Pid
@@ -378,6 +390,7 @@ non-trivial leakage function that depends on the protocol state)
 build their `EnvOpenProcess` directly with a bespoke `EnvAction`
 rather than going through this wrapping.
 -/
+@[expose]
 def MachineProcess.withMomentaryCorruption
     {Sid Pid : Type} {m : Type → Type w'} [Pure m] {Δ : PortBoundary}
     [DecidableEq Sid] [DecidableEq Pid]

--- a/PolyFun/Interaction/UC/Notation.lean
+++ b/PolyFun/Interaction/UC/Notation.lean
@@ -3,7 +3,10 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.UC.OpenSyntax.Expr
+
+module
+
+public import PolyFun.Interaction.UC.OpenSyntax.Expr
 
 /-!
 # UC composition notation
@@ -46,6 +49,8 @@ Precedence ensures natural parenthesization:
 * `Γᵛ ⊗ᵇ Δ` = `tensor (swap Γ) Δ` (postfix `ᵛ` at max precedence)
 * `(Δ₁ ⊗ᵇ Δ₂)ᵛ` = `swap (tensor Δ₁ Δ₂)` (parentheses required)
 -/
+
+public section
 
 namespace Interaction.UC
 

--- a/PolyFun/Interaction/UC/OpenProcess.lean
+++ b/PolyFun/Interaction/UC/OpenProcess.lean
@@ -3,12 +3,16 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.PFunctor.Trace
-import PolyFun.Control.Bisimulation
-import PolyFun.Interaction.Basic.Sampler
-import PolyFun.Interaction.Concurrent.Process
-import PolyFun.Interaction.UC.Interface
-import Batteries.Tactic.Lint
+
+module
+
+import all PolyFun.Interaction.UC.Interface
+public import PolyFun.PFunctor.Trace
+public import PolyFun.Control.Bisimulation
+public import PolyFun.Interaction.Basic.Sampler
+public import PolyFun.Interaction.Concurrent.Process
+public import PolyFun.Interaction.UC.Interface
+public import Batteries.Tactic.Lint
 
 /-!
 # Open concurrent processes with boundary traffic
@@ -56,6 +60,8 @@ decorated step path. It is structural only: routing, buffering, and
 probabilistic execution belong to downstream runtime interpreters.
 -/
 
+public section
+
 universe u v v₁ v₂ v₃ w w'
 
 namespace Interaction
@@ -101,6 +107,7 @@ namespace BoundaryAction
 /--
 A purely internal node: not externally activated and no outbound packets.
 -/
+@[expose]
 def internal (Δ : PortBoundary) (X : Type w) : BoundaryAction Δ X where
   isActivated := false
   emit := 1
@@ -125,6 +132,7 @@ The activation flag is preserved (it does not depend on the boundary
 presentation). The emitted-trace is pushed forward along the output chart
 `φ.onOut` via `PFunctor.Trace.mapChart`.
 -/
+@[expose]
 def mapBoundary {Δ₁ Δ₂ : PortBoundary} {X : Type w}
     (φ : PortBoundary.Hom Δ₁ Δ₂) (b : BoundaryAction Δ₁ X) : BoundaryAction Δ₂ X where
   isActivated := b.isActivated
@@ -214,6 +222,7 @@ This is used by `plug` to internalize all boundary interactions. The
 emitted-trace is the monoid unit `1`, which is definitionally the constant-`[]`
 trace.
 -/
+@[expose]
 def closed {Δ : PortBoundary} {X : Type w} (b : BoundaryAction Δ X) :
     BoundaryAction PortBoundary.empty X where
   isActivated := b.isActivated
@@ -383,6 +392,7 @@ abbrev productView (Party : Type u) (Δ : PortBoundary) : TypeTree.Node.Context.
 /--
 Forward direction of the polynomial-product bridge: read off the
 `(NodeProfile, BoundaryAction)` pair from an `OpenNodeProfile`. -/
+@[expose]
 def toProductView (Party : Type u) (Δ : PortBoundary) : TypeTree.Node.ContextHom
       (OpenNodeContext Party Δ : TypeTree.Node.Context.{w}) (productView.{u, w} Party Δ) :=
   fun _ ons => (ons.toNodeProfile, ons.boundary)
@@ -390,6 +400,7 @@ def toProductView (Party : Type u) (Δ : PortBoundary) : TypeTree.Node.ContextHo
 /--
 Inverse direction of the polynomial-product bridge: reassemble an
 `OpenNodeProfile` from a `(NodeProfile, BoundaryAction)` pair. -/
+@[expose]
 def ofProductView (Party : Type u) (Δ : PortBoundary) : TypeTree.Node.ContextHom
       (productView.{u, w} Party Δ) (OpenNodeContext Party Δ : TypeTree.Node.Context.{w}) :=
   fun _ p => { toNodeProfile := p.1, boundary := p.2 }
@@ -417,6 +428,7 @@ The forgetful map from the open-world context to the closed-world context.
 This drops the `BoundaryAction` and retains only the `NodeProfile`
 (controllers and local views).
 -/
+@[expose]
 def forget (Party : Type u) (Δ : PortBoundary) : TypeTree.Node.ContextHom
       (OpenNodeContext Party Δ : TypeTree.Node.Context.{w}) (StepContext Party) :=
   fun _ ons => ons.toNodeProfile
@@ -426,6 +438,7 @@ The embedding from the closed-world context into the open-world context.
 
 This marks every node as purely internal (no boundary traffic).
 -/
+@[expose]
 def embed (Party : Type u) (Δ : PortBoundary) : TypeTree.Node.ContextHom (StepContext Party)
       (OpenNodeContext Party Δ : TypeTree.Node.Context.{w}) :=
   fun _ ns => .ofClosed ns
@@ -436,6 +449,7 @@ The context hom induced by a boundary adaptation.
 This transforms every node's boundary action along `φ` while preserving
 the closed-world node semantics.
 -/
+@[expose]
 def map (Party : Type u) {Δ₁ Δ₂ : PortBoundary} (φ : PortBoundary.Hom Δ₁ Δ₂) :
     TypeTree.Node.ContextHom (OpenNodeContext Party Δ₁ : TypeTree.Node.Context.{w})
       (OpenNodeContext Party Δ₂ : TypeTree.Node.Context.{w}) :=
@@ -578,7 +592,10 @@ theorem forget_eq_prodFst_comp_toProductView (Party : Type u) (Δ : PortBoundary
     forget.{u, w} Party Δ = TypeTree.Node.ContextHom.comp
         (TypeTree.Node.Context.prodFst (StepContext Party)
           (fun X : Type w => BoundaryAction Δ X))
-        (toProductView Party Δ) := rfl
+        (toProductView Party Δ) := by
+  funext X ons
+  cases ons
+  rfl
 
 /-- `embed` is the pairing of the identity on `StepContext` with the
 constant `internal` boundary action, transported back along the bridge. -/
@@ -586,7 +603,10 @@ theorem embed_eq_ofProductView_comp_prodPair (Party : Type u) (Δ : PortBoundary
     embed.{u, w} Party Δ = TypeTree.Node.ContextHom.comp (ofProductView Party Δ)
         (TypeTree.Node.Context.prodPair
           (TypeTree.Node.ContextHom.id (StepContext Party))
-          (fun X _ => BoundaryAction.internal Δ X)) := rfl
+          (fun X _ => BoundaryAction.internal Δ X)) := by
+  funext X node
+  cases node
+  rfl
 
 /-- `map φ` factors as the polynomial-product map of the identity on
 `StepContext` and the boundary-action transport
@@ -599,7 +619,10 @@ theorem map_eq_ofProductView_comp_prodMap_comp_toProductView
           (TypeTree.Node.Context.prodMap
             (TypeTree.Node.ContextHom.id (StepContext Party))
             (fun X (b : BoundaryAction Δ₁ X) => b.mapBoundary φ)))
-        (toProductView Party Δ₁) := rfl
+        (toProductView Party Δ₁) := by
+  funext X ons
+  cases ons
+  rfl
 
 end OpenNodeContext
 
@@ -687,7 +710,7 @@ namespace OpenProcess
 /-- Structural projection onto the underlying `ProcessOver`, dropping
 the per-state sampler. The closed-world `ProcessOver` lemmas from
 `Concurrent/Process.lean` apply through this projection. -/
-@[reducible]
+@[expose, reducible]
 def toProcess {m : Type w → Type w'} {Party : Type u} {Δ : PortBoundary}
     (op : OpenProcess.{u, v, w, w'} m Party Δ) :
     ProcessOver op.Proc (OpenNodeContext.{u, w} Party Δ) :=
@@ -731,6 +754,7 @@ packets, preserving activation flags) while leaving the process structure,
 closed-world node semantics, and per-step samplers unchanged. The sampler
 carries over verbatim because `StepOver.mapContext` preserves `step.tree`.
 -/
+@[expose]
 def mapBoundary {m : Type w → Type w'} {Party : Type u} {Δ₁ Δ₂ : PortBoundary}
     (φ : PortBoundary.Hom Δ₁ Δ₂) (op : OpenProcess.{u, v, w, w'} m Party Δ₁) :
     OpenProcess.{u, v, w, w'} m Party Δ₂ where
@@ -843,6 +867,7 @@ observation is whether a complete path is externally activated. Silent
 paths receive label `none`; every activated path receives the
 single visible label `some ()`. Packet/action identity and sampler effects are
 deliberately absent from this structural observation. -/
+@[expose]
 noncomputable def OpenProcess.activationLTS
     {m : Type w → Type w'} {Party : Type u} {Δ : PortBoundary}
     (p : OpenProcess.{u, v, w, w'} m Party Δ) : Control.LTS Unit := by

--- a/PolyFun/Interaction/UC/OpenProcessModel.lean
+++ b/PolyFun/Interaction/UC/OpenProcessModel.lean
@@ -3,8 +3,12 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.UC.OpenProcess
-import PolyFun.Interaction.UC.OpenTheory
+
+module
+
+import all PolyFun.Interaction.UC.OpenProcess
+public import PolyFun.Interaction.UC.OpenProcess
+public import PolyFun.Interaction.UC.OpenTheory
 
 /-!
 # Concrete `OpenTheory` model backed by `OpenProcess m`
@@ -38,6 +42,8 @@ that carry a per-step nodewise-monadic sampler in the intermediate monad
   the scheduler-interleaving pattern.
 -/
 
+public section
+
 universe u v w w'
 
 namespace Interaction
@@ -52,8 +58,9 @@ variable (Party : Type u)
 variable (m : Type w → Type w')
 variable (schedulerSampler : m (ULift.{w, 0} Bool))
 
-/-- The hidden scheduler node shared by `par`, `wire`, and `plug`. -/
-private def schedulerNode (Δ : PortBoundary) :
+/-- The canonical internal scheduler node shared by `par`, `wire`, and `plug`. -/
+@[expose]
+def schedulerNode (Δ : PortBoundary) :
     OpenNodeProfile.{u, w} Party Δ (ULift.{w, 0} Bool) where
   controllers := fun _ => []
   views := fun _ => .hidden
@@ -70,6 +77,7 @@ The concrete open-composition theory backed by `OpenProcess m`.
   appropriate context morphisms and thread the shared `schedulerSampler`
   through `TypeTree.Sampler.interleave`.
 -/
+@[expose]
 def openTheory : OpenTheory where
   Obj Δ := OpenProcess.{u, v, w, w'} m Party Δ
   map φ p := p.mapBoundary φ

--- a/PolyFun/Interaction/UC/OpenSyntax/Expr.lean
+++ b/PolyFun/Interaction/UC/OpenSyntax/Expr.lean
@@ -3,8 +3,13 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.UC.OpenSyntax.Interp
-import PolyFun.Interaction.UC.OpenSyntax.Raw
+
+module
+
+import all PolyFun.Interaction.UC.OpenSyntax.Interp
+import all PolyFun.Interaction.UC.OpenSyntax.Raw
+public import PolyFun.Interaction.UC.OpenSyntax.Interp
+public import PolyFun.Interaction.UC.OpenSyntax.Raw
 
 /-!
 # Quotiented free model of open composition
@@ -31,6 +36,8 @@ construction: each law holds because it is a constructor of `Raw.Equiv`.
 * `Expr.toInterp`: embedding into the tagless-final `Interp` model.
 -/
 
+public section
+
 universe u
 
 namespace Interaction
@@ -48,6 +55,7 @@ laws, so it forms a lawful `OpenTheory`.
 For pattern matching on the underlying syntax, project to `Raw` via
 `Expr.liftOn` or work with `Raw` directly.
 -/
+@[expose]
 def Expr (Atom : PortBoundary → Type u) (Δ : PortBoundary) : Type (u + 1) :=
   Quotient (Raw.setoid Atom Δ)
 
@@ -56,6 +64,7 @@ namespace Expr
 /--
 Project a raw expression into the quotiented `Expr`.
 -/
+@[expose]
 def mk {Atom : PortBoundary → Type u} {Δ : PortBoundary}
     (e : Raw Atom Δ) : Expr Atom Δ :=
   Quotient.mk _ e
@@ -63,6 +72,7 @@ def mk {Atom : PortBoundary → Type u} {Δ : PortBoundary}
 /--
 Inject a primitive open component.
 -/
+@[expose]
 def atom {Atom : PortBoundary → Type u} {Δ : PortBoundary}
     (a : Atom Δ) : Expr Atom Δ :=
   mk (.atom a)
@@ -70,6 +80,7 @@ def atom {Atom : PortBoundary → Type u} {Δ : PortBoundary}
 /--
 Adapt the exposed boundary along a structural morphism.
 -/
+@[expose]
 def map {Atom : PortBoundary → Type u} {Δ₁ Δ₂ : PortBoundary}
     (f : PortBoundary.Hom Δ₁ Δ₂)
     (e : Expr Atom Δ₁) : Expr Atom Δ₂ :=
@@ -79,6 +90,7 @@ def map {Atom : PortBoundary → Type u} {Δ₁ Δ₂ : PortBoundary}
 /--
 Place two open systems side by side.
 -/
+@[expose]
 def par {Atom : PortBoundary → Type u} {Δ₁ Δ₂ : PortBoundary}
     (e₁ : Expr Atom Δ₁) (e₂ : Expr Atom Δ₂) :
     Expr Atom (PortBoundary.tensor Δ₁ Δ₂) :=
@@ -88,6 +100,7 @@ def par {Atom : PortBoundary → Type u} {Δ₁ Δ₂ : PortBoundary}
 /--
 Connect one shared boundary between two open systems.
 -/
+@[expose]
 def wire {Atom : PortBoundary → Type u} {Δ₁ Γ Δ₂ : PortBoundary}
     (e₁ : Expr Atom (PortBoundary.tensor Δ₁ Γ))
     (e₂ : Expr Atom (PortBoundary.tensor (PortBoundary.swap Γ) Δ₂)) :
@@ -98,6 +111,7 @@ def wire {Atom : PortBoundary → Type u} {Δ₁ Γ Δ₂ : PortBoundary}
 /--
 The identity wire (coevaluation) on boundary `Γ`.
 -/
+@[expose]
 def idWire {Atom : PortBoundary → Type u} (Γ : PortBoundary) :
     Expr Atom (PortBoundary.tensor (PortBoundary.swap Γ) Γ) :=
   mk (.idWire Γ)
@@ -106,6 +120,7 @@ def idWire {Atom : PortBoundary → Type u} (Γ : PortBoundary) :
 Close an open system against a matching context.
 Derived from `wire` and `map`, mirroring `Raw.plug`.
 -/
+@[expose]
 def plug {Atom : PortBoundary → Type u} {Δ : PortBoundary}
     (e : Expr Atom Δ) (k : Expr Atom (PortBoundary.swap Δ)) :
     Expr Atom PortBoundary.empty :=
@@ -119,6 +134,7 @@ def plug {Atom : PortBoundary → Type u} {Δ : PortBoundary}
 The monoidal unit (closed system with no boundary).
 Derived from `idWire` and `map`, mirroring `Raw.unit`.
 -/
+@[expose]
 def unit {Atom : PortBoundary → Type u} : Expr Atom PortBoundary.empty :=
   Expr.map (PortBoundary.Equiv.tensorEmptyLeft PortBoundary.empty).toHom
     (Expr.idWire PortBoundary.empty)
@@ -130,6 +146,7 @@ plug-wire factorization structure.
 Well-defined on the quotient because `Raw.Equiv.interpret_eq` shows that
 equivalent raw expressions interpret the same way in any such theory.
 -/
+@[expose]
 def interpret {Atom : PortBoundary → Type u} {Δ : PortBoundary}
     (e : Expr Atom Δ)
     (T : OpenTheory)
@@ -334,6 +351,7 @@ Well-defined on the quotient because equivalent raw expressions interpret the
 same way in every compact closed theory (which is exactly what `Interp.ext`
 requires).
 -/
+@[expose]
 def toInterp {Atom : PortBoundary → Type u} {Δ : PortBoundary}
     (e : Expr Atom Δ) : Interp Atom Δ :=
   Quotient.liftOn e

--- a/PolyFun/Interaction/UC/OpenSyntax/Interp.lean
+++ b/PolyFun/Interaction/UC/OpenSyntax/Interp.lean
@@ -3,7 +3,10 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.UC.OpenTheory
+
+module
+
+public import PolyFun.Interaction.UC.OpenTheory
 
 /-!
 # Tagless-final free model of open composition
@@ -22,6 +25,8 @@ its lawfulness reduces immediately to the target theory's laws.
 See `OpenSyntax.Expr` for the quotiented initial model that supports
 pattern matching and inspection.
 -/
+
+public section
 
 universe u
 
@@ -80,6 +85,7 @@ theorem ext {Atom : PortBoundary → Type u} {Δ : PortBoundary} {W₁ W₂ : In
 /--
 Inject a primitive open component into the tagless-final syntax.
 -/
+@[expose]
 def atom {Atom : PortBoundary → Type u} {Δ : PortBoundary} : Atom Δ → Interp Atom Δ
   | a => ⟨fun _ _ interp => interp a⟩
 
@@ -93,6 +99,7 @@ theorem interpret_atom {Atom : PortBoundary → Type u} {Δ : PortBoundary} (a :
 /--
 Adapt the exposed boundary of a tagless-final expression.
 -/
+@[expose]
 def map {Atom : PortBoundary → Type u} {Δ₁ Δ₂ : PortBoundary} (f : PortBoundary.Hom Δ₁ Δ₂) :
     Interp Atom Δ₁ → Interp Atom Δ₂
   | W => ⟨fun T hT interp => T.map f (W.run T hT interp)⟩
@@ -107,6 +114,7 @@ theorem interpret_map {Atom : PortBoundary → Type u} {Δ₁ Δ₂ : PortBounda
 /--
 Place two tagless-final expressions side by side.
 -/
+@[expose]
 def par {Atom : PortBoundary → Type u} {Δ₁ Δ₂ : PortBoundary} :
     Interp Atom Δ₁ → Interp Atom Δ₂ → Interp Atom (PortBoundary.tensor Δ₁ Δ₂)
   | W₁, W₂ => ⟨fun T hT interp =>
@@ -123,6 +131,7 @@ theorem interpret_par {Atom : PortBoundary → Type u} {Δ₁ Δ₂ : PortBounda
 /--
 Connect one shared boundary between two tagless-final expressions.
 -/
+@[expose]
 def wire {Atom : PortBoundary → Type u} {Δ₁ Γ Δ₂ : PortBoundary} :
     Interp Atom (PortBoundary.tensor Δ₁ Γ) →
     Interp Atom (PortBoundary.tensor (PortBoundary.swap Γ) Δ₂) →
@@ -143,6 +152,7 @@ theorem interpret_wire {Atom : PortBoundary → Type u} {Δ₁ Γ Δ₂ : PortBo
 /--
 Close a tagless-final expression against a matching context.
 -/
+@[expose]
 def plug {Atom : PortBoundary → Type u} {Δ : PortBoundary} :
     Interp Atom Δ → Interp Atom (PortBoundary.swap Δ) → Interp Atom (PortBoundary.empty)
   | W, K => ⟨fun T hT interp =>
@@ -159,6 +169,7 @@ theorem interpret_plug {Atom : PortBoundary → Type u} {Δ : PortBoundary} (W :
 /--
 The monoidal unit (closed system with no boundary).
 -/
+@[expose]
 def unit {Atom : PortBoundary → Type u} : Interp Atom PortBoundary.empty :=
   ⟨fun _ hCC _ => OpenTheory.HasUnit.unit
     (self := hCC.toIsCompactClosed.toIsTraced.toIsMonoidal.toHasUnit)⟩
@@ -172,6 +183,7 @@ theorem interpret_unit {Atom : PortBoundary → Type u} (T : OpenTheory.{max (u 
 /--
 The identity wire (coevaluation) on boundary `Γ`.
 -/
+@[expose]
 def idWire {Atom : PortBoundary → Type u} (Γ : PortBoundary) :
     Interp Atom (PortBoundary.tensor (PortBoundary.swap Γ) Γ) :=
   ⟨fun _ hCC _ => OpenTheory.HasIdWire.idWire

--- a/PolyFun/Interaction/UC/OpenSyntax/Raw.lean
+++ b/PolyFun/Interaction/UC/OpenSyntax/Raw.lean
@@ -3,7 +3,10 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.UC.OpenTheory
+
+module
+
+public import PolyFun.Interaction.UC.OpenTheory
 
 /-!
 # Raw syntax trees for open composition
@@ -32,6 +35,8 @@ The quotient of `Raw` by the `OpenTheory` equations is defined in
   equations and closed under all constructors.
 * `Raw.setoid`: packages `Raw.Equiv` as a `Setoid`.
 -/
+
+public section
 
 universe u
 
@@ -93,6 +98,7 @@ This is structural recursion: each constructor maps to the corresponding
 `OpenTheory` operation. The target theory need not be lawful; lawfulness is
 only required when reasoning about equivalence of interpretations.
 -/
+@[expose]
 def interpret {Atom : PortBoundary → Type u} {Δ : PortBoundary} (e : Raw Atom Δ) (T : OpenTheory)
     (interp : ∀ {Δ : PortBoundary}, Atom Δ → T.Obj Δ)
     (idWireVal : ∀ (Γ : PortBoundary),

--- a/PolyFun/Interaction/UC/OpenTheory.lean
+++ b/PolyFun/Interaction/UC/OpenTheory.lean
@@ -3,7 +3,10 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.UC.Interface
+
+module
+
+public import PolyFun.Interaction.UC.Interface
 
 /-!
 # Open composition algebra with monoidal coherence
@@ -65,6 +68,8 @@ process-backed `openTheory` in `OpenProcessModel.lean` instantiates only
 `IsLawful`; its monoidal coherence and snake equations hold up to
 `OpenProcessActivationEquiv`, not strict equality.
 -/
+
+public section
 
 universe u
 

--- a/PolyFunTest/Interaction/Basic/ChainAppendExamples.lean
+++ b/PolyFunTest/Interaction/Basic/ChainAppendExamples.lean
@@ -3,7 +3,12 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.Basic.Chain.Append
+
+module
+
+import all PolyFun.Interaction.Basic.Chain
+import all PolyFun.Interaction.Basic.Chain.Append
+public import PolyFun.Interaction.Basic.Chain.Append
 
 /-!
 # Dependent chain-concatenation regression tests
@@ -15,52 +20,54 @@ and flattened units, boundary path and output-family transport, strategy
 composition, and typed three-stage reassociation.
 -/
 
+@[expose] public section
+
 namespace Interaction
 namespace TypeTree
 namespace ChainAppendExamples
 
-private def prefixTree : TypeTree :=
+def prefixTree : TypeTree :=
   .node Bool fun _ => .done
 
-private def prefixChain : Chain 1 :=
+def prefixChain : Chain 1 :=
   ⟨prefixTree, fun _ => ⟨⟩⟩
 
-private def middleTree (path : Path (Chain.toTypeTree 1 prefixChain)) : TypeTree :=
+def middleTree (path : Path (Chain.toTypeTree 1 prefixChain)) : TypeTree :=
   .node (Fin (bif path.1 then 2 else 3)) fun _ => .done
 
-private def middle (path : Path (Chain.toTypeTree 1 prefixChain)) : Chain 1 :=
+def middle (path : Path (Chain.toTypeTree 1 prefixChain)) : Chain 1 :=
   ⟨middleTree path, fun _ => ⟨⟩⟩
 
-private def finalArity
+def finalArity
     (path : Path (Chain.toTypeTree (1 + 1) (Chain.then prefixChain middle))) : Nat :=
   let pieces := Chain.splitThenPath prefixChain middle path
   (bif pieces.1.1 then 10 else 20) + pieces.2.1.val + 1
 
-private def finalTree
+def finalTree
     (path : Path (Chain.toTypeTree (1 + 1) (Chain.then prefixChain middle))) : TypeTree :=
   .node (Fin (finalArity path)) fun _ => .done
 
-private def final
+def final
     (path : Path (Chain.toTypeTree (1 + 1) (Chain.then prefixChain middle))) : Chain 1 :=
   ⟨finalTree path, fun _ => ⟨⟩⟩
 
-private def prefixPath : Path (Chain.toTypeTree 1 prefixChain) :=
+def prefixPath : Path (Chain.toTypeTree 1 prefixChain) :=
   ⟨true, ⟨⟩⟩
 
-private def middlePath : Path (Chain.toTypeTree 1 (middle prefixPath)) :=
+def middlePath : Path (Chain.toTypeTree 1 (middle prefixPath)) :=
   ⟨(1 : Fin 2), ⟨⟩⟩
 
-private def combinedPath :
+def combinedPath :
     Path (Chain.toTypeTree (1 + 1) (Chain.then prefixChain middle)) :=
   Chain.appendThenPath prefixChain middle prefixPath middlePath
 
-private def otherPrefixPath : Path (Chain.toTypeTree 1 prefixChain) :=
+def otherPrefixPath : Path (Chain.toTypeTree 1 prefixChain) :=
   ⟨false, ⟨⟩⟩
 
-private def otherMiddlePath : Path (Chain.toTypeTree 1 (middle otherPrefixPath)) :=
+def otherMiddlePath : Path (Chain.toTypeTree 1 (middle otherPrefixPath)) :=
   ⟨(2 : Fin 3), ⟨⟩⟩
 
-private def otherCombinedPath :
+def otherCombinedPath :
     Path (Chain.toTypeTree (1 + 1) (Chain.then prefixChain middle)) :=
   Chain.appendThenPath prefixChain middle otherPrefixPath otherMiddlePath
 
@@ -81,19 +88,19 @@ example : Chain.appendThenPath prefixChain middle
 
 /-! ## Strategy composition across the chain boundary -/
 
-private def boundaryFamily (path : Path (Chain.toTypeTree 1 prefixChain))
+def boundaryFamily (path : Path (Chain.toTypeTree 1 prefixChain))
     (suffix : Path (Chain.toTypeTree 1 (middle path))) : Type :=
   Fin ((bif path.1 then 10 else 20) + suffix.1.val + 1)
 
-private def prefixStrategy : Strategy.Plain Id (Chain.toTypeTree 1 prefixChain) (fun _ => PUnit) :=
+def prefixStrategy : Strategy.Plain Id (Chain.toTypeTree 1 prefixChain) (fun _ => PUnit) :=
   ⟨true, ⟨⟩⟩
 
-private def suffixStrategy : (path : Path (Chain.toTypeTree 1 prefixChain)) → PUnit →
+def suffixStrategy : (path : Path (Chain.toTypeTree 1 prefixChain)) → PUnit →
     Id (Strategy.Plain Id (Chain.toTypeTree 1 (middle path)) (boundaryFamily path))
   | ⟨true, ⟨⟩⟩, _ => ⟨(1 : Fin 2), (0 : Fin 12)⟩
   | ⟨false, ⟨⟩⟩, _ => ⟨(2 : Fin 3), (0 : Fin 23)⟩
 
-private def composedStrategy : Strategy.Plain Id
+def composedStrategy : Strategy.Plain Id
     (Chain.toTypeTree (1 + 1) (Chain.then prefixChain middle))
     (Chain.liftThen prefixChain middle boundaryFamily) :=
   Chain.strategyCompThen prefixChain middle prefixStrategy suffixStrategy

--- a/PolyFunTest/Interaction/Basic/ChainExamples.lean
+++ b/PolyFunTest/Interaction/Basic/ChainExamples.lean
@@ -3,7 +3,11 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.Basic.Chain
+
+module
+
+import all PolyFun.Interaction.Basic.Chain
+public import PolyFun.Interaction.Basic.Chain
 
 /-!
 # Worked examples for continuation-style chains (`TypeTree.Chain`)
@@ -14,6 +18,8 @@ and double as regression tests: a chain whose per-round message type grows with
 the round index, a chain with genuine path-prefix dependence, and
 dependent strategy composition (`replay`) over the prefix-dependent example.
 -/
+
+@[expose] public section
 
 universe u
 
@@ -27,7 +33,7 @@ section GrowingMessages
 
 /-- A protocol where round `k` exchanges a value from `Fin (k + 1)`.
 No state type — the dependency is baked directly into the chain. -/
-private def growingChain : (n : Nat) → (k : Nat) → Chain.{0} n
+def growingChain : (n : Nat) → (k : Nat) → Chain.{0} n
   | 0, _ => ⟨⟩
   | n + 1, k => ⟨.node (Fin (k + 1)) fun _ => .done,
                   fun _ => growingChain n (k + 1)⟩
@@ -47,7 +53,7 @@ example : Path (Chain.toTypeTree 2 (growingChain 2 0)) =
 
 /-- A fully literal 3-round protocol — no parameters, no recursion,
 no state. Just data. -/
-private def threeRoundsLiteral : Chain.{0} 3 :=
+def threeRoundsLiteral : Chain.{0} 3 :=
   ⟨.node (Fin 1) fun _ => .done, fun _ =>
     ⟨.node (Fin 2) fun _ => .done, fun _ =>
       ⟨.node (Fin 3) fun _ => .done, fun _ => ⟨⟩⟩⟩⟩
@@ -63,7 +69,7 @@ end GrowingMessages
 section PrefixDependent
 
 /-- First round branches and exposes branch-specific data to later rounds. -/
-private def branchingRound : TypeTree :=
+def branchingRound : TypeTree :=
   .node Bool fun b =>
     if b then
       .node Nat fun _ => .done
@@ -71,17 +77,17 @@ private def branchingRound : TypeTree :=
       .node (Fin 2) fun _ => .done
 
 /-- The second round depends on the full first-round path. -/
-private def secondRound : Path branchingRound → TypeTree
+def secondRound : Path branchingRound → TypeTree
   | ⟨true, ⟨(n : Nat), ⟨⟩⟩⟩ => .node (Fin (n + 1)) fun _ => .done
   | ⟨false, ⟨i, ⟨⟩⟩⟩ => .node (Fin (i.val + 2)) fun _ => .done
 
 /-- The third round depends on the full two-round path prefix. -/
-private def thirdRound : (tr₁ : Path branchingRound) → Path (secondRound tr₁) → TypeTree
+def thirdRound : (tr₁ : Path branchingRound) → Path (secondRound tr₁) → TypeTree
   | ⟨true, ⟨(n : Nat), ⟨⟩⟩⟩, ⟨k, ⟨⟩⟩ => .node (Fin (n + k.val + 1)) fun _ => .done
   | ⟨false, ⟨i, ⟨⟩⟩⟩, ⟨k, ⟨⟩⟩ => .node (Fin (i.val + k.val + 2)) fun _ => .done
 
 /-- A three-round chain whose final move type genuinely depends on the prefix path. -/
-private def prefixDependent : Chain.{0} 3 :=
+def prefixDependent : Chain.{0} 3 :=
   ⟨branchingRound, fun tr₁ =>
     ⟨secondRound tr₁, fun tr₂ =>
       ⟨thirdRound tr₁ tr₂, fun _ => ⟨⟩⟩⟩⟩
@@ -117,30 +123,30 @@ example (i : Fin 2) :
 /-! ## Dependent strategy composition over the prefix-dependent example -/
 
 /-- Pure strategy that follows a prescribed path and returns a chosen leaf output. -/
-private def scriptStrategy : (spec : TypeTree) → (tr : Path spec) → {Output : Path spec → Type u} →
+def scriptStrategy : (spec : TypeTree) → (tr : Path spec) → {Output : Path spec → Type u} →
     Output tr → Strategy.Plain Id spec Output
   | .done, _, _, out => out
   | .node _ rest, ⟨x, trRest⟩, _, out => ⟨x, scriptStrategy (rest x) trRest out⟩
 
 /-- Carry the flattened path of the remaining chain as the dependent state. -/
-private abbrev ReplayState {n : Nat} (c : Chain.{0} n) : Type :=
+abbrev ReplayState {n : Nat} (c : Chain.{0} n) : Type :=
   Path (Chain.toTypeTree n c)
 
 /-- One dependent step: split the remaining flattened path into this round and the tail,
 play the current round verbatim, and return the tail path. -/
-private def replayStep {n : Nat} (c : Chain.{0} (n + 1)) (tr : ReplayState c) :
+def replayStep {n : Nat} (c : Chain.{0} (n + 1)) (tr : ReplayState c) :
     Id (Strategy.Plain Id c.1 (fun tr₁ => ReplayState (c.2 tr₁))) :=
   let ⟨tr₁, trRest⟩ := Chain.splitPath n c tr
   scriptStrategy c.1 tr₁ trRest
 
 /-- Replay a full flattened path using the intrinsic dependent strategy combinator. -/
-private def replayStrategy (n : Nat) (c : Chain.{0} n) (tr : ReplayState c) :
+def replayStrategy (n : Nat) (c : Chain.{0} n) (tr : ReplayState c) :
     Strategy.Plain Id (Chain.toTypeTree n c)
       (Chain.outputFamily (Family := fun {_} c => ReplayState c) n c) :=
   Chain.strategyComp (Family := fun {_} c => ReplayState c) replayStep n c tr
 
 /-- A concrete `true`-branch path for the prefix-dependent chain. -/
-private def trueReplayPath (n : Nat) (k : Fin (n + 1)) (j : Fin (n + k.val + 1)) :
+def trueReplayPath (n : Nat) (k : Fin (n + 1)) (j : Fin (n + k.val + 1)) :
     Path (Chain.toTypeTree 3 prefixDependent) := by
   let tr₁ : Path branchingRound := ⟨true, ⟨n, ⟨⟩⟩⟩
   let c₂ := prefixDependent.2 tr₁
@@ -152,7 +158,7 @@ private def trueReplayPath (n : Nat) (k : Fin (n + 1)) (j : Fin (n + k.val + 1))
       (Chain.appendPath 0 c₃ tr₃ ⟨⟩))
 
 /-- A concrete `false`-branch path for the prefix-dependent chain. -/
-private def falseReplayPath (i : Fin 2) (k : Fin (i.val + 2)) (j : Fin (i.val + k.val + 2)) :
+def falseReplayPath (i : Fin 2) (k : Fin (i.val + 2)) (j : Fin (i.val + k.val + 2)) :
     Path (Chain.toTypeTree 3 prefixDependent) := by
   let tr₁ : Path branchingRound := ⟨false, ⟨i, ⟨⟩⟩⟩
   let c₂ := prefixDependent.2 tr₁

--- a/PolyFunTest/Interaction/Basic/FoundationNormalization.lean
+++ b/PolyFunTest/Interaction/Basic/FoundationNormalization.lean
@@ -3,9 +3,16 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.Basic.Chain
-import PolyFun.Interaction.Basic.Telescope
-import PolyFun.Interaction.Basic.TypeTreeFintype
+
+module
+
+import all PolyFun.Interaction.Basic.TypeTree
+import all PolyFun.Interaction.Basic.Chain
+import all PolyFun.Interaction.Basic.Telescope
+import all PolyFun.Interaction.Basic.TypeTreeFintype
+public import PolyFun.Interaction.Basic.Chain
+public import PolyFun.Interaction.Basic.Telescope
+public import PolyFun.Interaction.Basic.TypeTreeFintype
 
 /-!
 # Polynomial normalization regression tests
@@ -14,12 +21,14 @@ Checks that interaction type trees, finite chains, and stopping trees expose the
 canonical polynomial structures used by their implementations.
 -/
 
+@[expose] public section
+
 namespace Interaction
 namespace TypeTree
 
 /-! ## Branching properties remain separate and universe-polymorphic -/
 
-private abbrev FiniteEmptyTree : TypeTree := .node Empty fun x => nomatch x
+abbrev FiniteEmptyTree : TypeTree := .node Empty fun x => nomatch x
 
 example : TypeTree.Fintype FiniteEmptyTree :=
   .node inferInstance fun x => nomatch x
@@ -28,7 +37,7 @@ example : ¬ TypeTree.Nonempty FiniteEmptyTree := by
   intro h
   exact h.rootNonempty.elim fun x => nomatch x
 
-private abbrev HigherTree : TypeTree.{1} := .node (ULift (Fin 2)) fun _ => .done
+abbrev HigherTree : TypeTree.{1} := .node (ULift (Fin 2)) fun _ => .done
 
 example : TypeTree.Fintype HigherTree := inferInstance
 
@@ -55,12 +64,12 @@ example (spec : TypeTree) (next : Path spec → TypeTree)
 example (n : Nat) : Chain (Nat.succ n) ≃ TypeTree.stepPoly.Obj (Chain n) :=
   Chain.succEquiv n
 
-private abbrev Stage (i : Nat) := Fin (i + 1)
+abbrev Stage (i : Nat) := Fin (i + 1)
 
-private def stageSpec (i : Nat) (_ : Stage i) : TypeTree :=
+def stageSpec (i : Nat) (_ : Stage i) : TypeTree :=
   .node (Fin (i + 1)) fun _ => .done
 
-private def advance (i : Nat) (s : Stage i) (_ : Path (stageSpec i s)) :
+def advance (i : Nat) (s : Stage i) (_ : Path (stageSpec i s)) :
     Stage (i + 1) :=
   s.castSucc
 
@@ -71,28 +80,28 @@ example (n i : Nat) (s : Stage i) :
 
 /-! ## Telescopes have the indexed initial-algebra fold -/
 
-private def stoppedRound (_ : PUnit) : TypeTree := .done
+def stoppedRound (_ : PUnit) : TypeTree := .done
 
-private def stoppedStep (s : PUnit) (_ : Path (stoppedRound s)) : PUnit :=
+def stoppedStep (s : PUnit) (_ : Path (stoppedRound s)) : PUnit :=
   PUnit.unit
 
-private def twoLayers : Telescope stoppedRound stoppedStep PUnit.unit :=
+def twoLayers : Telescope stoppedRound stoppedStep PUnit.unit :=
   Telescope.extend PUnit.unit fun _ =>
     Telescope.extend PUnit.unit fun _ => Telescope.done PUnit.unit
 
-private def heightAlg :
+def heightAlg :
     PFunctor.FreeM.StoppingTree.Algebra
       (Obs := fun s => Path (stoppedRound s)) (step := stoppedStep)
       (fun _ => Nat) where
   done _ := 0
   extend _ cont := cont PUnit.unit + 1
 
-private def height : {s : PUnit} → Telescope stoppedRound stoppedStep s → Nat :=
+def height : {s : PUnit} → Telescope stoppedRound stoppedStep s → Nat :=
   PFunctor.FreeM.StoppingTree.fold heightAlg
 
 example : height twoLayers = 2 := rfl
 
-private def manualHeight :
+def manualHeight :
     {s : PUnit} → Telescope stoppedRound stoppedStep s → Nat
   | _, .done _ => 0
   | _, .extend _ cont => manualHeight (cont PUnit.unit) + 1

--- a/PolyFunTest/Interaction/Concurrent/Examples.lean
+++ b/PolyFunTest/Interaction/Concurrent/Examples.lean
@@ -3,18 +3,41 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.Concurrent.Equivalence
-import PolyFun.Interaction.Concurrent.Execution
-import PolyFun.Interaction.Concurrent.Fairness
-import PolyFun.Interaction.Concurrent.Independence
-import PolyFun.Interaction.Concurrent.Interleaving
-import PolyFun.Interaction.Concurrent.Liveness
-import PolyFun.Interaction.Concurrent.Machine
-import PolyFun.Interaction.Concurrent.Observation
-import PolyFun.Interaction.Concurrent.Policy
-import PolyFun.Interaction.Concurrent.Refinement
-import PolyFun.Interaction.Concurrent.Run
-import PolyFun.Interaction.Concurrent.Tree
+
+module
+
+import all PolyFun.Interaction.Concurrent.Spec
+import all PolyFun.Interaction.Concurrent.Frontier
+import all PolyFun.Interaction.Concurrent.Control
+import all PolyFun.Interaction.Concurrent.Independence
+import all PolyFun.Interaction.Concurrent.Trace
+import all PolyFun.Interaction.Concurrent.Interleaving
+import all PolyFun.Interaction.Concurrent.Process
+import all PolyFun.Interaction.Concurrent.Profile
+import all PolyFun.Interaction.Concurrent.Current
+import all PolyFun.Interaction.Concurrent.Machine
+import all PolyFun.Interaction.Concurrent.Execution
+import all PolyFun.Interaction.Concurrent.Policy
+import all PolyFun.Interaction.Concurrent.Tree
+import all PolyFun.Interaction.Concurrent.Run
+import all PolyFun.Interaction.Concurrent.Fairness
+import all PolyFun.Interaction.Concurrent.Liveness
+import all PolyFun.Interaction.Concurrent.Observation
+import all PolyFun.Interaction.Concurrent.Refinement
+import all PolyFun.Interaction.Concurrent.MutualSafetyRefinement
+import all PolyFun.Interaction.Concurrent.Equivalence
+public import PolyFun.Interaction.Concurrent.Equivalence
+public import PolyFun.Interaction.Concurrent.Execution
+public import PolyFun.Interaction.Concurrent.Fairness
+public import PolyFun.Interaction.Concurrent.Independence
+public import PolyFun.Interaction.Concurrent.Interleaving
+public import PolyFun.Interaction.Concurrent.Liveness
+public import PolyFun.Interaction.Concurrent.Machine
+public import PolyFun.Interaction.Concurrent.Observation
+public import PolyFun.Interaction.Concurrent.Policy
+public import PolyFun.Interaction.Concurrent.Refinement
+public import PolyFun.Interaction.Concurrent.Run
+public import PolyFun.Interaction.Concurrent.Tree
 
 /-!
 # Concurrent interaction examples
@@ -35,6 +58,8 @@ The examples are intentionally focused on:
 They are meant to exercise the current expressivity surface before later layers
 such as fairness or richer execution semantics are added.
 -/
+
+@[expose] public section
 
 universe u
 

--- a/PolyFunTest/Interaction/Multiparty/Examples.lean
+++ b/PolyFunTest/Interaction/Multiparty/Examples.lean
@@ -3,9 +3,17 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.Multiparty.Broadcast
-import PolyFun.Interaction.Multiparty.Directed
-import PolyFun.Interaction.Multiparty.Profile
+
+module
+
+import all PolyFun.Interaction.Multiparty.Observation
+import all PolyFun.Interaction.Multiparty.Core
+import all PolyFun.Interaction.Multiparty.Broadcast
+import all PolyFun.Interaction.Multiparty.Directed
+import all PolyFun.Interaction.Multiparty.Profile
+public import PolyFun.Interaction.Multiparty.Broadcast
+public import PolyFun.Interaction.Multiparty.Directed
+public import PolyFun.Interaction.Multiparty.Profile
 
 /-!
 # Examples: multiparty endpoints with local views
@@ -27,6 +35,8 @@ The examples are written using pattern-matching resolvers rather than equality
 tests. This is deliberate: for concrete finite party types, it keeps the local
 endpoint types definitionally transparent.
 -/
+
+@[expose] public section
 
 universe u
 
@@ -99,13 +109,13 @@ variable (ExtractedWit : Type u)
 
 /-- TypeTree for a one-round knowledge-soundness interaction:
 message, challenge, witness output, decision, extraction. -/
-private def ksSpec : TypeTree :=
+def ksSpec : TypeTree :=
   TypeTree.node Msg fun _ => .node Chal fun _ => .node WitOut fun _ =>
   .node Decision fun _ => .node ExtractedWit fun _ => .done
 
 /-- Acting parties for the knowledge-soundness interaction in the broadcast
 model. -/
-private def ksParties :
+def ksParties :
     Broadcast.PartyDecoration ThreeParty
       (ksSpec Msg Chal WitOut Decision ExtractedWit) :=
   ⟨.prover, fun _ => ⟨.verifier, fun _ => ⟨.prover, fun _ =>
@@ -154,11 +164,11 @@ variable (m : Type u → Type u) [Monad m] (α : Type u)
 
 /-- A tiny two-step protocol used to demonstrate the directed model:
 `prover → verifier`, then `verifier → extractor`. -/
-private def directedSpec : TypeTree :=
+def directedSpec : TypeTree :=
   TypeTree.node Msg fun _ => .node Ack fun _ => .done
 
 /-- Directed sender/receiver labels for `directedSpec`. -/
-private def directedEdges :
+def directedEdges :
     Directed.EdgeDecoration ThreeParty (directedSpec Msg Ack) :=
   ⟨(.prover, .verifier), fun _ => ⟨(.verifier, .extractor), fun _ => ⟨⟩⟩⟩
 
@@ -202,13 +212,13 @@ variable (Flag : Type u)
 variable (m : Type u → Type u) [Monad m] (α : Type u)
 
 /-- A one-step scheduled event with a public tag and a private payload. -/
-private def scheduledSpec : TypeTree :=
+def scheduledSpec : TypeTree :=
   TypeTree.node (Flag × Msg) fun _ => .done
 
 /-- Per-party local views of the scheduled event:
 the adversary chooses, the recipient observes the full event, the auditor
 learns only the public tag, and the outsider learns nothing. -/
-private def scheduledViews :
+def scheduledViews :
     Profile.Decoration ScheduleParty (scheduledSpec Msg Flag) :=
   ⟨(fun
       | .adversary => .pick
@@ -295,7 +305,7 @@ Bob's local observation of a network action.
 Bob learns the payload exactly in the branches where Bob receives a delivery,
 and otherwise learns only that no payload was received by Bob.
 -/
-private def bobObservation : NetworkAction Msg → Option Msg
+def bobObservation : NetworkAction Msg → Option Msg
   | .drop => none
   | .deliverBob msg => some msg
   | .deliverCarol _ => none
@@ -306,7 +316,7 @@ Carol's local observation of a network action.
 
 This is dual to Bob's observation.
 -/
-private def carolObservation : NetworkAction Msg → Option Msg
+def carolObservation : NetworkAction Msg → Option Msg
   | .drop => none
   | .deliverBob _ => none
   | .deliverCarol msg => some msg
@@ -318,7 +328,7 @@ The public scheduling summary seen by an external auditor.
 The auditor learns which delivery pattern occurred, but never learns the
 payload.
 -/
-private def deliverySummary : NetworkAction Msg → DeliverySummary
+def deliverySummary : NetworkAction Msg → DeliverySummary
   | .drop => .none
   | .deliverBob _ => .bob
   | .deliverCarol _ => .carol
@@ -327,7 +337,7 @@ private def deliverySummary : NetworkAction Msg → DeliverySummary
 /--
 A one-step adversarially scheduled delivery action.
 -/
-private def networkSpec : TypeTree :=
+def networkSpec : TypeTree :=
   TypeTree.node (NetworkAction Msg) fun _ => .done
 
 /--
@@ -339,7 +349,7 @@ This single node already captures several adversarial powers:
 * the auditor learns only the public delivery pattern; and
 * the outsider learns nothing at all.
 -/
-private def networkViews :
+def networkViews :
     Profile.Decoration DeliveryParty (networkSpec Msg) :=
   ⟨(fun
       | .adversary => .pick
@@ -419,7 +429,7 @@ The first move is the adversary's corruption decision. The second move is a
 post-corruption secret-bearing action whose local visibility depends on the
 chosen corruption target.
 -/
-private def corruptionSpec : TypeTree :=
+def corruptionSpec : TypeTree :=
   TypeTree.node CorruptionTarget fun _ => .node Secret fun _ => .done
 
 /--
@@ -435,7 +445,7 @@ This exhibits a key adversarial feature of the framework:
 the local views at later nodes can depend definitionally on earlier
 adversarially chosen moves.
 -/
-private def corruptionViews :
+def corruptionViews :
     Profile.Decoration CorruptionParty (corruptionSpec Secret) :=
   ⟨(fun
       | .adversary => .pick
@@ -462,7 +472,7 @@ to the adversary.
 It is written explicitly so that the resulting endpoint computation reduces by
 `rfl`.
 -/
-private def corruptionAdversaryViews :
+def corruptionAdversaryViews :
     PFunctor.FreeM.Displayed.Decoration (fun X : Type u => ViewMode X) (corruptionSpec Secret) :=
   ⟨.pick, fun _ => ⟨.pick, fun _ => ⟨⟩⟩⟩
 
@@ -473,7 +483,7 @@ to the external monitor.
 The monitor learns the public corruption decision but is hidden from the later
 secret-bearing move in every branch.
 -/
-private def corruptionMonitorViews :
+def corruptionMonitorViews :
     PFunctor.FreeM.Displayed.Decoration (fun X : Type u => ViewMode X) (corruptionSpec Secret) :=
   ⟨.observe, fun _ => ⟨.hidden, fun _ => ⟨⟩⟩⟩
 
@@ -481,7 +491,7 @@ private def corruptionMonitorViews :
 The post-corruption secret-bearing node viewed from the branch where Alice is
 the corrupted party.
 -/
-private def aliceAfterSelfCorruptionViews :
+def aliceAfterSelfCorruptionViews :
     PFunctor.FreeM.Displayed.Decoration (fun X : Type u => ViewMode X)
       (TypeTree.node Secret fun _ => .done) :=
   ⟨.observe, fun _ => ⟨⟩⟩
@@ -490,7 +500,7 @@ private def aliceAfterSelfCorruptionViews :
 The same post-corruption secret-bearing node viewed from the branch where Bob
 is corrupted instead, so Alice is hidden from the move.
 -/
-private def aliceAfterBobCorruptionViews :
+def aliceAfterBobCorruptionViews :
     PFunctor.FreeM.Displayed.Decoration (fun X : Type u => ViewMode X)
       (TypeTree.node Secret fun _ => .done) :=
   ⟨.hidden, fun _ => ⟨⟩⟩

--- a/PolyFunTest/Interaction/TwoParty/Examples.lean
+++ b/PolyFunTest/Interaction/TwoParty/Examples.lean
@@ -3,16 +3,25 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.Basic.TypeTree
-import PolyFun.Interaction.TwoParty.Role
-import PolyFun.Interaction.TwoParty.Decoration
-import PolyFun.Interaction.TwoParty.Strategy
+
+module
+
+import all PolyFun.Interaction.Basic.TypeTree
+import all PolyFun.Interaction.TwoParty.Role
+import all PolyFun.Interaction.TwoParty.Decoration
+import all PolyFun.Interaction.TwoParty.Strategy
+public import PolyFun.Interaction.Basic.TypeTree
+public import PolyFun.Interaction.TwoParty.Role
+public import PolyFun.Interaction.TwoParty.Decoration
+public import PolyFun.Interaction.TwoParty.Strategy
 
 /-!
 # Examples: computing paired two-party strategy types
 
 Small hand-crafted specs show how role-dependent strategy types unfold.
 -/
+
+@[expose] public section
 
 universe u
 
@@ -23,8 +32,8 @@ section Examples
 variable (m : Type u → Type u) [Monad m]
 variable (T U : Type u) (α : Type u)
 
-private def exSpec := TypeTree.node T fun _ => .node U fun _ => .done
-private def exRoles : TwoParty.RoleDecoration (exSpec T U) :=
+def exSpec := TypeTree.node T fun _ => .node U fun _ => .done
+def exRoles : TwoParty.RoleDecoration (exSpec T U) :=
   ⟨.sender, fun _ => ⟨.receiver, fun _ => ⟨⟩⟩⟩
 
 example : StrategyOver (SyntaxOver.TwoParty.pairedTypeTree m) TwoParty.Participant.focal

--- a/PolyFunTest/Interaction/UC/OpenProcessActivationExamples.lean
+++ b/PolyFunTest/Interaction/UC/OpenProcessActivationExamples.lean
@@ -3,7 +3,11 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import PolyFun.Interaction.UC.OpenProcess
+
+module
+
+import all PolyFun.Interaction.UC.OpenProcess
+public import PolyFun.Interaction.UC.OpenProcess
 
 /-!
 # Activation-labelled open-process examples
@@ -12,6 +16,8 @@ Regression checks that the open-process coherence relation is the generic
 delay-bisimulation notion, including across independent process-state
 universes, and therefore inherits the standard delay-to-weak inclusion.
 -/
+
+@[expose] public section
 
 universe u v₁ v₂ w w'
 

--- a/docs/wiki/generated-files.md
+++ b/docs/wiki/generated-files.md
@@ -5,7 +5,7 @@ Edit the source of truth, not the output.
 | Path | What it is | Edit directly? | Source of truth / refresh path |
 | --- | --- | --- | --- |
 | `CLAUDE.md` | compatibility symlink | No | Edit `AGENTS.md` |
-| `PolyFun.lean` | generated umbrella imports | No | `./scripts/update-lib.sh` or `./scripts/check-imports.sh` |
+| `PolyFun.lean` | generated module with umbrella public imports | No | `./scripts/update-lib.sh` or `./scripts/check-imports.sh` |
 | `.lake/` | build artifacts and cache | No | `lake build`, `lake exe cache get` |
 | `lake-manifest.json` | resolved dependency lockfile | Manual edits unsafe | `lake update` (or the `update.yml` workflow) |
 
@@ -13,7 +13,8 @@ Edit the source of truth, not the output.
 
 - `./scripts/update-lib.sh` only uses tracked `PolyFun/**/*.lean` files and
   fails fast if untracked Lean files would be skipped. Stage new files
-  first, then rerun.
+  first, then rerun. It emits a `module` command followed by sorted
+  `public import` commands so importing `PolyFun` re-exports the library API.
 - `./scripts/check-imports.sh` is the lightweight read-only check used in
   CI: it regenerates `PolyFun.lean` to a temp file and diffs against the
   committed copy.

--- a/docs/wiki/interaction.md
+++ b/docs/wiki/interaction.md
@@ -57,6 +57,13 @@ Dependencies flow downward: `Concurrent/` may import `Multiparty/` and
 `Basic/`; `TwoParty/` and `Multiparty/` import only `Basic/`; `UC/` is
 above all of them.
 
+The source modules make this boundary machine-checkable. Public declarations
+are grouped in `public section`; dependencies appearing in their signatures
+use `public import`, while implementation-only dependencies remain private.
+Definitions are `@[expose]` only when downstream computation or definitional
+equality is an intentional part of the API. Proof modules use `import all`
+when they need opaque bodies without widening the exported reducer surface.
+
 ## Core concepts: TypeTree, Node, Party, Profile
 
 Before reading any one file, it helps to fix four words. They are the

--- a/docs/wiki/quickstart.md
+++ b/docs/wiki/quickstart.md
@@ -23,9 +23,11 @@ local validation. By default it runs:
 
 1. `lake build --wfail` (warnings — including `mathlibStandardSet` style
    warnings — are hard failures, matching CI)
-2. `./scripts/check-imports.sh` (umbrella `PolyFun.lean` matches the
+2. `./scripts/check-modules.sh` (all Lean sources use module mode and the
+   Interaction public-scope policy is respected)
+3. `./scripts/check-imports.sh` (umbrella `PolyFun.lean` matches the
    tracked source tree)
-3. `python3 ./scripts/check-docs-integrity.py` (CLAUDE.md symlink and
+4. `python3 ./scripts/check-docs-integrity.py` (CLAUDE.md symlink and
    tracked-markdown link resolution)
 
 ## Validation By Change Type
@@ -68,6 +70,7 @@ issue:
 
 ```bash
 lake build
+./scripts/check-modules.sh
 ./scripts/check-imports.sh
 python3 ./scripts/check-docs-integrity.py
 ```

--- a/docs/wiki/repo-map.md
+++ b/docs/wiki/repo-map.md
@@ -188,6 +188,12 @@ Interaction/{Concurrent, Basic} -> Interaction/UC/{Interface,
 `PolyFun.lean` is a generated umbrella import file, not a hand-maintained
 module index. See [`generated-files.md`](generated-files.md).
 
+Every Lean source uses module mode. The arrows above describe dependency
+direction; a `public import` additionally records that the lower module is
+part of the importing module's API surface. Within `Interaction/`, exported
+declarations live in `public section`, implementation dependencies stay as
+plain imports, and reducibility is exposed declaration-by-declaration.
+
 ## Where To Start By Task
 
 - Working on the polynomial-functor substrate (positions / directions,

--- a/scripts/check-imports.sh
+++ b/scripts/check-imports.sh
@@ -21,14 +21,14 @@ trap restore_original EXIT
 
 ./scripts/update-lib.sh
 
-if git diff --quiet -- PolyFun.lean; then
+if cmp -s "$backup_file" PolyFun.lean; then
   echo "✓ All imports are up to date!"
   exit 0
 fi
 
 echo "❌ Import file is out of date!"
 echo "Differences found:"
-git diff -- PolyFun.lean
+diff -u "$backup_file" PolyFun.lean || true
 echo ""
 echo "To fix this, run: ./scripts/update-lib.sh"
 exit 1

--- a/scripts/check-modules.sh
+++ b/scripts/check-modules.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Check repository-wide Lean module-scope invariants.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+status=0
+
+while IFS= read -r file; do
+  if ! grep -qx 'module' "$file"; then
+    echo "ERROR: $file does not enable module mode with a 'module' command." >&2
+    status=1
+  fi
+done < <(git ls-files -- 'PolyFun.lean' 'PolyFun/*.lean' 'PolyFunTest/*.lean')
+
+while IFS= read -r file; do
+  if ! grep -qx 'public section' "$file"; then
+    echo "ERROR: $file does not declare its Interaction API in a 'public section'." >&2
+    status=1
+  fi
+done < <(git ls-files -- 'PolyFun/Interaction/*.lean')
+
+if rg -n '@\[expose\][[:space:]]+public section' PolyFun/Interaction --glob '*.lean'; then
+  echo "ERROR: Broad exposed public sections are forbidden in PolyFun/Interaction." >&2
+  echo "Expose individual definitions, or use 'import all' in proof modules." >&2
+  status=1
+fi
+
+if (( status != 0 )); then
+  exit "$status"
+fi
+
+echo "✓ Module scopes and Interaction API boundaries are valid."

--- a/scripts/update-lib.sh
+++ b/scripts/update-lib.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Update PolyFun.lean with all imports.
+# Update PolyFun.lean with all public imports.
 # This script only considers tracked files. New PolyFun/**/*.lean files
 # must be staged first.
 
@@ -36,11 +36,16 @@ cleanup() {
 }
 trap cleanup EXIT
 
-git ls-files -- 'PolyFun/*.lean' \
-  | LC_ALL=C sort \
-  | sed 's/\.lean//;s,/,.,g;s/^/import /' > "$tmp_file"
+{
+  echo "module"
+  echo ""
+  git ls-files -- 'PolyFun/*.lean' \
+    | LC_ALL=C sort \
+    | sed 's/\.lean//;s,/,.,g;s/^/public import /'
+} > "$tmp_file"
 
 mv "$tmp_file" PolyFun.lean
 trap - EXIT
 
-echo "✓ PolyFun.lean updated with $(wc -l < PolyFun.lean) imports"
+import_count="$(grep -c '^public import ' PolyFun.lean)"
+echo "✓ PolyFun.lean updated with $import_count public imports"

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -16,6 +16,7 @@ Usage: ./scripts/validate.sh [--lint] [--test]
 
 Default checks:
   - lake build
+  - ./scripts/check-modules.sh
   - ./scripts/check-imports.sh
   - python3 ./scripts/check-docs-integrity.py
 
@@ -47,6 +48,10 @@ done
 
 echo "# Building project"
 lake build --wfail
+
+echo ""
+echo "# Checking module scopes"
+./scripts/check-modules.sh
 
 echo ""
 echo "# Checking umbrella imports"


### PR DESCRIPTION
## Summary

- migrate the remaining `PolyFun/Interaction` production modules and their tests to Lean 4 module scopes
- make import and API boundaries explicit with `public import` and `public section`, using selective exposure only where downstream reduction requires it
- make the generated `PolyFun.lean` umbrella module-aware and add validation that prevents module-scope regressions
- document the module and public-API conventions for future work

## Motivation

This is a first step toward [Verified-zkEVM/VCVio#509](https://github.com/Verified-zkEVM/VCVio/issues/509), “Convert to module system,” opened by @BoltonBailey. That issue identifies PolyFun as one of the dependencies that needs to move first so VCVio can adopt Lean's module system and remain compatible with downstream Lean projects.

The changes here are intentionally minimal: they preserve the existing declaration layout and behavior while making the public surface required by the current codebase explicit. This establishes the compatibility baseline without folding a broad API redesign into the migration.

We should continue with more aggressive follow-up work to:

- reduce public imports and transitive module interdependence
- split modules where that reveals cleaner, smaller APIs
- narrow the definitions exposed for reduction
- distinguish stable consumer-facing declarations from implementation details

Those follow-ups should yield more of the module system's benefits for elaboration and loading performance, encapsulation, and compatibility.

## Validation

- `./scripts/validate.sh --lint --test`
- downstream `VCVio` build against this PolyFun worktree (`lake build VCVio`, 3005 jobs), using VCVio commit `1925179c559594254bf3b5aee93c05147f31a9ba`

Reference: [Lean module scopes](https://lean-lang.org/doc/reference/latest/Source-Files-and-Modules/#module-scopes)
