### PR TITLE
ci: skip PR summary without OpenRouter key

### DIFF
--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -21,7 +21,20 @@ jobs:
   summarize:
     runs-on: ubuntu-latest
     steps:
+      - name: Check OpenRouter API key
+        id: openrouter
+        env:
+          OPENROUTER_KEY: ${{ secrets.OPENROUTER_KEY }}
+        run: |
+          if [[ -z "$OPENROUTER_KEY" ]]; then
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::OPENROUTER_KEY is not configured; PR summary was not run."
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Generate PR Summary
+        if: steps.openrouter.outputs.configured == 'true'
         uses: alexanderlhicks/lean4repo-utils/summary@0.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -18,8 +18,11 @@ permissions:
   issues: read
 
 jobs:
-  summarize:
+  check-openrouter-key:
+    name: Check OpenRouter key
     runs-on: ubuntu-latest
+    outputs:
+      configured: ${{ steps.openrouter.outputs.configured }}
     steps:
       - name: Check OpenRouter API key
         id: openrouter
@@ -28,13 +31,17 @@ jobs:
         run: |
           if [[ -z "$OPENROUTER_KEY" ]]; then
             echo "configured=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::OPENROUTER_KEY is not configured; PR summary was not run."
+            echo "::warning::OPENROUTER_KEY is not configured; PR summary will be skipped."
           else
             echo "configured=true" >> "$GITHUB_OUTPUT"
           fi
 
+  summarize:
+    needs: check-openrouter-key
+    if: needs.check-openrouter-key.outputs.configured == 'true'
+    runs-on: ubuntu-latest
+    steps:
       - name: Generate PR Summary
-        if: steps.openrouter.outputs.configured == 'true'
         uses: alexanderlhicks/lean4repo-utils/summary@0.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/wiki/quickstart.md
+++ b/docs/wiki/quickstart.md
@@ -117,8 +117,8 @@ deliberately outside the `lake lint` scope.
   docstrings).
 - [`../../.github/workflows/summary.yml`](../../.github/workflows/summary.yml):
   optional AI-generated PR summary; gated on the `OPENROUTER_KEY` repository
-  secret. The summary action is skipped with a workflow warning if the secret
-  is not set, without failing CI.
+  secret. A preflight check emits a workflow warning if the secret is not set,
+  and the summary job is marked skipped without blocking the PR.
 - [`../../.github/workflows/release-tag.yml`](../../.github/workflows/release-tag.yml),
   [`../../.github/workflows/update.yml`](../../.github/workflows/update.yml),
   [`../../.github/workflows/review.yml`](../../.github/workflows/review.yml):

--- a/docs/wiki/quickstart.md
+++ b/docs/wiki/quickstart.md
@@ -116,8 +116,9 @@ deliberately outside the `lake lint` scope.
   Mathlib text style linter: copyright headers, line length, module
   docstrings).
 - [`../../.github/workflows/summary.yml`](../../.github/workflows/summary.yml):
-  optional AI-generated PR summary; gated on `GEMINI_API_KEY` repository
-  secret. Skipped (with a notice) if the secret is not set.
+  optional AI-generated PR summary; gated on the `OPENROUTER_KEY` repository
+  secret. The summary action is skipped with a workflow warning if the secret
+  is not set, without failing CI.
 - [`../../.github/workflows/release-tag.yml`](../../.github/workflows/release-tag.yml),
   [`../../.github/workflows/update.yml`](../../.github/workflows/update.yml),
   [`../../.github/workflows/review.yml`](../../.github/workflows/review.yml):


### PR DESCRIPTION
## Summary

- check OPENROUTER_KEY before invoking the PR summary action
- emit a workflow warning and skip summary generation when the key is absent
- document the OpenRouter gate and non-failing behavior in the quickstart

## Motivation

PR #108 exposed that the new summary workflow exits with API_KEY not set when OPENROUTER_KEY is unavailable. A missing optional AI-provider secret should not fail otherwise healthy CI.

## Validation

- git diff --check
- ./scripts/check-docs-integrity.py