### PR TITLE
refactor: complete the Lean 4.33 transparency conversion

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,6 +142,47 @@ normalize local fixtures, while remaining outside the production library.
 Run `./scripts/check-modules.sh` after changing module scopes. The full
 validation wrapper runs this check automatically.
 
+### Transparency Attributes
+
+Lean orders unfolding by transparency level (`reducible < instances <
+implicit < default < all`) and, since Lean 4.33, respects those levels
+strictly: assigned metavariable types are compared at *implicit*
+transparency, and typeclass resolution unfolds only up to *instances*
+transparency. A plain `def` no longer unfolds during unification in those
+positions. Choose the weakest attribute that fixes the failure:
+
+- **No attribute** is the normal state. Prefer an equation or simp lemma
+  over a transparency change when a proof merely rewrites through a
+  definition.
+- **`@[implicit_reducible]`** is the standard fix for Lean 4.33
+  unification failures (`rw` not finding a visible pattern, `subst`
+  motive errors, goals "not type-correct under the implicit transparency
+  level"). It unfolds during implicit-transparency checks only; simp
+  validation, simp and typeclass indexing are unaffected, so `rfl` simp
+  lemmas keyed on the definition stay valid. Per the core documentation
+  (`Init.MetaTypes`), operations occurring in type parameters should be
+  implicit-reducible as a basic rule.
+- **`@[instance_reducible]`** when *instance synthesis* must see through
+  the definition. This changes typeclass discrimination-tree indexing;
+  use it only for genuine instance-resolution failures.
+- **`@[reducible]`** only for thin type wrappers all automation should
+  index through (the `TypeTree.done` / `TypeTree.node` pattern). It
+  invalidates `rfl` simp lemmas whose head is the wrapper, and is never
+  appropriate on recursive functions.
+- **`attribute [local implicit_reducible] Foo.bar`** is the sanctioned,
+  option-free way to grant one file implicit-transparency access to an
+  imported declaration (including Mathlib/cslib ones). Add a short
+  comment naming the proofs that need it. `attribute [local reducible]`
+  on imported declarations requires `allowUnsafeReducibility` and is not
+  permitted.
+- **`set_option allowUnsafeReducibility true`** is reserved for a
+  *global* attribute on an imported declaration, always with a comment
+  justifying why a local attribute does not suffice and pointing at the
+  upstream fix. The option is currently unused: every override of an
+  imported declaration is a per-file `attribute [local implicit_reducible]`.
+- **`with_unfolding_all`** should not appear in new proofs; prefer
+  equation lemmas for well-founded or structural recursion.
+
 ### Section Headers Within A File
 
 Use Mathlib-style doc-comment section headers, **not** ASCII banners.

--- a/PolyFun/ITree/Bisim/Bind.lean
+++ b/PolyFun/ITree/Bisim/Bind.lean
@@ -48,6 +48,12 @@ namespace ITree
 variable {F : PFunctor.{uFA, uFB}} {α : Type uα} {β : Type uβ}
   {γ : Type uγ} {δ : Type uδ}
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+the `bindStep`-unfolding proofs below produce sigma goals whose types only
+match once `PFunctor.Obj` unfolds there. `implicit_reducible` restores that
+without touching simp or typeclass resolution. -/
+attribute [local implicit_reducible] PFunctor.Obj
+
 /-! ### Monad laws -/
 
 /-- Auxiliary: once `bind` has consumed the pure-leaf prefix and entered the
@@ -107,19 +113,16 @@ theorem bind_pure_right (t : ITree F α) :
                 fun _ => Or.inl rfl⟩
         unfold bindStep
         simp only [hdest]
-        rfl
     | query a =>
         refine ⟨.query a, fun b => Sum.inl (c b), c, ?_, rfl,
                 fun _ => Or.inl rfl⟩
         unfold bindStep
         simp only [hdest]
-        rfl
   · rcases h : PFunctor.M.dest u with ⟨sh, c⟩
     have hdest : PFunctor.M.dest u = ⟨sh, c⟩ := h
     refine ⟨sh, fun b => Sum.inr (c b), c, ?_, rfl, fun _ => Or.inr rfl⟩
     unfold bindStep
     simp only [hdest]
-    rfl
 
 /-- Compute one `M.dest` step of `bind` whose head is a step. -/
 theorem dest_bind_step (k : α → ITree F β) (t : ITree F α)
@@ -504,10 +507,9 @@ theorem iter_bind (body : β → ITree F (β ⊕ α)) (k : α → ITree F γ) (i
           fun _ => PFunctor.M.corec (iterStep newBody)
             (bind (c PUnit.unit) wrapper),
           ?_, ?_, fun _ => Or.inl ⟨c PUnit.unit, rfl, rfl⟩⟩
-        · have hL : PFunctor.M.dest (PFunctor.M.corec (iterStep body) t) =
-              ⟨.step, fun _ => PFunctor.M.corec (iterStep body) (c PUnit.unit)⟩ := by
-            rw [PFunctor.M.dest_corec_apply, iterStep, h]
-          exact dest_bind_step k _ _ hL
+        · rw [bind, PFunctor.M.dest_corec_apply, bindStep_inl,
+              PFunctor.M.dest_corec_apply, iterStep, h]
+          rfl
         · have hdest_bind : PFunctor.M.dest (bind t wrapper) =
               ⟨.step, fun _ => bind (c PUnit.unit) wrapper⟩ := dest_bind_step wrapper t c h
           rw [PFunctor.M.dest_corec_apply, iterStep, hdest_bind]
@@ -516,10 +518,9 @@ theorem iter_bind (body : β → ITree F (β ⊕ α)) (k : α → ITree F γ) (i
           fun b => bind (PFunctor.M.corec (iterStep body) (c b)) k,
           fun b => PFunctor.M.corec (iterStep newBody) (bind (c b) wrapper),
           ?_, ?_, fun b => Or.inl ⟨c b, rfl, rfl⟩⟩
-        · have hL : PFunctor.M.dest (PFunctor.M.corec (iterStep body) t) =
-              ⟨.query a, fun b => PFunctor.M.corec (iterStep body) (c b)⟩ := by
-            rw [PFunctor.M.dest_corec_apply, iterStep, h]
-          exact dest_bind_query k _ a _ hL
+        · rw [bind, PFunctor.M.dest_corec_apply, bindStep_inl,
+              PFunctor.M.dest_corec_apply, iterStep, h]
+          rfl
         · have hdest_bind : PFunctor.M.dest (bind t wrapper) =
               ⟨.query a, fun b => bind (c b) wrapper⟩ := dest_bind_query wrapper t a c h
           rw [PFunctor.M.dest_corec_apply, iterStep, hdest_bind]

--- a/PolyFun/ITree/Construct.lean
+++ b/PolyFun/ITree/Construct.lean
@@ -41,6 +41,13 @@ namespace ITree
 
 variable {F : PFunctor.{uA, uB}} {α : Type uα} {β : Type uβ} {γ : Type uγ}
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+the `unfold`-style corecursor proof below exposes an `M.corec` step whose
+sigma-typed body only typechecks once `PFunctor.Obj` unfolds there.
+`implicit_reducible` restores that without touching simp or typeclass
+resolution. -/
+attribute [local implicit_reducible] PFunctor.Obj
+
 /-! ### Diverging tree -/
 
 /-- The diverging interaction tree, an infinite sequence of silent (`step`)
@@ -52,11 +59,8 @@ def diverge : ITree F α :=
 
 @[simp] theorem shape'_diverge :
     shape' (diverge (F := F) (α := α)) = ⟨.step, fun _ => diverge⟩ := by
-  let g : PUnit.{uB + 1} → (Poly F α) PUnit.{uB + 1} :=
-    fun _ => ⟨.step, fun _ => PUnit.unit⟩
-  change PFunctor.M.dest (PFunctor.M.corec g PUnit.unit) =
-    ⟨.step, fun _ => PFunctor.M.corec g PUnit.unit⟩
-  rw [PFunctor.M.dest_corec_apply]
+  unfold shape' diverge
+  rw [PFunctor.M.dest_corec_eq _ _ rfl]
 
 @[simp] theorem shape_diverge :
     shape (diverge (F := F) (α := α)) = .step := by

--- a/PolyFun/ITree/Events/ExceptionFacts.lean
+++ b/PolyFun/ITree/Events/ExceptionFacts.lean
@@ -5,7 +5,6 @@ Authors: Quang Dao
 -/
 module
 
-import all PolyFun.ITree.Events.Exception
 public import PolyFun.ITree.Events.Exception
 public import PolyFun.ITree.Bisim.Bind
 
@@ -26,6 +25,13 @@ namespace ITree
 
 variable {ε : Type uε} {E : PFunctor.{uEA, uB}} {α : Type uα}
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+the proofs below need `(ExceptE ε + E).B (.inl e)` to unfold to `PEmpty`
+there, which goes through the sum functor's `Sum.elim` child family.
+`implicit_reducible` restores that without touching simp or typeclass
+resolution. -/
+attribute [local implicit_reducible] Sum.elim
+
 @[simp] theorem interpExcept_pure (r : α) :
     interpExcept (ε := ε) (E := E)
       (pure (F := (ExceptE.{uε, uB} ε + E :
@@ -38,8 +44,8 @@ variable {ε : Type uε} {E : PFunctor.{uEA, uB}} {α : Type uα}
     simp [interpExceptStep]
   apply PFunctor.M.eq_of_dest_eq
   rw [interpExcept, PFunctor.M.dest_corec_eq _ _ hstep]
-  change _ = shape' (pure (Except.ok r))
-  rw [shape'_pure]
+  unfold ITree.pure
+  rw [PFunctor.M.dest_mk]
   congr 1
   funext b
   exact b.elim
@@ -53,8 +59,8 @@ variable {ε : Type uε} {E : PFunctor.{uEA, uB}} {α : Type uα}
     simp [interpExceptStep]
   apply PFunctor.M.eq_of_dest_eq
   rw [interpExcept, PFunctor.M.dest_corec_eq _ _ hstep]
-  change _ = shape' (step (interpExcept t))
-  rw [shape'_step]
+  unfold ITree.step
+  rw [PFunctor.M.dest_mk]
   rfl
 
 @[simp] theorem interpExcept_throw (e : ε)
@@ -63,11 +69,11 @@ variable {ε : Type uε} {E : PFunctor.{uEA, uB}} {α : Type uα}
     interpExcept (query (.inl e) k) = pure (.error e) := by
   have hstep : interpExceptStep (query (.inl e) k) =
       ⟨.pure (.error e), PEmpty.elim⟩ := by
-    simp [interpExceptStep]; rfl
+    simp [interpExceptStep]
   apply PFunctor.M.eq_of_dest_eq
   rw [interpExcept, PFunctor.M.dest_corec_eq _ _ hstep]
-  change _ = shape' (pure (Except.error e))
-  rw [shape'_pure]
+  unfold ITree.pure
+  rw [PFunctor.M.dest_mk]
   congr 1
   funext b
   exact b.elim
@@ -79,11 +85,11 @@ variable {ε : Type uε} {E : PFunctor.{uEA, uB}} {α : Type uα}
       query e (fun b => interpExcept (k b)) := by
   have hstep : interpExceptStep (query (.inr e) k) =
       ⟨.query e, k⟩ := by
-    simp [interpExceptStep]; rfl
+    simp [interpExceptStep]
   apply PFunctor.M.eq_of_dest_eq
   rw [interpExcept, PFunctor.M.dest_corec_eq _ _ hstep]
-  change _ = shape' (query e (fun b => interpExcept (k b)))
-  rw [shape'_query]
+  unfold ITree.query
+  rw [PFunctor.M.dest_mk]
   rfl
 
 /-- Exception interpretation is the canonical exception-transformer monad
@@ -125,7 +131,8 @@ theorem interpExcept_bind
           congr 1
           funext z
           exact z.elim
-        rw [ht, bind_pure_left, interpExcept_pure, bind_pure_left]
+        subst ht
+        rw [bind_pure_left, interpExcept_pure, bind_pure_left]
         rcases hk : PFunctor.M.dest (interpExcept (k r)) with ⟨sh', c'⟩
         exact ⟨sh', c', c', rfl, rfl, fun _ => Or.inl rfl⟩
     | step =>
@@ -133,7 +140,8 @@ theorem interpExcept_bind
           apply PFunctor.M.eq_of_dest_eq
           rw [h]
           rfl
-        rw [ht, bind_step, interpExcept_step, interpExcept_step, bind_step]
+        subst ht
+        rw [bind_step, interpExcept_step, interpExcept_step, bind_step]
         exact ⟨.step,
           fun _ => interpExcept (bind (c PUnit.unit) k),
           fun _ => bind (interpExcept (c PUnit.unit)) next,
@@ -142,44 +150,36 @@ theorem interpExcept_bind
     | query event =>
         cases event with
         | inl e =>
+            change PEmpty.{uB + 1} → ITree
+              (ExceptE.{uε, uB} ε + E :
+                PFunctor.{max uε uEA, uB}) α at c
             have ht : t = query
                 (Sum.inl e : (ExceptE.{uε, uB} ε + E :
                   PFunctor.{max uε uEA, uB}).A) c := by
               apply PFunctor.M.eq_of_dest_eq
               rw [h]
               rfl
-            rw [ht, bind_query]
-            have hleft : interpExcept (query
-                (Sum.inl e : (ExceptE.{uε, uB} ε + E :
-                  PFunctor.{max uε uEA, uB}).A) (fun b => bind (c b) k)) =
-                pure (Except.error e) := interpExcept_throw e _
-            have hright : interpExcept (query
-                (Sum.inl e : (ExceptE.{uε, uB} ε + E :
-                  PFunctor.{max uε uEA, uB}).A) c) =
-                pure (Except.error e) := interpExcept_throw e c
-            rw [hleft, hright, bind_pure_left]
+            subst ht
+            clear h
+            rw [bind_query, interpExcept_throw,
+              interpExcept_throw, bind_pure_left]
             rcases hp : PFunctor.M.dest
                 (pure (F := E) (Except.error e : Except ε β)) with ⟨sh', c'⟩
             exact ⟨sh', c', c', rfl, rfl, fun _ => Or.inl rfl⟩
         | inr e =>
+            change E.B e → ITree
+              (ExceptE.{uε, uB} ε + E :
+                PFunctor.{max uε uEA, uB}) α at c
             have ht : t = query
                 (Sum.inr e : (ExceptE.{uε, uB} ε + E :
                   PFunctor.{max uε uEA, uB}).A) c := by
               apply PFunctor.M.eq_of_dest_eq
               rw [h]
               rfl
-            rw [ht, bind_query]
-            have hleft : interpExcept (query
-                (Sum.inr e : (ExceptE.{uε, uB} ε + E :
-                  PFunctor.{max uε uEA, uB}).A) (fun b => bind (c b) k)) =
-                query e (fun b => interpExcept (bind (c b) k)) :=
-              interpExcept_query_external e _
-            have hright : interpExcept (query
-                (Sum.inr e : (ExceptE.{uε, uB} ε + E :
-                  PFunctor.{max uε uEA, uB}).A) c) =
-                query e (fun b => interpExcept (c b)) :=
-              interpExcept_query_external e c
-            rw [hleft, hright, bind_query]
+            subst ht
+            clear h
+            rw [bind_query, interpExcept_query_external,
+              interpExcept_query_external, bind_query]
             exact ⟨.query e,
               fun b => interpExcept (bind (c b) k),
               fun b => bind (interpExcept (c b)) next,

--- a/PolyFun/ITree/Events/ExceptionFacts.lean
+++ b/PolyFun/ITree/Events/ExceptionFacts.lean
@@ -66,7 +66,7 @@ attribute [local implicit_reducible] Sum.elim
 @[simp] theorem interpExcept_throw (e : ε)
     (k : PEmpty.{uB + 1} →
       ITree (ExceptE.{uε, uB} ε + E : PFunctor.{max uε uEA, uB}) α) :
-    interpExcept (query (.inl e) k) = pure (.error e) := by
+    interpExcept (query (Sum.inl (α := ε) (β := E.A) e) k) = pure (.error e) := by
   have hstep : interpExceptStep (query (.inl e) k) =
       ⟨.pure (.error e), PEmpty.elim⟩ := by
     simp [interpExceptStep]
@@ -81,7 +81,7 @@ attribute [local implicit_reducible] Sum.elim
 @[simp] theorem interpExcept_query_external (e : E.A)
     (k : E.B e →
       ITree (ExceptE.{uε, uB} ε + E : PFunctor.{max uε uEA, uB}) α) :
-    interpExcept (query (.inr e) k) =
+    interpExcept (query (Sum.inr (α := ε) (β := E.A) e) k) =
       query e (fun b => interpExcept (k b)) := by
   have hstep : interpExceptStep (query (.inr e) k) =
       ⟨.query e, k⟩ := by

--- a/PolyFun/ITree/Events/StateFacts.lean
+++ b/PolyFun/ITree/Events/StateFacts.lean
@@ -5,7 +5,6 @@ Authors: Quang Dao
 -/
 module
 
-import all PolyFun.ITree.Events.State
 public import PolyFun.ITree.Events.State
 public import PolyFun.ITree.Bisim.Bind
 
@@ -25,6 +24,13 @@ universe uσ uEA uα uβ
 namespace ITree
 
 variable {σ : Type uσ} {E : PFunctor.{uEA, uσ}} {α : Type uα}
+
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+the proofs below need `(StateE σ + E).B` at `.inl`/`.inr` events to unfold
+there, which goes through the sum functor's `Sum.elim` child family.
+`implicit_reducible` restores that without touching simp or typeclass
+resolution. -/
+attribute [local implicit_reducible] Sum.elim
 
 @[simp] theorem interpState_pure (s : σ) (r : α) :
     interpState (E := E)
@@ -65,7 +71,6 @@ variable {σ : Type uσ} {E : PFunctor.{uEA, uσ}} {α : Type uα}
         (StateE σ + E : PFunctor.{max uσ uEA, uσ}).A) k) =
       ⟨.step, fun _ => (s, k s)⟩ := by
     simp [interpStateStep]
-    rfl
   apply PFunctor.M.eq_of_dest_eq
   rw [interpState, PFunctor.M.dest_corec_eq _ _ hstep]
   unfold ITree.step
@@ -85,7 +90,6 @@ variable {σ : Type uσ} {E : PFunctor.{uEA, uσ}} {α : Type uα}
           (StateE σ + E : PFunctor.{max uσ uEA, uσ}).A) k) =
       ⟨.step, fun _ => (s', k PUnit.unit)⟩ := by
     simp [interpStateStep]
-    rfl
   apply PFunctor.M.eq_of_dest_eq
   rw [interpState, PFunctor.M.dest_corec_eq _ _ hstep]
   unfold ITree.step
@@ -102,7 +106,6 @@ variable {σ : Type uσ} {E : PFunctor.{uEA, uσ}} {α : Type uα}
       (Sum.inr e : (StateE σ + E : PFunctor.{max uσ uEA, uσ}).A) k) =
       ⟨.query e, fun b => (s, k b)⟩ := by
     simp [interpStateStep]
-    rfl
   apply PFunctor.M.eq_of_dest_eq
   rw [interpState, PFunctor.M.dest_corec_eq _ _ hstep]
   unfold ITree.query
@@ -234,24 +237,18 @@ theorem interpState_bind {β : Type uβ}
                   hLeft, hRight,
                   fun _ => Or.inr ⟨s', c PUnit.unit, rfl, rfl⟩⟩
         | inr e =>
+            change E.B e → ITree
+              (StateE σ + E : PFunctor.{max uσ uEA, uσ}) α at c
             have ht : t = query
                 (Sum.inr e :
                   (StateE σ + E : PFunctor.{max uσ uEA, uσ}).A) c := by
               apply PFunctor.M.eq_of_dest_eq
               rw [h]
               rfl
-            rw [ht, bind_query]
-            have hleft : interpState (query
-                (Sum.inr e : (StateE σ + E :
-                  PFunctor.{max uσ uEA, uσ}).A) (fun b => bind (c b) k)) s =
-                query e (fun b => interpState (bind (c b) k) s) :=
-              interpState_query_external s e _
-            have hright : interpState (query
-                (Sum.inr e : (StateE σ + E :
-                  PFunctor.{max uσ uEA, uσ}).A) c) s =
-                query e (fun b => interpState (c b) s) :=
-              interpState_query_external s e c
-            rw [hleft, hright, bind_query]
+            subst ht
+            clear h
+            rw [bind_query, interpState_query_external,
+              interpState_query_external, bind_query]
             exact ⟨.query e,
               fun b => interpState (bind (c b) k) s,
               fun b => bind (interpState (c b) s) next,

--- a/PolyFun/ITree/Events/StateFacts.lean
+++ b/PolyFun/ITree/Events/StateFacts.lean
@@ -63,8 +63,7 @@ attribute [local implicit_reducible] Sum.elim
 @[simp] theorem interpState_get (s : σ)
     (k : σ → ITree (StateE σ + E : PFunctor.{max uσ uEA, uσ}) α) :
     interpState (query
-      (Sum.inl StateE.Shape.get :
-        (StateE σ + E : PFunctor.{max uσ uEA, uσ}).A) k) s =
+      (Sum.inl (α := StateE.Shape σ) (β := E.A) StateE.Shape.get) k) s =
       step (interpState (k s) s) := by
   have hstep : interpStateStep (s, query
       (Sum.inl StateE.Shape.get :
@@ -81,8 +80,7 @@ attribute [local implicit_reducible] Sum.elim
     (k : PUnit.{uσ + 1} →
       ITree (StateE σ + E : PFunctor.{max uσ uEA, uσ}) α) :
     interpState (query
-      (Sum.inl (StateE.Shape.put s') :
-        (StateE σ + E : PFunctor.{max uσ uEA, uσ}).A) k) s =
+      (Sum.inl (α := StateE.Shape σ) (β := E.A) (StateE.Shape.put s')) k) s =
       step (interpState (k PUnit.unit) s') := by
   have hstep : interpStateStep
       (s, query
@@ -100,7 +98,7 @@ attribute [local implicit_reducible] Sum.elim
     (k : E.B e →
       ITree (StateE σ + E : PFunctor.{max uσ uEA, uσ}) α) :
     interpState (query
-      (Sum.inr e : (StateE σ + E : PFunctor.{max uσ uEA, uσ}).A) k) s =
+      (Sum.inr (α := StateE.Shape σ) (β := E.A) e) k) s =
       query e (fun b => interpState (k b) s) := by
   have hstep : interpStateStep (s, query
       (Sum.inr e : (StateE σ + E : PFunctor.{max uσ uEA, uσ}).A) k) =

--- a/PolyFun/ITree/Handler.lean
+++ b/PolyFun/ITree/Handler.lean
@@ -62,7 +62,7 @@ variable {E : PFunctor.{uEA, uEB}} {F : PFunctor.{uFA, uFB}}
 
 /-- The trivial handler that interprets each `E`-event as itself, i.e. the
 single-step `lift` from `PolyFun.ITree.Basic`. -/
-@[reducible]
+@[implicit_reducible]
 def id (E : PFunctor.{uEA, uEB}) : Handler E E :=
   fun a => lift a
 

--- a/PolyFun/ITree/Rec/Facts.lean
+++ b/PolyFun/ITree/Rec/Facts.lean
@@ -34,6 +34,13 @@ variable {D : PFunctor.{uDA, uB}} {E : PFunctor.{uEA, uB}}
 variable (body : ∀ a : D.A,
   ITree (D + E : PFunctor.{max uDA uEA, uB}) (D.B a))
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+the proofs below need `(D + E).B` at `.inl`/`.inr` events to unfold there,
+which goes through the sum functor's `Sum.elim` child family.
+`implicit_reducible` restores that without touching simp or typeclass
+resolution. -/
+attribute [local implicit_reducible] Sum.elim
+
 @[simp] theorem interpMrec_pure (r : α) :
     interpMrec body
       (pure (F := (D + E : PFunctor.{max uDA uEA, uB})) r) = pure r := by
@@ -69,7 +76,6 @@ variable (body : ∀ a : D.A,
   have hstep : mutualRecStep body (query (.inl d) k) =
       ⟨.step, fun _ => bind (body d) k⟩ := by
     simp [mutualRecStep]
-    rfl
   apply PFunctor.M.eq_of_dest_eq
   rw [interpMrec, PFunctor.M.dest_corec_eq _ _ hstep]
   unfold ITree.step
@@ -83,7 +89,6 @@ variable (body : ∀ a : D.A,
   have hstep : mutualRecStep body (query (.inr e) k) =
       ⟨.query e, k⟩ := by
     simp [mutualRecStep]
-    rfl
   apply PFunctor.M.eq_of_dest_eq
   rw [interpMrec, PFunctor.M.dest_corec_eq _ _ hstep]
   unfold ITree.query
@@ -138,21 +143,16 @@ theorem interpMrec_bind
     | query event =>
         cases event with
         | inl d =>
+            change D.B d →
+              ITree (D + E : PFunctor.{max uDA uEA, uB}) α at c
             have ht : t = query (Sum.inl d) c := by
               apply PFunctor.M.eq_of_dest_eq
               rw [h]
               rfl
-            rw [ht, bind_query]
-            have hleft : interpMrec body (query
-                (Sum.inl d : (D + E : PFunctor.{max uDA uEA, uB}).A)
-                (fun b => bind (c b) k)) =
-                step (interpMrec body (bind (body d) (fun b => bind (c b) k))) :=
-              interpMrec_query_recursive body d _
-            have hright : interpMrec body (query
-                (Sum.inl d : (D + E : PFunctor.{max uDA uEA, uB}).A) c) =
-                step (interpMrec body (bind (body d) c)) :=
-              interpMrec_query_recursive body d c
-            rw [hleft, hright, bind_step]
+            subst ht
+            clear h
+            rw [bind_query, interpMrec_query_recursive,
+              interpMrec_query_recursive, bind_step]
             have hassoc :
                 bind (body d) (fun b => bind (c b) k) =
                   bind (bind (body d) c) k :=
@@ -165,21 +165,16 @@ theorem interpMrec_bind
               fun _ => Or.inr ⟨bind (body d) c,
                 congrArg (interpMrec body) hassoc, rfl⟩⟩
         | inr e =>
+            change E.B e →
+              ITree (D + E : PFunctor.{max uDA uEA, uB}) α at c
             have ht : t = query (Sum.inr e) c := by
               apply PFunctor.M.eq_of_dest_eq
               rw [h]
               rfl
-            rw [ht, bind_query]
-            have hleft : interpMrec body (query
-                (Sum.inr e : (D + E : PFunctor.{max uDA uEA, uB}).A)
-                (fun b => bind (c b) k)) =
-                query e (fun b => interpMrec body (bind (c b) k)) :=
-              interpMrec_query_external body e _
-            have hright : interpMrec body (query
-                (Sum.inr e : (D + E : PFunctor.{max uDA uEA, uB}).A) c) =
-                query e (fun b => interpMrec body (c b)) :=
-              interpMrec_query_external body e c
-            rw [hleft, hright, bind_query]
+            subst ht
+            clear h
+            rw [bind_query, interpMrec_query_external,
+              interpMrec_query_external, bind_query]
             exact ⟨.query e,
               fun b => interpMrec body (bind (c b) k),
               fun b => bind (interpMrec body (c b)) next,
@@ -253,32 +248,16 @@ theorem mapSpec_interpMrec {G : PFunctor.{uGA, uB}}
               apply PFunctor.M.eq_of_dest_eq
               rw [h]
               rfl
-            rw [ht]
+            subst ht
+            clear h
             have hmap :
                 mapSpec sumLens (bind (body d) c) =
                   bind (mappedBody d) (fun b => mapSpec sumLens (c b)) := by
               simpa only [mappedBody] using
                 mapSpec_bind (α := D.B d) (β := α) sumLens (body d) c
-            have hinterp : interpMrec body (query
-                (Sum.inl d : (D + E : PFunctor.{max uDA uEA, uB}).A) c) =
-                step (interpMrec body (bind (body d) c)) :=
-              interpMrec_query_recursive body d c
-            have hspec : mapSpec sumLens (query
-                (Sum.inl d : (D + E : PFunctor.{max uDA uEA, uB}).A) c) =
-                query (F := (D + G : PFunctor.{max uDA uGA, uB})) (α := α)
-                  (Sum.inl d : (D + G : PFunctor.{max uDA uGA, uB}).A)
-                  (fun b : D.B d => mapSpec sumLens (c b)) := by
-              convert mapSpec_query sumLens
-                (Sum.inl d : (D + E : PFunctor.{max uDA uEA, uB}).A) c using 1
-              all_goals simp [sumLens, PFunctor.Lens.sumMap, PFunctor.Lens.id]
-              all_goals rfl
-            have hinterp' : interpMrec mappedBody (query
-                (Sum.inl d : (D + G : PFunctor.{max uDA uGA, uB}).A)
-                (fun b : D.B d => mapSpec sumLens (c b))) =
-                step (interpMrec mappedBody
-                  (bind (mappedBody d) (fun b : D.B d => mapSpec sumLens (c b)))) :=
-              interpMrec_query_recursive mappedBody d _
-            rw [hinterp, mapSpec_step, hspec, hinterp']
+            rw [interpMrec_query_recursive, mapSpec_step, mapSpec_query]
+            dsimp [sumLens, PFunctor.Lens.sumMap, PFunctor.Lens.id]
+            rw [interpMrec_query_recursive]
             exact ⟨.step,
               fun _ => mapSpec φ (interpMrec body (bind (body d) c)),
               fun _ => interpMrec mappedBody
@@ -295,31 +274,11 @@ theorem mapSpec_interpMrec {G : PFunctor.{uGA, uB}}
               apply PFunctor.M.eq_of_dest_eq
               rw [h]
               rfl
-            rw [ht]
-            have hinterp : interpMrec body (query
-                (Sum.inr e : (D + E : PFunctor.{max uDA uEA, uB}).A) c) =
-                query e (fun b => interpMrec body (c b)) :=
-              interpMrec_query_external body e c
-            have hspec : mapSpec sumLens (query
-                (Sum.inr e : (D + E : PFunctor.{max uDA uEA, uB}).A) c) =
-                query (F := (D + G : PFunctor.{max uDA uGA, uB})) (α := α)
-                  (Sum.inr (φ.toFunA e) :
-                  (D + G : PFunctor.{max uDA uGA, uB}).A)
-                  (fun b : G.B (φ.toFunA e) =>
-                    mapSpec sumLens (c (φ.toFunB e b))) := by
-              convert mapSpec_query sumLens
-                (Sum.inr e : (D + E : PFunctor.{max uDA uEA, uB}).A) c using 1
-              all_goals simp [sumLens, PFunctor.Lens.sumMap, PFunctor.Lens.id]
-              all_goals rfl
-            have hinterp' : interpMrec mappedBody (query
-                (Sum.inr (φ.toFunA e) :
-                  (D + G : PFunctor.{max uDA uGA, uB}).A)
-                (fun b : G.B (φ.toFunA e) =>
-                  mapSpec sumLens (c (φ.toFunB e b)))) =
-                query (φ.toFunA e) (fun b => interpMrec mappedBody
-                  (mapSpec sumLens (c (φ.toFunB e b)))) :=
-              interpMrec_query_external mappedBody (φ.toFunA e) _
-            rw [hinterp, mapSpec_query, hspec, hinterp']
+            subst ht
+            clear h
+            rw [interpMrec_query_external, mapSpec_query, mapSpec_query]
+            dsimp [sumLens, PFunctor.Lens.sumMap, PFunctor.Lens.id]
+            rw [interpMrec_query_external]
             exact ⟨.query (φ.toFunA e),
               fun b => mapSpec φ
                 (interpMrec body (c (φ.toFunB e b))),
@@ -334,7 +293,7 @@ theorem mapSpec_interpMrec {G : PFunctor.{uGA, uB}}
 ITree simulation. Recursive events invoke `mutualRec body`; external events
 are forwarded unchanged. This is the polynomial-functor counterpart of the
 upstream ITree handler `mrecursive`. -/
-@[reducible]
+@[implicit_reducible]
 def recursiveHandler :
     Handler (D + E : PFunctor.{max uDA uEA, uB}) E :=
   Handler.case_ (mutualRec body) (Handler.id E)
@@ -349,80 +308,35 @@ def recursiveHandler :
 handler up to the productivity guard inserted by `interpMrec`. -/
 theorem interpMrec_lift_inl (d : D.A) :
     WeakBisim
-      (show ITree E (D.B d) from interpMrec body
+      (interpMrec body
         (lift (F := (D + E : PFunctor.{max uDA uEA, uB})) (.inl d)))
       (recursiveHandler body (.inl d)) := by
-  change WeakBisim
-    (interpMrec body
-      (lift (F := (D + E : PFunctor.{max uDA uEA, uB})) (.inl d)))
-    (mutualRec body d)
   have hbind :
       bind (body d)
           (fun b : D.B d =>
             pure (F := (D + E : PFunctor.{max uDA uEA, uB})) b) =
         body d :=
     bind_pure_right (body d)
-  have hlift :
-      (lift (F := (D + E : PFunctor.{max uDA uEA, uB})) (.inl d) :
-        ITree (D + E : PFunctor.{max uDA uEA, uB}) (D.B d)) =
-      query (F := (D + E : PFunctor.{max uDA uEA, uB})) (α := D.B d)
-        (.inl d) (fun b : D.B d => pure b) := rfl
-  have hinterp : interpMrec body
-      (query (F := (D + E : PFunctor.{max uDA uEA, uB})) (α := D.B d)
-        (.inl d) (fun b : D.B d => pure b)) =
-      step (interpMrec body (bind (body d) (fun b : D.B d => pure b))) :=
-    interpMrec_query_recursive body d _
-  have heq : interpMrec body
-      (lift (F := (D + E : PFunctor.{max uDA uEA, uB})) (.inl d) :
-        ITree (D + E : PFunctor.{max uDA uEA, uB}) (D.B d)) =
-      step (interpMrec body (bind (body d) (fun b : D.B d =>
-        pure (F := (D + E : PFunctor.{max uDA uEA, uB})) b))) :=
-    (congrArg (interpMrec body) hlift).trans hinterp
-  have hfinal : interpMrec body
-      (lift (F := (D + E : PFunctor.{max uDA uEA, uB})) (.inl d) :
-        ITree (D + E : PFunctor.{max uDA uEA, uB}) (D.B d)) =
-      step (mutualRec body d) := by
-    calc
-      _ = step (interpMrec body (bind (body d) (fun b : D.B d =>
-          pure (F := (D + E : PFunctor.{max uDA uEA, uB})) b))) := heq
-      _ = step (mutualRec body d) := congrArg step (congrArg (interpMrec body) hbind)
-  exact hfinal.symm ▸ step_weakBisim _
+  rw [lift, interpMrec_query_recursive]
+  change WeakBisim
+    (step (interpMrec body
+      (bind (body d) (fun b : D.B d =>
+        pure (F := (D + E : PFunctor.{max uDA uEA, uB})) b))))
+    (mutualRec body d)
+  rw [hbind]
+  exact step_weakBisim _
 
 /-- Interpreting a lifted external event forwards it through the canonical
 recursive handler. The trees are equal before promotion to weak
 bisimulation. -/
 theorem interpMrec_lift_inr (e : E.A) :
     WeakBisim
-      (show ITree E (E.B e) from interpMrec body
+      (interpMrec body
         (lift (F := (D + E : PFunctor.{max uDA uEA, uB})) (.inr e)))
       (recursiveHandler body (.inr e)) := by
-  change WeakBisim
-    (interpMrec body
-      (lift (F := (D + E : PFunctor.{max uDA uEA, uB})) (.inr e)))
-    (Handler.id E e)
-  have hlift :
-      (lift (F := (D + E : PFunctor.{max uDA uEA, uB})) (.inr e) :
-        ITree (D + E : PFunctor.{max uDA uEA, uB}) (E.B e)) =
-      query (F := (D + E : PFunctor.{max uDA uEA, uB})) (α := E.B e)
-        (.inr e) (fun b : E.B e => pure b) := rfl
-  have hinterp : interpMrec body
-      (query (F := (D + E : PFunctor.{max uDA uEA, uB})) (α := E.B e)
-        (.inr e) (fun b : E.B e => pure b)) =
-      query e (fun b : E.B e => interpMrec body (pure b)) :=
-    interpMrec_query_external body e _
-  have heq : interpMrec body
-      (lift (F := (D + E : PFunctor.{max uDA uEA, uB})) (.inr e) :
-        ITree (D + E : PFunctor.{max uDA uEA, uB}) (E.B e)) =
-      query e (fun b : E.B e => interpMrec body (pure b)) :=
-    (congrArg (interpMrec body) hlift).trans hinterp
-  have hfinal : interpMrec body
-      (lift (F := (D + E : PFunctor.{max uDA uEA, uB})) (.inr e) :
-        ITree (D + E : PFunctor.{max uDA uEA, uB}) (E.B e)) =
-      Handler.id E e := by
-    calc
-      _ = query e (fun b : E.B e => interpMrec body (pure b)) := heq
-      _ = Handler.id E e := by simp [Handler.id, lift]
-  exact hfinal.symm ▸ WeakBisim.refl _
+  rw [lift, interpMrec_query_external, recursiveHandler_inr]
+  simp only [interpMrec_pure, Handler.id, lift]
+  exact WeakBisim.refl _
 
 /-- Definition bridge: `mutualRec` is the recursive interpreter applied to
 one body invocation. The guarded recursive-query equation is

--- a/PolyFun/ITree/Sim/Facts.lean
+++ b/PolyFun/ITree/Sim/Facts.lean
@@ -5,7 +5,6 @@ Authors: Quang Dao
 -/
 module
 
-import all PolyFun.ITree.Sim.Defs
 public import PolyFun.ITree.Sim.Defs
 public import PolyFun.ITree.Bisim.Bind
 

--- a/PolyFun/ITree/Unfold.lean
+++ b/PolyFun/ITree/Unfold.lean
@@ -28,6 +28,11 @@ universe uA uB uR uS
 
 namespace PFunctor
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+the one-step unfolding equations below rewrite corecursive ITree objects
+there, so `P.Obj` must unfold to its sigma form in those checks. -/
+attribute [local implicit_reducible] PFunctor.Obj
+
 /-- Embed a `p`-behavior tree as an interaction tree over event signature `p`:
 every node becomes a visible `query` at its position, with the same children.
 The result never returns (`PEmpty` leaves) and takes no silent steps. The empty

--- a/PolyFun/ITree/Unfold.lean
+++ b/PolyFun/ITree/Unfold.lean
@@ -5,7 +5,6 @@ Authors: Devon Tuma
 -/
 module
 
-import all PolyFun.ITree.Basic
 public import PolyFun.ITree.Basic
 public import PolyFun.PFunctor.Dynamical.Trajectory
 
@@ -48,27 +47,15 @@ def toITree {S : Type uS} {p : PFunctor.{uA, uB}} (s : DynSystem S p) :
     (s : DynSystem S p) (st : S) :
     M.dest (s.toITree st)
       = ⟨.query (s.expose st), fun d => s.toITree (s.update st d)⟩ := by
-  let g : S → (ITree.Poly p PEmpty) S :=
-    fun st => ⟨.query (s.expose st), fun d => s.update st d⟩
-  change M.dest (M.corec g st) =
-    ⟨.query (s.expose st), fun d => M.corec g (s.update st d)⟩
-  rw [M.dest_corec_apply]
+  simp only [toITree, M.dest_corec_apply]
 
 /-- Unfolding a system into an ITree is the query-embedding of its behavior
 tree: the two coinductive semantics agree. -/
 theorem toITree_eq_toITree_behavior {S : Type uS} {p : PFunctor.{uA, uB}}
-    (s : DynSystem S p) (st : S) :
-    s.toITree st = M.toITree (s.behavior st) := by
+    (s : DynSystem S p) (st : S) : s.toITree st = M.toITree (s.behavior st) := by
   refine congrFun (M.corec_unique _ (fun st => M.toITree (s.behavior st)) ?_).symm st
   intro st
-  let g : M p → (ITree.Poly p PEmpty) (M p) :=
-    fun t => ⟨.query (M.dest t).1, (M.dest t).2⟩
-  change M.dest (M.corec g (s.behavior st)) = _
-  have hg : g (s.behavior st) =
-      ⟨.query (s.expose st), fun d => s.behavior (s.update st d)⟩ := by
-    dsimp only [g]
-    rw [DynSystem.dest_behavior]
-  rw [M.dest_corec_eq g _ hg]
+  simp only [M.toITree, M.dest_corec_apply]
   rfl
 
 end DynSystem

--- a/PolyFun/Interaction/Basic/Chain.lean
+++ b/PolyFun/Interaction/Basic/Chain.lean
@@ -97,7 +97,12 @@ def toTypeTree : (n : Nat) → Chain n → TypeTree
   | n + 1, ⟨spec, cont⟩ =>
       TypeTree.substMonoid.mult.toFunA ⟨spec, fun tr => toTypeTree n (cont tr)⟩
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+the flattening lemmas below equate `toTypeTree` layers with `FreeM.append`
+through the substitution monoid there. `implicit_reducible` (unlike
+`reducible`) stays invisible to simp validation and instance search. -/
 attribute [local implicit_reducible] PFunctor.FreeP.substMonoid PFunctor.FreeP.mult
+  toTypeTree
 
 @[simp, grind =]
 theorem toTypeTree_zero (c : Chain 0) : toTypeTree 0 c = TypeTree.done := rfl
@@ -138,11 +143,9 @@ theorem toTypeTree_replicate (spec : TypeTree) :
     (n : Nat) → toTypeTree n (Chain.replicate spec n) = spec.replicate n
   | 0 => rfl
   | n + 1 => by
-      simp only [Chain.replicate, toTypeTree, PFunctor.FreeM.replicate]
-      rw [TypeTree.substMonoid_mult_toFunA]
-      congr 1
-      funext _
-      exact toTypeTree_replicate spec n
+      simp only [Chain.replicate, toTypeTree, TypeTree.substMonoid_mult_toFunA,
+        PFunctor.FreeM.replicate]
+      congr 1; funext _; exact toTypeTree_replicate spec n
 
 /-- Flattening the finite unfold of a stage-indexed coalgebra agrees with
 `TypeTree.stateChain`. -/
@@ -154,8 +157,8 @@ theorem toTypeTree_ofStateChain (Stage : Nat → Type u)
       PFunctor.FreeM.stateChain PUnit.unit Stage step next n i s
   | 0, _, _ => rfl
   | n + 1, i, s => by
-      simp only [Chain.ofStateChain, toTypeTree, PFunctor.FreeM.stateChain]
-      rw [TypeTree.substMonoid_mult_toFunA]
+      simp only [Chain.ofStateChain, toTypeTree, TypeTree.substMonoid_mult_toFunA,
+        PFunctor.FreeM.stateChain]
       congr 1
       funext tr
       exact toTypeTree_ofStateChain Stage step next n (i + 1) (next i s tr)
@@ -232,7 +235,6 @@ theorem outputFamily_eq_terminal
   | 0, ⟨⟩, _ => rfl
   | n + 1, ⟨spec, cont⟩, path => by
       simp only [outputFamily]
-      change Path (spec.append (fun first => toTypeTree n (cont first))) at path
       rw [PFunctor.FreeM.Path.liftAppend_congr spec _ _ _
         (fun first rest => outputFamily_eq_terminal Family n (cont first) rest)]
       exact PFunctor.FreeM.Path.liftAppend_const (@Family 0 PUnit.unit)

--- a/PolyFun/Interaction/Basic/Chain/Append.lean
+++ b/PolyFun/Interaction/Basic/Chain/Append.lean
@@ -40,6 +40,10 @@ namespace Interaction
 namespace TypeTree
 namespace Chain
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+the concatenation lemmas below equate flattened chains with `FreeM.append`
+through the substitution monoid there. `implicit_reducible` (unlike
+`reducible`) stays invisible to simp validation and instance search. -/
 attribute [local implicit_reducible] PFunctor.Obj PFunctor.FreeP.substMonoid
   PFunctor.FreeP.mult TypeTree.Chain toTypeTree
 
@@ -50,9 +54,11 @@ def castRounds {m n : Nat} (h : m = n) (c : Chain m) : Chain n :=
 
 attribute [local implicit_reducible] castRounds
 
+@[simp]
 theorem castRounds_rfl {m : Nat} (c : Chain m) : castRounds rfl c = c :=
   by rfl
 
+@[simp]
 theorem castRounds_symm {m n : Nat} (h : m = n) (c : Chain m) :
     castRounds h.symm (castRounds h c) = c := by
   subst n
@@ -66,6 +72,7 @@ theorem castRounds_trans {m n p : Nat} (h : m = n) (h' : n = p)
   rfl
 
 /-- Transporting the round count does not change the flattened type tree. -/
+@[simp]
 theorem toTypeTree_castRounds {m n : Nat} (h : m = n) (c : Chain m) :
     toTypeTree n (castRounds h c) = toTypeTree m c := by
   subst n
@@ -89,10 +96,10 @@ theorem toTypeTree_then : {m n : Nat} → (c : Chain m) →
       (toTypeTree m c).append (fun path => toTypeTree n (k path))
   | 0, n, ⟨⟩, k => by
       simp only [Chain.then, toTypeTree_castRounds, toTypeTree_zero]
+      rfl
   | m + 1, n, ⟨tree, cont⟩, k => by
-      simp only [Chain.then]
-      rw [toTypeTree_castRounds]
-      simp only [toTypeTree_succ]
+      simp only [Chain.then, toTypeTree_castRounds, toTypeTree,
+        TypeTree.substMonoid_mult_toFunA]
       rw [PFunctor.FreeM.Path.append_tree_assoc]
       congr 1
       funext path
@@ -103,6 +110,7 @@ theorem toTypeTree_then : {m n : Nat} → (c : Chain m) →
 
 /-- An empty prefix is a left unit for `Chain.then` already at the
 round-indexed presentation level. -/
+@[simp]
 theorem then_zero_left {n : Nat} (c : Chain 0)
     (k : Path (toTypeTree 0 c) → Chain n) :
     castRounds (Nat.zero_add n) (Chain.then c k) = k ⟨⟩ := by

--- a/PolyFun/Interaction/Basic/Chain/Append.lean
+++ b/PolyFun/Interaction/Basic/Chain/Append.lean
@@ -130,7 +130,7 @@ theorem toTypeTree_then_zero_left {n : Nat} (c : Chain 0)
     toTypeTree (0 + n) (Chain.then c k) = toTypeTree n (k ⟨⟩) := by
   cases c
   rw [toTypeTree_then]
-  simp only [toTypeTree_zero]
+  rfl
 
 /-- An empty suffix is a right unit for `Chain.then` after flattening. -/
 theorem toTypeTree_then_zero_right {m : Nat} (c : Chain m)

--- a/PolyFun/Interaction/Basic/StateChain.lean
+++ b/PolyFun/Interaction/Basic/StateChain.lean
@@ -273,6 +273,10 @@ theorem PFunctor.FreeM.Path.stateChainFamily_zero
     (Family : (i : Nat) → Stage i → Type u) (i : Nat) (s : Stage i) (tr : PUnit) :
     PFunctor.FreeM.Path.stateChainFamily (advance := advance) Family 0 i s tr = Family i s := rfl
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+the path-family lemma below rewrites along a `stateChain` layer there.
+`implicit_reducible` (unlike `reducible`) stays invisible to simp
+validation and instance search. -/
 attribute [local implicit_reducible] PFunctor.FreeM.stateChain
 
 /-- A constant family is unaffected by `stateChainFamily`. -/

--- a/PolyFun/Interaction/Basic/Strategy.lean
+++ b/PolyFun/Interaction/Basic/Strategy.lean
@@ -127,8 +127,6 @@ theorem Strategy.mapOutput_id {m : Type u → Type u} [Functor m] [LawfulFunctor
   | done => rfl
   | node X rest ih =>
     rcases σ with ⟨x, cont⟩
-    simp only [PFunctor.Lens.id, id_eq] at cont
-    change m (Strategy.Plain m (rest x) (fun p => A ⟨x, p⟩)) at cont
     simp only [Strategy.mapOutput]
     congr 1
     calc (mapOutput (fun (p : Path (rest x)) (y : A ⟨x, p⟩) => y) ·) <$> cont
@@ -146,8 +144,6 @@ theorem Strategy.mapOutput_comp
   | done => rfl
   | node X rest ih =>
     rcases σ with ⟨x, cont⟩
-    simp only [PFunctor.Lens.id, id_eq] at cont
-    change m (Strategy.Plain m (rest x) (fun p => A ⟨x, p⟩)) at cont
     simp only [Strategy.mapOutput]
     congr 1
     calc (mapOutput (fun (p : Path (rest x)) (y : A ⟨x, p⟩) => g ⟨x, p⟩ (f ⟨x, p⟩ y)) ·)

--- a/PolyFun/Interaction/Basic/StrategyOver.lean
+++ b/PolyFun/Interaction/Basic/StrategyOver.lean
@@ -237,7 +237,7 @@ This is the recursive global form of the local `ShapeOver.map` field. The
 runtime path index is `PathAlong l spec`, so it applies equally to plain type trees
 and to control trees such as `Oracle.TypeTree` executed through a lens.
 -/
-@[reducible]
+@[implicit_reducible]
 def mapOutput
     (shape : ShapeOver l Agent Γ)
     {agent : Agent}

--- a/PolyFun/Interaction/Basic/TypeTree.lean
+++ b/PolyFun/Interaction/Basic/TypeTree.lean
@@ -214,10 +214,14 @@ abbrev substMonoid : PFunctor.SubstMonoid.{u + 1, u} :=
 theorem substMonoid_unit_toFunA (x : PUnit) : TypeTree.substMonoid.unit.toFunA x = TypeTree.done :=
   rfl
 
+-- Not `@[simp]`: `substMonoid` is a reducible `abbrev`, so the LHS
+-- dsimp-normalizes through the `FreeP.substMonoid` projection lemmas and the
+-- `simpNF` linter rejects the attribute. Used by name in `simp only` rewrites.
 theorem substMonoid_mult_toFunA (spec : TypeTree) (next : Path spec → TypeTree) :
     TypeTree.substMonoid.mult.toFunA ⟨spec, next⟩ = spec.append next :=
   rfl
 
+-- Not `@[simp]` for the same `simpNF` reason as `substMonoid_mult_toFunA`.
 theorem substMonoid_mult_toFunB (spec : TypeTree) (next : Path spec → TypeTree)
     (tr : Path (spec.append next)) :
     TypeTree.substMonoid.mult.toFunB ⟨spec, next⟩ tr =

--- a/PolyFun/Interaction/TwoParty/Compose.lean
+++ b/PolyFun/Interaction/TwoParty/Compose.lean
@@ -41,6 +41,10 @@ namespace TwoParty
 
 open TwoParty
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+the sequential-composition lemmas below rewrite through the runner and the
+strategy family there. `implicit_reducible` (unlike `reducible`) stays
+invisible to simp validation and instance search. -/
 attribute [local implicit_reducible] run InteractionOver.runTypeTree StrategyOver
 
 /-- A lawful monad whose independent effects may be swapped.

--- a/PolyFun/Interaction/TwoParty/Decoration.lean
+++ b/PolyFun/Interaction/TwoParty/Decoration.lean
@@ -263,7 +263,7 @@ theorem withMonads_constant_eq_map
   | .done, _ => rfl
   | .node _ rest, ⟨role, rRest⟩ => by
       simp only [RoleDecoration.withMonads, RoleDecoration.monadsOver,
-        MonadDecoration.constant,
+        TypeTree.MonadDecoration.constant, MonadDecoration.constant,
         Decoration.ofOver]
       change
         (⟨⟨role, bm⟩,

--- a/PolyFun/Interaction/TwoParty/Refine.lean
+++ b/PolyFun/Interaction/TwoParty/Refine.lean
@@ -304,6 +304,7 @@ theorem ofDecorationOver_map {S T : Type u → Type v} (f : ∀ X, S X → T X) 
   | .node _ rest, ⟨.sender, rRest⟩, ⟨s, rr⟩ => by
       simp only [ofDecorationOver, Decoration.Over.map,
         PFunctor.FreeM.Displayed.Decoration.Over.fiberLocalMap,
+        PFunctor.FreeM.Displayed.Over.FiberLocalMap.toHom,
         PFunctor.FreeM.Displayed.Over.FiberLocalMap.toHomFun, map]
       congr 1; funext x
       exact ofDecorationOver_map f (rest x) (rRest x) (rr x)
@@ -312,6 +313,7 @@ theorem ofDecorationOver_map {S T : Type u → Type v} (f : ∀ X, S X → T X) 
       funext x
       simp only [ofDecorationOver, Decoration.Over.map,
         PFunctor.FreeM.Displayed.Decoration.Over.fiberLocalMap,
+        PFunctor.FreeM.Displayed.Over.FiberLocalMap.toHom,
         PFunctor.FreeM.Displayed.Over.FiberLocalMap.toHomFun, map]
       exact ofDecorationOver_map f (rest x) (rRest x) (rr x)
 

--- a/PolyFun/Interaction/TwoParty/Strategy.lean
+++ b/PolyFun/Interaction/TwoParty/Strategy.lean
@@ -57,9 +57,15 @@ namespace TwoParty
 variable {m : Type u → Type u}
 open TwoParty
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+the runner lemmas below rewrite through the strategy family and the generic
+runner there. `implicit_reducible` (unlike `reducible`) stays invisible to
+simp validation and instance search. -/
+attribute [local implicit_reducible] StrategyOver InteractionOver.runTypeTree
+
 /-- The ordinary paired two-party local syntax specialized to plain type trees,
 using the identity lens on `TypeTree.basePFunctor` and roles as node metadata. -/
-@[expose, reducible]
+@[expose, implicit_reducible]
 def _root_.Interaction.SyntaxOver.TwoParty.pairedTypeTree (m : Type u → Type u) :
     SyntaxOver
       (PFunctor.Lens.id TypeTree.basePFunctor) Participant.{u} (fun _ => Role) :=
@@ -107,7 +113,7 @@ theorem _root_.Interaction.SyntaxOver.TwoParty.pairedTypeTree_eq_ownerBased
         simp [PFunctor.Lens.id, TypeTree.Ownership.LocalView.node, perspective, typeTreePerspective]
 
 /-- Functorial shape for the ordinary paired two-party syntax over plain type trees. -/
-@[expose, reducible]
+@[expose, implicit_reducible]
 def _root_.Interaction.ShapeOver.TwoParty.pairedTypeTree (m : Type u → Type u) [Functor m] :
     ShapeOver
       (PFunctor.Lens.id TypeTree.basePFunctor) Participant.{u} (fun _ => Role) :=
@@ -121,7 +127,7 @@ supplies the move and continuation, while the focal participant observes it.
 Together with `InteractionOver.run`, this is the canonical whole-protocol runner
 for two-party role-decorated strategies.
 -/
-@[expose, reducible]
+@[expose, implicit_reducible]
 def _root_.Interaction.InteractionOver.TwoParty.pairedTypeTree (m : Type u → Type u) [Monad m] :
     InteractionOver
       (PFunctor.Lens.id TypeTree.basePFunctor) Participant.{u} (fun _ => Role)
@@ -224,7 +230,7 @@ theorem _root_.Interaction.SyntaxOver.TwoParty.pairedMonadicTypeTree_eq_ownerBas
               typeTreePerspective, TypeTree.Ownership.LocalView.monadic]
 
 /-- Functorial output map for role-dependent strategies. -/
-@[reducible]
+@[implicit_reducible]
 def _root_.Interaction.StrategyOver.TwoParty.Focal.mapOutput {m : Type u → Type u} [Functor m] :
     {spec : TypeTree.{u}} → {roles : RoleDecoration spec} →
     {A B : PFunctor.FreeM.Path spec → Type u} →
@@ -287,20 +293,13 @@ theorem _root_.Interaction.StrategyOver.TwoParty.Focal.mapOutput_id
             (rest x) (rRest x) (fun p => A ⟨x, p⟩) s
       simp only [StrategyOver.TwoParty.Focal.mapOutput, ShapeOver.mapOutput,
         ShapeOver.TwoParty.pairedTypeTree, ShapeOver.TwoParty.paired, PFunctor.Lens.id]
-      let Sx := StrategyOver (SyntaxOver.TwoParty.pairedTypeTree m) Participant.focal
-        (rest x) (rRest x) (fun p => A ⟨x, p⟩)
-      let sx : m Sx := σ x
-      change (StrategyOver.TwoParty.Focal.mapOutput
-          (fun (p : PFunctor.FreeM.Path (rest x)) (y : A ⟨x, p⟩) => y) ·) <$> sx = sx
-      have hfun : (fun s : Sx => StrategyOver.TwoParty.Focal.mapOutput
-          (fun (p : PFunctor.FreeM.Path (rest x)) (y : A ⟨x, p⟩) => y) s) =
-          (fun s : Sx => s) := by
-        funext s
-        exact hid s
-      exact (congrArg (fun h => h <$> sx) hfun).trans (LawfulFunctor.id_map sx)
+      calc (StrategyOver.TwoParty.Focal.mapOutput
+              (fun (p : PFunctor.FreeM.Path (rest x)) (y : A ⟨x, p⟩) => y) ·) <$> σ x
+          = id <$> σ x := by congr 1; funext s; exact hid s
+        _ = σ x := LawfulFunctor.id_map (σ x)
 
 /-- Functorial output map for counterparts. -/
-@[reducible]
+@[implicit_reducible]
 def _root_.Interaction.StrategyOver.TwoParty.Counterpart.mapOutput
     {m : Type u → Type u} [Functor m] :
     {spec : TypeTree.{u}} → {roles : RoleDecoration spec} →
@@ -480,7 +479,7 @@ The focal participant carries `OutputP`, while the counterpart carries
 `OutputC`. Naming this family gives the runner, profiles, and computation
 rules a single canonical shape for participant outputs, which keeps dependent
 function arguments definitionally aligned. -/
-@[expose, reducible]
+@[expose, implicit_reducible]
 def participantOutputFamily
     {spec : TypeTree} (OutputP OutputC : PFunctor.FreeM.Path spec → Type u)
     (agent : Participant.{u}) (tr : PFunctor.FreeM.Path spec) : Type u :=
@@ -490,7 +489,7 @@ def participantOutputFamily
 
 /-- Collect the two participant-indexed outputs into the result pair of a
 two-party run. -/
-@[expose, reducible]
+@[expose, implicit_reducible]
 def collectParticipantOutputs
     {spec : TypeTree} {OutputP OutputC : PFunctor.FreeM.Path spec → Type u} :
     (tr : PFunctor.FreeM.Path spec) →
@@ -500,7 +499,7 @@ def collectParticipantOutputs
 
 /-- Assemble the focal strategy and counterpart strategy into a
 participant-indexed profile for the generic runner. -/
-@[expose, reducible]
+@[expose, implicit_reducible]
 def participantProfile
     {m : Type u → Type u} {spec : TypeTree} {roles : RoleDecoration spec}
     {OutputP OutputC : PFunctor.FreeM.Path spec → Type u}
@@ -666,32 +665,24 @@ theorem _root_.Interaction.InteractionOver.TwoParty.run_paired_mapOutput_mapOutp
           InteractionOver.runTypeTree,
           participantProfile, collectParticipantOutputs]
     | .node X rest, ⟨.sender, rRest⟩ =>
-        change (x : X) → m (StrategyOver (SyntaxOver.TwoParty.pairedTypeTree m)
-          Participant.counterpart (rest x) (rRest x) (fun tr => OutputC ⟨x, tr⟩)) at cpt
         simp only [StrategyOver.TwoParty.Focal.mapOutput,
-          StrategyOver.TwoParty.Counterpart.mapOutput, ShapeOver.mapOutput]
+          StrategyOver.TwoParty.Counterpart.mapOutput]
         simp only [InteractionOver.runTypeTree, InteractionOver.TwoParty.pairedTypeTree,
           InteractionOver.TwoParty.paired, SyntaxOver.TwoParty.pairedTypeTree,
           participantOutputFamily, participantProfile, collectParticipantOutputs, bind_pure_comp]
-        change m ((x : X) × StrategyOver (SyntaxOver.TwoParty.pairedTypeTree m)
-          Participant.focal (rest x) (rRest x) (fun tr => OutputP ⟨x, tr⟩)) at strat
         refine (bind_map_left
           (fun xc =>
             (⟨xc.1, StrategyOver.TwoParty.Focal.mapOutput (fun p => fP ⟨xc.1, p⟩) xc.2⟩ :
               (x : X) × StrategyOver (SyntaxOver.TwoParty.pairedTypeTree m) Participant.focal
                 (rest x) (rRest x) (fun tr => OutputP' ⟨x, tr⟩)))
           strat _).trans ?_
-        simp only [PFunctor.Lens.id, id_eq]
-        rw [map_bind]
-        change strat >>= _ = strat >>= _
+        simp only [map_bind, Functor.map_map]
         refine congrArg (fun k => strat >>= k) ?_
         funext xc
         refine (bind_map_left
           (fun cNext =>
             StrategyOver.TwoParty.Counterpart.mapOutput (fun p => fC ⟨xc.1, p⟩) cNext)
           (cpt xc.1) _).trans ?_
-        rw [map_bind]
-        change cpt xc.1 >>= _ = cpt xc.1 >>= _
         refine congrArg (fun k => cpt xc.1 >>= k) ?_
         funext cNext
         let addPrefix :
@@ -699,38 +690,17 @@ theorem _root_.Interaction.InteractionOver.TwoParty.run_paired_mapOutput_mapOutp
               (fun tr => OutputC' ⟨xc.1, tr⟩) tr) →
             ((tr : PFunctor.FreeM.Path (TypeTree.node _ rest)) × OutputP' tr × OutputC' tr) :=
           fun a => ⟨⟨xc.1, a.1⟩, a.2.1, a.2.2⟩
-        let addPrefixIn :
-            ((tr : PFunctor.FreeM.Path (rest xc.1)) × (fun tr => OutputP ⟨xc.1, tr⟩) tr ×
-              (fun tr => OutputC ⟨xc.1, tr⟩) tr) →
-            ((tr : PFunctor.FreeM.Path (TypeTree.node _ rest)) × OutputP tr × OutputC tr) :=
-          fun a => ⟨⟨xc.1, a.1⟩, a.2.1, a.2.2⟩
         have h := congrArg (fun z => addPrefix <$> z)
           (go (rest xc.1) (rRest xc.1) (fun tr => fP ⟨xc.1, tr⟩) (fun tr => fC ⟨xc.1, tr⟩)
             xc.2 cNext)
-        change addPrefix <$> InteractionOver.runTypeTree
-          (I := InteractionOver.TwoParty.pairedTypeTree m) (spec := rest xc.1)
-          (ctxs := rRest xc.1)
-          (participantProfile
-            (StrategyOver.TwoParty.Focal.mapOutput (fun p => fP ⟨xc.1, p⟩) xc.2)
-            (StrategyOver.TwoParty.Counterpart.mapOutput (fun p => fC ⟨xc.1, p⟩) cNext))
-          collectParticipantOutputs =
-            (fun z => ⟨z.1, fP z.1 z.2.1, fC z.1 z.2.2⟩) <$>
-              (addPrefixIn <$> InteractionOver.runTypeTree
-                (I := InteractionOver.TwoParty.pairedTypeTree m) (spec := rest xc.1)
-                (ctxs := rRest xc.1) (participantProfile xc.2 cNext)
-                collectParticipantOutputs)
-        rw [Functor.map_map] at h ⊢
+        rw [Functor.map_map] at h
         exact h
     | .node X rest, ⟨.receiver, rRest⟩ =>
-        change (x : X) → m (StrategyOver (SyntaxOver.TwoParty.pairedTypeTree m)
-          Participant.focal (rest x) (rRest x) (fun tr => OutputP ⟨x, tr⟩)) at strat
         simp only [StrategyOver.TwoParty.Focal.mapOutput,
-          StrategyOver.TwoParty.Counterpart.mapOutput, ShapeOver.mapOutput]
+          StrategyOver.TwoParty.Counterpart.mapOutput]
         simp only [InteractionOver.runTypeTree, InteractionOver.TwoParty.pairedTypeTree,
           InteractionOver.TwoParty.paired, SyntaxOver.TwoParty.pairedTypeTree,
           participantOutputFamily, participantProfile, collectParticipantOutputs, bind_pure_comp]
-        change m ((x : X) × StrategyOver (SyntaxOver.TwoParty.pairedTypeTree m)
-          Participant.counterpart (rest x) (rRest x) (fun tr => OutputC ⟨x, tr⟩)) at cpt
         refine (bind_map_left
           (fun xc =>
             (⟨xc.1, StrategyOver.TwoParty.Counterpart.mapOutput
@@ -738,16 +708,12 @@ theorem _root_.Interaction.InteractionOver.TwoParty.run_paired_mapOutput_mapOutp
               (x : X) × StrategyOver (SyntaxOver.TwoParty.pairedTypeTree m) Participant.counterpart
                 (rest x) (rRest x) (fun tr => OutputC' ⟨x, tr⟩)))
           cpt _).trans ?_
-        simp only [PFunctor.Lens.id, id_eq]
-        rw [map_bind]
-        change cpt >>= _ = cpt >>= _
+        simp only [map_bind, Functor.map_map]
         refine congrArg (fun k => cpt >>= k) ?_
         funext xc
         refine (bind_map_left
           (fun next => StrategyOver.TwoParty.Focal.mapOutput (fun p => fP ⟨xc.1, p⟩) next)
           (strat xc.1) _).trans ?_
-        rw [map_bind]
-        change strat xc.1 >>= _ = strat xc.1 >>= _
         refine congrArg (fun k => strat xc.1 >>= k) ?_
         funext next
         let addPrefix :
@@ -755,27 +721,10 @@ theorem _root_.Interaction.InteractionOver.TwoParty.run_paired_mapOutput_mapOutp
               (fun tr => OutputC' ⟨xc.1, tr⟩) tr) →
             ((tr : PFunctor.FreeM.Path (TypeTree.node _ rest)) × OutputP' tr × OutputC' tr) :=
           fun a => ⟨⟨xc.1, a.1⟩, a.2.1, a.2.2⟩
-        let addPrefixIn :
-            ((tr : PFunctor.FreeM.Path (rest xc.1)) × (fun tr => OutputP ⟨xc.1, tr⟩) tr ×
-              (fun tr => OutputC ⟨xc.1, tr⟩) tr) →
-            ((tr : PFunctor.FreeM.Path (TypeTree.node _ rest)) × OutputP tr × OutputC tr) :=
-          fun a => ⟨⟨xc.1, a.1⟩, a.2.1, a.2.2⟩
         have h := congrArg (fun z => addPrefix <$> z)
           (go (rest xc.1) (rRest xc.1) (fun tr => fP ⟨xc.1, tr⟩) (fun tr => fC ⟨xc.1, tr⟩)
             next xc.2)
-        change addPrefix <$> InteractionOver.runTypeTree
-          (I := InteractionOver.TwoParty.pairedTypeTree m) (spec := rest xc.1)
-          (ctxs := rRest xc.1)
-          (participantProfile
-            (StrategyOver.TwoParty.Focal.mapOutput (fun p => fP ⟨xc.1, p⟩) next)
-            (StrategyOver.TwoParty.Counterpart.mapOutput (fun p => fC ⟨xc.1, p⟩) xc.2))
-          collectParticipantOutputs =
-            (fun z => ⟨z.1, fP z.1 z.2.1, fC z.1 z.2.2⟩) <$>
-              (addPrefixIn <$> InteractionOver.runTypeTree
-                (I := InteractionOver.TwoParty.pairedTypeTree m) (spec := rest xc.1)
-                (ctxs := rRest xc.1) (participantProfile next xc.2)
-                collectParticipantOutputs)
-        rw [Functor.map_map] at h ⊢
+        rw [Functor.map_map] at h
         exact h
   exact go spec roles fP fC strat cpt
 
@@ -898,43 +847,35 @@ def _root_.Interaction.StrategyOver.TwoParty.Focal.toConstantMonadsHom
   mapNode_map := by
     intro X role A B C D f₁ f₂ g₁ g₂ comm node
     cases role
-    · simp only [PFunctor.Lens.id, id_eq] at node
-      have hfun :
-          (fun dx : (d : X) × A d =>
+    · have hfun :
+          (fun dx : (d : (PFunctor.Lens.id TypeTree.basePFunctor).toFunA X) × A d =>
             Sigma.mk dx.1 (g₁ dx.1 (f₁ dx.1 dx.2))) =
-          (fun dx : (d : X) × A d =>
+          (fun dx : (d : (PFunctor.Lens.id TypeTree.basePFunctor).toFunA X) × A d =>
             Sigma.mk dx.1 (g₂ dx.1 (f₂ dx.1 dx.2))) := by
           funext dx
           exact Sigma.ext rfl (heq_of_eq (comm dx.1 dx.2))
-      change
-        (fun db : (d : X) × B d => Sigma.mk db.1 (g₁ db.1 db.2)) <$>
-            ((fun da : (d : X) × A d => Sigma.mk da.1 (f₁ da.1 da.2)) <$> node) =
-          (fun dc : (d : X) × C d => Sigma.mk dc.1 (g₂ dc.1 dc.2)) <$>
-            ((fun da : (d : X) × A d => Sigma.mk da.1 (f₂ da.1 da.2)) <$> node)
-      calc
-        _ = ((fun db : (d : X) × B d => Sigma.mk db.1 (g₁ db.1 db.2)) ∘
-              (fun da : (d : X) × A d => Sigma.mk da.1 (f₁ da.1 da.2))) <$> node := by
-            rw [Functor.map_map]
-            apply congrArg (fun h => h <$> node)
-            funext a
-            rfl
-        _ = ((fun dc : (d : X) × C d => Sigma.mk dc.1 (g₂ dc.1 dc.2)) ∘
-              (fun da : (d : X) × A d => Sigma.mk da.1 (f₂ da.1 da.2))) <$> node := by
-            exact congrArg (fun h => h <$> node) hfun
-        _ = _ := by
-          rw [Functor.map_map]
-          apply congrArg (fun h => h <$> node)
-          funext a
-          rfl
-    · simp only [PFunctor.Lens.id, id_eq] at node
-      funext x
+      simpa [ShapeOver.TwoParty.Focal.monadicTypeTree, SyntaxOver.TwoParty.Focal.monadicTypeTree,
+        ShapeOver.comap, SyntaxOver.comap, ShapeOver.forAgent, SyntaxOver.forAgent,
+        ShapeOver.TwoParty.pairedTypeTree, ShapeOver.TwoParty.paired,
+        SyntaxOver.TwoParty.pairedTypeTree, SyntaxOver.TwoParty.paired,
+        RoleMonadContext.diagonal, TypeTree.Node.Context.extendMap, TypeTree.Node.ContextHom.id,
+        ShapeOver.TwoParty.pairedMonadicTypeTree, ShapeOver.TwoParty.pairedMonadic,
+        SyntaxOver.TwoParty.pairedMonadicTypeTree, SyntaxOver.TwoParty.pairedMonadic,
+        Functor.map_map]
+        using congrArg (fun h => h <$> node) hfun
+    · funext x
       have hfun : (fun y : A x => g₁ x (f₁ x y)) = (fun y : A x => g₂ x (f₂ x y)) := by
         funext y
         exact comm x y
-      change g₁ x <$> (f₁ x <$> node x) = g₂ x <$> (f₂ x <$> node x)
-      rw [← Functor.map_map, ← Functor.map_map]
-      simpa only [LawfulFunctor.id_map, Functor.map_map, Function.comp_apply, id_eq] using
-        congrArg (fun h => h <$> node x) hfun
+      simpa [ShapeOver.TwoParty.Focal.monadicTypeTree, SyntaxOver.TwoParty.Focal.monadicTypeTree,
+        ShapeOver.comap, SyntaxOver.comap, ShapeOver.forAgent, SyntaxOver.forAgent,
+        ShapeOver.TwoParty.pairedTypeTree, ShapeOver.TwoParty.paired,
+        SyntaxOver.TwoParty.pairedTypeTree, SyntaxOver.TwoParty.paired,
+        RoleMonadContext.diagonal, TypeTree.Node.Context.extendMap, TypeTree.Node.ContextHom.id,
+        ShapeOver.TwoParty.pairedMonadicTypeTree, ShapeOver.TwoParty.pairedMonadic,
+        SyntaxOver.TwoParty.pairedMonadicTypeTree, SyntaxOver.TwoParty.pairedMonadic,
+        Functor.map_map]
+        using congrArg (fun h => h <$> node x) hfun
 
 /--
 View an ordinary single-monad role strategy as a monadic focal strategy by

--- a/PolyFun/Interaction/TwoParty/Swap.lean
+++ b/PolyFun/Interaction/TwoParty/Swap.lean
@@ -28,6 +28,11 @@ universe u
 namespace Interaction
 namespace TwoParty
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+rewriting decorated trees through `Decoration.map_liftBind` needs
+`FreeM.bind` and `FreeM.map` to unfold there. -/
+attribute [local implicit_reducible] PFunctor.FreeM.bind PFunctor.FreeM.map
+
 open TwoParty
 
 @[simp, grind =]

--- a/PolyFun/Interaction/TwoParty/Syntax.lean
+++ b/PolyFun/Interaction/TwoParty/Syntax.lean
@@ -61,7 +61,7 @@ by an unbundled effect-like type constructor.
 This is weaker than `SyntaxOver.TwoParty.monadic`: it records the same owner/observer node
 shapes but does not require a `Monad` instance for `m`. Execution laws can add
 that instance only at the point where effects are actually run. -/
-@[expose, reducible]
+@[expose, implicit_reducible]
 def _root_.Interaction.SyntaxOver.TwoParty.paired (m : Type uB₂ → Type uB₂) :
     SyntaxOver l Participant (fun _ : P.A => Role) where
   Node agent pos role Cont :=
@@ -72,7 +72,7 @@ def _root_.Interaction.SyntaxOver.TwoParty.paired (m : Type uB₂ → Type uB₂
     | .counterpart, .receiver => m ((d : Q.B (l.toFunA pos)) × Cont d)
 
 /-- Functorial shape for `SyntaxOver.TwoParty.paired`. -/
-@[expose, reducible]
+@[expose, implicit_reducible]
 def _root_.Interaction.ShapeOver.TwoParty.paired (m : Type uB₂ → Type uB₂) [Functor m] :
     Interaction.ShapeOver l Participant (fun _ : P.A => Role) where
   toSyntaxOver := (SyntaxOver.TwoParty.paired l m :
@@ -209,24 +209,23 @@ def _root_.Interaction.ShapeOver.TwoParty.pairedMonadic :
     Interaction.ShapeOver l Participant
       (RolePairedMonadContextOver.{uB₂, uA, uB} P) where
   toSyntaxOver := SyntaxOver.TwoParty.pairedMonadic l
+  -- The branch retypings below hold definitionally; binding `node` directly
+  -- (rather than via `simpa`) keeps the elaborated `map` cast-free, so
+  -- downstream `simp` unfoldings see no `Eq.mp` obstructions.
   map := fun {agent} {pos} {γ} {A} {B} f node =>
     match agent, γ with
     | Participant.focal, ⟨Role.sender, ⟨bmP, _⟩⟩ =>
-        let send : bmP.M ((d : Q.B (l.toFunA pos)) × A d) := by
-          simpa [SyntaxOver.TwoParty.pairedMonadic] using node
+        let send : bmP.M ((d : Q.B (l.toFunA pos)) × A d) := node
         ((fun da => ⟨da.1, f da.1 da.2⟩) <$> send :
           bmP.M ((d : Q.B (l.toFunA pos)) × B d))
     | Participant.focal, ⟨Role.receiver, ⟨bmP, _⟩⟩ =>
-        let observe : (d : Q.B (l.toFunA pos)) → bmP.M (A d) := by
-          simpa [SyntaxOver.TwoParty.pairedMonadic] using node
+        let observe : (d : Q.B (l.toFunA pos)) → bmP.M (A d) := node
         fun d => f d <$> observe d
     | Participant.counterpart, ⟨Role.sender, ⟨_, bmC⟩⟩ =>
-        let observe : (d : Q.B (l.toFunA pos)) → bmC.M (A d) := by
-          simpa [SyntaxOver.TwoParty.pairedMonadic] using node
+        let observe : (d : Q.B (l.toFunA pos)) → bmC.M (A d) := node
         fun d => f d <$> observe d
     | Participant.counterpart, ⟨Role.receiver, ⟨_, bmC⟩⟩ =>
-        let receive : bmC.M ((d : Q.B (l.toFunA pos)) × A d) := by
-          simpa [SyntaxOver.TwoParty.pairedMonadic] using node
+        let receive : bmC.M ((d : Q.B (l.toFunA pos)) × A d) := node
         ((fun da => ⟨da.1, f da.1 da.2⟩) <$> receive :
           bmC.M ((d : Q.B (l.toFunA pos)) × B d))
 

--- a/PolyFun/Interaction/UC/Interface.lean
+++ b/PolyFun/Interaction/UC/Interface.lean
@@ -750,7 +750,7 @@ Swap the direction of a boundary.
 This is the structural operation underlying plugging:
 the outputs expected by one side become inputs for the other, and vice versa.
 -/
-@[expose, reducible]
+@[expose, implicit_reducible]
 def swap (Δ : PortBoundary) : PortBoundary :=
   ⟨Δ.Out, Δ.In⟩
 
@@ -760,7 +760,7 @@ Side-by-side composition of open boundaries.
 Inputs and outputs are combined by disjoint sum, so the resulting boundary
 exposes both components in parallel.
 -/
-@[expose, reducible]
+@[expose, implicit_reducible]
 def tensor (Δ₁ Δ₂ : PortBoundary) : PortBoundary :=
   ⟨Interface.sum Δ₁.In Δ₂.In, Interface.sum Δ₁.Out Δ₂.Out⟩
 
@@ -863,6 +863,7 @@ theorem tensor_id {Δ₁ Δ₂ : PortBoundary} :
   cases Δ₁
   cases Δ₂
   simp [tensor, id, Interface.Hom.sum_id]
+  constructor <;> rfl
 
 theorem tensor_comp {Δ₁ Δ₂ Δ₃ Δ₄ Δ₁' Δ₂' : PortBoundary} (g₁ : Hom Δ₁' Δ₃) (f₁ : Hom Δ₁ Δ₁')
     (g₂ : Hom Δ₂' Δ₄) (f₂ : Hom Δ₂ Δ₂') :

--- a/PolyFun/Interaction/UC/OpenProcess.lean
+++ b/PolyFun/Interaction/UC/OpenProcess.lean
@@ -106,6 +106,13 @@ structure BoundaryAction (Δ : PortBoundary) (X : Type w) where
 
 namespace BoundaryAction
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+the wiring lemmas below rewrite `List.filterMap` chains over `TraceList`
+carriers (reducibly `FreeMonoid (Idx _)`) there. `implicit_reducible` (unlike
+`reducible`) stays invisible to simp and instance search, and needs no
+`allowUnsafeReducibility`. -/
+attribute [local implicit_reducible] FreeMonoid PFunctor.Idx
+
 /--
 A purely internal node: not externally activated and no outbound packets.
 -/

--- a/PolyFun/Interaction/UC/OpenProcess.lean
+++ b/PolyFun/Interaction/UC/OpenProcess.lean
@@ -62,6 +62,11 @@ probabilistic execution belong to downstream runtime interpreters.
 
 public section
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+the wiring lemmas below rewrite `List.filterMap` chains over `TraceList`
+carriers (reducibly `FreeMonoid (Idx _)`) there. `implicit_reducible` (unlike
+`reducible`) stays invisible to simp and instance search, and needs no
+`allowUnsafeReducibility`. -/
 attribute [local implicit_reducible] PFunctor.Obj PFunctor.Idx FreeMonoid
 
 universe u v v₁ v₂ v₃ w w'
@@ -105,13 +110,6 @@ structure BoundaryAction (Δ : PortBoundary) (X : Type w) where
   emit : PFunctor.Trace Δ.Out X := 1
 
 namespace BoundaryAction
-
-/- Lean 4.33 compares assigned metavariable types at implicit transparency;
-the wiring lemmas below rewrite `List.filterMap` chains over `TraceList`
-carriers (reducibly `FreeMonoid (Idx _)`) there. `implicit_reducible` (unlike
-`reducible`) stays invisible to simp and instance search, and needs no
-`allowUnsafeReducibility`. -/
-attribute [local implicit_reducible] FreeMonoid PFunctor.Idx
 
 /--
 A purely internal node: not externally activated and no outbound packets.

--- a/PolyFun/Interaction/UC/OpenProcess.lean
+++ b/PolyFun/Interaction/UC/OpenProcess.lean
@@ -713,6 +713,10 @@ structure OpenProcess (m : Type w → Type w') (Party : Type u) (Δ : PortBounda
 
 namespace OpenProcess
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+the boundary-remapping lemmas below rewrite through nodewise decoration maps
+there. `implicit_reducible` (unlike `reducible`) stays invisible to simp
+validation and instance search. -/
 attribute [local implicit_reducible] PFunctor.FreeM.Displayed.Decoration.localMap
   PFunctor.FreeM.Displayed.LocalMap.toHom PFunctor.FreeM.Displayed.LocalMap.toHomFun
 
@@ -853,15 +857,11 @@ theorem isSilentDecoration_iff_map {Party : Type u} {Δ₁ Δ₂ : PortBoundary}
     simp only [IsSilentDecoration, Decoration.map]
     constructor
     · rintro ⟨h1, h2⟩
-      change (f _ ons).boundary.isActivated = false at h1
       exact ⟨by rwa [hAct] at h1,
         (isSilentDecoration_iff_map f hAct (drest x) tr).mp h2⟩
     · rintro ⟨h1, h2⟩
-      constructor
-      · change (f _ ons).boundary.isActivated = false
-        rwa [hAct]
-      · exact
-          (isSilentDecoration_iff_map f hAct (drest x) tr).mpr h2
+      exact ⟨by rwa [hAct],
+        (isSilentDecoration_iff_map f hAct (drest x) tr).mpr h2⟩
 
 /-- `IsSilentStep` is invariant under `OpenProcess.mapBoundary`: remapping
 the boundary does not change which paths are silent, because all

--- a/PolyFun/Interaction/UC/OpenProcessModel.lean
+++ b/PolyFun/Interaction/UC/OpenProcessModel.lean
@@ -52,6 +52,10 @@ namespace UC
 
 open Concurrent
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+the activation-equivalence lemmas below rewrite through the interleaved
+dynamical model there. `implicit_reducible` (unlike `reducible`) stays
+invisible to simp validation and instance search. -/
 attribute [local implicit_reducible] PFunctor.DynSystem.expose PFunctor.DynSystem.update
   PFunctor.DynSystem.mk' Concurrent.ProcessOver.interleave OpenProcess.mapBoundary
   OpenProcess.interleave
@@ -652,9 +656,9 @@ theorem openTheory_par_left_unit_activation_equiv
     rw [isSilentStep_mapBoundary_iff] at hvisible
     match b with
     | true =>
-      exact absurd (by
-        simp only [IsSilentStep, ProcessOver.interleave, Decoration.map]
-        exact ⟨rfl, trivial⟩) hvisible
+      exact absurd (by simp [IsSilentStep, ProcessOver.interleave,
+        IsSilentDecoration, schedulerNode,
+        BoundaryAction.internal, -PFunctor.FreeM.liftBind_eq]) hvisible
     | false =>
       refine ⟨rest, fun h => hvisible ?_, rfl⟩
       simp only [IsSilentStep, ProcessOver.interleave, Decoration.map]
@@ -712,9 +716,9 @@ theorem openTheory_par_right_unit_activation_equiv
       intro X ons
       simp [OpenNodeContext.inlTensor, BoundaryAction.embedInlTensor]
     | false =>
-      exact absurd (by
-        simp only [IsSilentStep, ProcessOver.interleave, Decoration.map]
-        exact ⟨rfl, trivial⟩) hvisible
+      exact absurd (by simp [IsSilentStep, ProcessOver.interleave,
+        IsSilentDecoration, schedulerNode,
+        BoundaryAction.internal, -PFunctor.FreeM.liftBind_eq]) hvisible
   · intro tr₂ hsilent
     refine .inl ⟨⟨⟨true⟩, tr₂⟩, ?_, rfl⟩
     rw [isSilentStep_mapBoundary_iff]
@@ -770,9 +774,9 @@ theorem openTheory_wire_id_wire_activation_equiv
   · intro ⟨⟨b⟩, rest⟩ hvisible
     match b with
     | true =>
-      exact absurd (by
-        simp only [IsSilentStep, ProcessOver.interleave, Decoration.map]
-        exact ⟨rfl, trivial⟩) hvisible
+      exact absurd (by simp [IsSilentStep, ProcessOver.interleave,
+        IsSilentDecoration, schedulerNode,
+        BoundaryAction.internal, -PFunctor.FreeM.liftBind_eq]) hvisible
     | false =>
       refine ⟨rest, fun h => hvisible ?_, rfl⟩
       simp only [IsSilentStep, ProcessOver.interleave, Decoration.map]
@@ -826,9 +830,9 @@ theorem openTheory_wire_id_wire_right_activation_equiv
       intro X ons
       simp [OpenNodeContext.wireLeft, BoundaryAction.wireLeft]
     | false =>
-      exact absurd (by
-        simp only [IsSilentStep, ProcessOver.interleave, Decoration.map]
-        exact ⟨rfl, trivial⟩) hvisible
+      exact absurd (by simp [IsSilentStep, ProcessOver.interleave,
+        IsSilentDecoration, schedulerNode,
+        BoundaryAction.internal, -PFunctor.FreeM.liftBind_eq]) hvisible
   · intro tr₂ hsilent
     refine .inl ⟨⟨⟨true⟩, tr₂⟩, ?_, rfl⟩
     simp only [IsSilentStep, ProcessOver.interleave, Decoration.map]

--- a/PolyFun/Interaction/UC/OpenSyntax/Raw.lean
+++ b/PolyFun/Interaction/UC/OpenSyntax/Raw.lean
@@ -6,7 +6,6 @@ Authors: Quang Dao
 
 module
 
-import all PolyFun.Interaction.UC.OpenTheory
 public import PolyFun.Interaction.UC.OpenTheory
 
 /-!

--- a/PolyFun/PFunctor/Basic.lean
+++ b/PolyFun/PFunctor/Basic.lean
@@ -64,7 +64,12 @@ def X : PFunctor.{uA, uB} :=
 def linear (A : Type uA) : PFunctor.{uA, uB} :=
   A X^ PUnit
 
-/-- The self monomial polynomial functor `P(X) = S X^ S` -/
+/-- The self monomial polynomial functor `P(X) = S X^ S`.
+
+The body spells out the monomial rather than using `S X^ S` so that the
+head and child types are projections of an explicit structure literal at
+every transparency level; the mate-object equations in the dynamical
+layers rewrite through this carrier during implicit-transparency checks. -/
 @[reducible]
 def selfMonomial (S : Type uA) : PFunctor.{uA, uA} :=
   { A := S, B := fun _ => S }
@@ -131,10 +136,10 @@ abbrev sum (P : PFunctor.{uA₁, uB}) (Q : PFunctor.{uA₂, uB}) : PFunctor.{max
 /-- Addition of polynomial functors, defined as the sum construction. -/
 @[reducible] instance instHAddPFunctor :
     HAdd PFunctor.{uA₁, uB} PFunctor.{uA₂, uB} PFunctor.{max uA₁ uA₂, uB} where
-  hAdd P Q := ⟨P.A ⊕ Q.A, Sum.elim P.B Q.B⟩
+  hAdd := sum
 
 @[reducible] instance instAddPFunctor : Add PFunctor.{uA, uB} where
-  add P Q := ⟨P.A ⊕ Q.A, Sum.elim P.B Q.B⟩
+  add := sum
 
 lemma add_def (P : PFunctor.{uA₁, uB}) (Q : PFunctor.{uA₂, uB}) :
     P + Q = ⟨P.A ⊕ Q.A, Sum.elim P.B Q.B⟩ := rfl

--- a/PolyFun/PFunctor/Bound.lean
+++ b/PolyFun/PFunctor/Bound.lean
@@ -100,20 +100,7 @@ private lemma isRollBound_congr_aux
     (hcan : ∀ (a : P.A) (b : B), canRoll₁ a b ↔ canRoll₂ a b)
     (hcost : ∀ (a : P.A) (b : B), cost₁ a b = cost₂ a b) :
     ∀ {b : B}, oa.IsRollBound b canRoll₁ cost₁ ↔ oa.IsRollBound b canRoll₂ cost₂ := by
-  induction oa using FreeM.induction with
-  | pure _ => intro; simp only [isRollBound_pure]
-  | lift_bind a cont ih =>
-      intro b
-      rw [isRollBound_lift_bind_iff, isRollBound_lift_bind_iff]
-      constructor
-      · rintro ⟨ha, hcont⟩
-        refine ⟨(hcan a b).mp ha, fun y => ?_⟩
-        rw [← hcost a b]
-        exact (ih y).mp (hcont y)
-      · rintro ⟨ha, hcont⟩
-        refine ⟨(hcan a b).mpr ha, fun y => ?_⟩
-        rw [hcost a b]
-        exact (ih y).mpr (hcont y)
+  induction oa using FreeM.induction <;> intro b <;> grind
 
 lemma isRollBound_congr
     {oa : FreeM P α} {b : B}

--- a/PolyFun/PFunctor/CartesianClosed.lean
+++ b/PolyFun/PFunctor/CartesianClosed.lean
@@ -167,17 +167,6 @@ private lemma cast_exp_direction_of_inl {q r : PFunctor.{uA, uB}} {f f' : (exp r
   have hbd : bd = bd' := e.injective (Subsingleton.elim _ _)
   exact congrArg (fun z => (⟨i, ⟨d, z⟩⟩ : (exp r q).B f)) hbd
 
-private theorem Lens.ext_heq {p q : PFunctor} (l₁ l₂ : Lens p q)
-    (hA : l₁.toFunA = l₂.toFunA) (hB : l₁.toFunB ≍ l₂.toFunB) : l₁ = l₂ := by
-  cases l₁ with
-  | mk a₁ b₁ =>
-    cases l₂ with
-    | mk a₂ b₂ =>
-      dsimp only [Lens.toFunA, Lens.toFunB] at hA hB
-      cases hA
-      cases eq_of_heq hB
-      rfl
-
 private lemma exp_direction_components {q r : PFunctor} {f f' : (exp r q).A}
     (h : f = f') {x : (exp r q).B f} {y : (exp r q).B f'} (hy : x ≍ y) :
     x.1 = y.1 ∧ x.2.1 ≍ y.2.1 := by

--- a/PolyFun/PFunctor/CartesianClosed.lean
+++ b/PolyFun/PFunctor/CartesianClosed.lean
@@ -58,8 +58,13 @@ namespace PFunctor
 
 namespace CartesianClosed
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+the exponential-adjunction equations below rewrite through the cartesian
+product and exponential constructions there. `implicit_reducible` (unlike
+`reducible`) keeps them opaque to simp and typeclass resolution, and needs
+no `allowUnsafeReducibility`. -/
 attribute [local implicit_reducible] PFunctor.monomial PFunctor.X PFunctor.prod
-  PFunctor.pi PFunctor.exp PFunctor.comp
+  PFunctor.instHMulPFunctor PFunctor.instMulPFunctor PFunctor.pi PFunctor.exp PFunctor.comp
 
 /-- The evaluation lens `exp r q * q ⇆ r`, the counit of the cartesian
 exponential adjunction (Spivak–Niu Example 5.32).
@@ -111,18 +116,17 @@ theorem uncurry_curry {p q r : PFunctor.{uA, uB}} (l : Lens (p * q) r) :
     intro a
     obtain ⟨pa, qa⟩ := a
     funext d
-    change r.B (l.toFunA (pa, qa)) at d
     dsimp only [uncurry, eval, curry, Lens.comp, Lens.prodMap, Lens.piForall, Lens.id,
-      Function.comp_apply, id_eq] at d ⊢
+      Function.comp, Function.comp_apply, id_eq] at d ⊢
     split <;> rename_i heq
-    · simp only [Sum.elim_inl, Function.comp_apply]
+    · simp only [Sum.elim_inl, Function.comp]
       split <;> rename_i heq2
       · exact heq2.symm
       · rw [heq2] at heq; simp at heq
-    · simp only [Sum.elim_inr, Function.comp_apply, id_eq]
+    · simp only [Sum.elim_inr, Function.comp, id_eq]
       cases hs : l.toFunB (pa, qa) d with
       | inl pb => rw [hs] at heq; simp at heq
-      | inr qb' => rw [hs] at heq; simp_all
+      | inr qb' => rw [hs] at heq; simp_all; rfl
 
 /-- Position-level reverse round-trip: `curry (uncurry g)` and `g` agree on
 positions. This is the position component of the adjunction unit-counit identity
@@ -131,7 +135,7 @@ theorem curry_uncurry_toFunA {p q r : PFunctor.{uA, uB}} (g : Lens p (exp r q)) 
     (curry (uncurry g)).toFunA = g.toFunA := by
   funext pa a
   dsimp only [curry, uncurry, eval, Lens.comp, Lens.prodMap, Lens.piForall, Lens.id,
-    Function.comp_apply, id_eq]
+    Function.comp, Function.comp_apply, id_eq]
   refine Sigma.ext rfl (heq_of_eq ?_)
   funext d
   dsimp only
@@ -187,6 +191,10 @@ uncurried lens recovers the original lens. -/
 @[simp, grind =]
 theorem curry_uncurry {p q r : PFunctor.{uA, uB}} (g : Lens p (exp r q)) :
     curry (uncurry g) = g := by
+  -- Lean 4.33: the original transport through `transported_dependent_apply`
+  -- leaves a final goal that is no longer type-correct at implicit
+  -- transparency, defeating `grind`; the round-trip is instead established
+  -- componentwise through heterogeneous extensionality.
   apply Lens.ext_heq
   · exact curry_uncurry_toFunA g
   · apply Function.hfunext rfl
@@ -213,9 +221,9 @@ theorem curry_uncurry {p q r : PFunctor.{uA, uB}} (g : Lens p (exp r q)) :
       split <;> rename_i value hh
       · have hpb : value = pb := Sum.inl.inj (hh.symm.trans hs)
         dsimp only [uncurry, eval, Lens.comp, Lens.prodMap, Lens.id,
-          Function.comp_apply, id_eq] at hs
+          Function.comp, Function.comp_apply, id_eq] at hs
         split at hs <;> rename_i heval
-        · simp only [Sum.elim_inl, Function.comp_apply] at hs
+        · simp only [Sum.elim_inl] at hs
           have hp := Sum.inl.inj hs
           apply heq_of_eq
           rw [hpb, ← hp]
@@ -231,7 +239,7 @@ theorem curry_uncurry {p q r : PFunctor.{uA, uB}} (g : Lens p (exp r q)) :
           let e : (X + C (q.B iNew)).B ((g.toFunA pa iNew).2 dOld) ≃ PUnit :=
             _root_.Equiv.cast (congrArg (X + C (q.B iNew)).B heval)
           exact heq_of_eq (e.injective (Subsingleton.elim _ _))
-        · simp only [Sum.elim_inr, Function.comp_apply, id_eq] at hs
+        · simp only [Sum.elim_inr] at hs
           contradiction
       · cases hh.symm.trans hs
     | inr qi =>

--- a/PolyFun/PFunctor/Cofree.lean
+++ b/PolyFun/PFunctor/Cofree.lean
@@ -89,7 +89,8 @@ theorem dest_extend_eq {β : Type u} (t : CofreeC F α) (f : CofreeC F α → β
 
 @[simp] theorem head_extend {β : Type u} (t : CofreeC F α) (f : CofreeC F α → β) :
     head (extend t f) = f t := by
-  simp [head, extendF]
+  unfold head
+  rw [dest_extend_eq]
 
 @[simp] theorem tail_extend {β : Type u} (t : CofreeC F α) (f : CofreeC F α → β) :
     tail (extend t f) = F.map (fun x => extend x f) (tail t) := by

--- a/PolyFun/PFunctor/Cofree.lean
+++ b/PolyFun/PFunctor/Cofree.lean
@@ -89,8 +89,7 @@ theorem dest_extend_eq {β : Type u} (t : CofreeC F α) (f : CofreeC F α → β
 
 @[simp] theorem head_extend {β : Type u} (t : CofreeC F α) (f : CofreeC F α → β) :
     head (extend t f) = f t := by
-  unfold head
-  rw [dest_extend_eq]
+  simp [head, extendF]
 
 @[simp] theorem tail_extend {β : Type u} (t : CofreeC F α) (f : CofreeC F α → β) :
     tail (extend t f) = F.map (fun x => extend x f) (tail t) := by
@@ -108,8 +107,7 @@ instance : Comonad (CofreeC F) where
   have h_corec : h = M.corec (F := constProd F α) M.dest := by
     apply M.corec_unique (P := constProd F α) (g := M.dest) (f := h)
     intro x
-    simp only [dest_extend, h]
-    rfl
+    simp only [dest_extend, extendF_extract, h]
   have hid_corec : (id : CofreeC F α → CofreeC F α) = M.corec (F := constProd F α) M.dest := by
     apply M.corec_unique (P := constProd F α) (g := M.dest) (f := id)
     intro x

--- a/PolyFun/PFunctor/Cofree/FiniteProjection.lean
+++ b/PolyFun/PFunctor/Cofree/FiniteProjection.lean
@@ -33,7 +33,14 @@ universe uA uB u
 namespace PFunctor
 namespace CofreeP
 
-attribute [local implicit_reducible] M.Vertex.depth
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+the depth calculations below rewrite finite-projection directions whose
+types are indexed through `M.Vertex.depth`, `compNth`, and the composition
+product, which must unfold there for the rewrites to type-check.
+`implicit_reducible` (unlike `reducible`) keeps them opaque to simp and
+typeclass resolution, and needs no `allowUnsafeReducibility`. -/
+attribute [local implicit_reducible] M.Vertex.depth compNth PFunctor.comp
+  Lens.comp Lens.compMap cogenerator comult M.Vertex.subtree M.head M.children
 
 /-! ## Structural finite projections -/
 
@@ -43,7 +50,7 @@ At depth zero it keeps only the composition unit and pulls its unique
 direction back to the root.  At a successor depth it exposes the root layer
 and recursively projects each child subtree.  Consequently every composite
 direction pulls back to a vertex of exactly depth `n`. -/
-@[reducible]
+@[implicit_reducible]
 def projectionN (P : PFunctor.{uA, uB}) : (n : ℕ) →
     Lens (CofreeP P) (compNth P n)
   | 0 =>
@@ -90,18 +97,16 @@ theorem depth_projectionN_toFunB (P : PFunctor.{uA, uB}) :
         (compNth P n).B ((projectionN P n).toFunA tree)) →
       M.Vertex.depth ((projectionN P n).toFunB tree direction) = n
   | 0, tree, direction => by
-      rfl
+      simp only [projectionN_zero_toFunB, M.Vertex.depth_root]
   | n + 1, tree, direction => by
-      change M.Vertex.depth ((projectionN P n).toFunB
-        (M.children tree direction.1) direction.2) + 1 = n + 1
-      exact congrArg (fun depth => depth + 1)
-        (depth_projectionN_toFunB P n
-          (M.children tree direction.1) direction.2)
+      simp only [projectionN_succ_toFunB, M.Vertex.depth_child,
+        depth_projectionN_toFunB P n]
 
 /-! ## Low-depth coherence -/
 
 /-- In the homogeneous universe boundary, the zero-stage projection is the
 cofree counit. -/
+@[simp]
 theorem projectionN_zero (P : PFunctor.{u, u}) :
     projectionN P 0 = counit :=
   rfl

--- a/PolyFun/PFunctor/Cofree/LaxMonoidal.lean
+++ b/PolyFun/PFunctor/Cofree/LaxMonoidal.lean
@@ -35,6 +35,11 @@ universe uA uB uA₁ uB₁ uA₂ uB₂ uA₃ uB₃
 namespace PFunctor
 namespace CofreeP
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+the lax-monoidal structure equations below rewrite through the tensor
+substrate and the cofree unfolding pipeline there. `implicit_reducible`
+(unlike `reducible`) leaves the `rfl` simp lemmas on these constants valid,
+and needs no `allowUnsafeReducibility`. -/
 attribute [local implicit_reducible] PFunctor.X PFunctor.monomial PFunctor.tensor
   Comonoid.Hom.ofCategoryLaws comonoid cogenerator extend
 
@@ -61,6 +66,7 @@ theorem laxUnitHom_toLens :
 
 /-- Projecting the lax unit to one generator layer recovers the canonical unit
 comparison. -/
+@[simp]
 theorem cogenerator_comp_laxUnit :
     cogenerator X.{uA, uB} ∘ₗ laxUnit.{uA, uB} =
       (Lens.unitComparison :
@@ -83,8 +89,11 @@ def laxTensor (P : PFunctor.{uA₁, uB₁}) (Q : PFunctor.{uA₂, uB₂}) :
     Lens (CofreeP P ⊗ CofreeP Q) (CofreeP (P ⊗ Q)) :=
   (laxTensorHom P Q).toLens
 
+/- Lean 4.33: the comparison retrofunctors themselves must likewise unfold
+during implicit-transparency defeq checks below. -/
 attribute [local implicit_reducible] laxUnitHom laxUnit laxTensorHom laxTensor
 
+@[simp]
 theorem laxTensorHom_toLens
     (P : PFunctor.{uA₁, uB₁}) (Q : PFunctor.{uA₂, uB₂}) :
     (laxTensorHom P Q).toLens = laxTensor P Q :=
@@ -92,6 +101,7 @@ theorem laxTensorHom_toLens
 
 /-- Projecting the binary comparison to one generator layer recovers the
 tensor of the two cogenerators. -/
+@[simp]
 theorem cogenerator_comp_laxTensor
     (P : PFunctor.{uA₁, uB₁}) (Q : PFunctor.{uA₂, uB₂}) :
     cogenerator (P ⊗ Q) ∘ₗ laxTensor P Q =
@@ -112,6 +122,7 @@ theorem laxUnit_children :
   rw [children_unfoldShape]
   rfl
 
+@[simp]
 theorem laxUnit_toFunB
     (vertex : M.Vertex ((laxUnit.{uA, uB}).toFunA PUnit.unit)) :
     (laxUnit.{uA, uB}).toFunB PUnit.unit vertex = PUnit.unit :=
@@ -133,6 +144,9 @@ theorem laxTensor_children (P : PFunctor.{uA₁, uB₁})
     M.children ((laxTensor P Q).toFunA (left, right)) direction =
       (laxTensor P Q).toFunA
         (M.children left direction.1, M.children right direction.2) := by
+  -- Lean 4.33: the direction transported across `head_unfoldShape` fails the
+  -- implicit-transparency check of a `rw`, so the recurrence is applied as an
+  -- explicit term instead.
   exact children_unfoldShape
     (Comonoid.tensor (comonoid P) (comonoid Q))
     (cogenerator P ⊗ₗ cogenerator Q) (left, right) direction
@@ -144,6 +158,7 @@ theorem laxTensor_toFunB_root (P : PFunctor.{uA₁, uB₁})
     (laxTensor P Q).toFunB (left, right)
         (.root ((laxTensor P Q).toFunA (left, right))) =
       (.root left, .root right) := by
+  -- Lean 4.33: as above, the root direction is produced by an explicit term.
   exact unfoldDirection_root
     (Comonoid.tensor (comonoid P) (comonoid Q))
     (cogenerator P ⊗ₗ cogenerator Q) (left, right)
@@ -225,7 +240,7 @@ theorem laxTensorHom_natural
       (laxTensorHom P Q).comp (mapHom (f ⊗ₗ g)) := by
   apply hom_ext_cogenerator
   simp only [Comonoid.Hom.comp_toLens, Comonoid.Hom.tensor_toLens,
-    mapHom_toLens]
+    mapHom_toLens, laxTensorHom_toLens]
   calc
     cogenerator (P' ⊗ Q') ∘ₗ
           (laxTensor P' Q' ∘ₗ (map f ⊗ₗ map g)) =
@@ -276,8 +291,8 @@ theorem laxTensorHom_unit_left (P : PFunctor.{uA, uB}) :
       (Comonoid.tensorUnitLeftIso (comonoid P)).hom := by
   apply hom_ext_cogenerator
   simp only [Comonoid.Hom.comp_toLens, Comonoid.Hom.tensor_toLens,
-    Comonoid.Hom.id_toLens, mapHom_toLens,
-    Comonoid.tensorUnitLeftIso_hom_toLens]
+    Comonoid.Hom.id_toLens, mapHom_toLens, laxTensorHom_toLens,
+    laxUnitHom_toLens, Comonoid.tensorUnitLeftIso_hom_toLens]
   calc
     cogenerator P ∘ₗ
           (map ((Lens.Equiv.xTensor (P := P)).toLens) ∘ₗ
@@ -320,8 +335,8 @@ theorem laxTensorHom_unit_right (P : PFunctor.{uA, uB}) :
       (Comonoid.tensorUnitRightIso (comonoid P)).hom := by
   apply hom_ext_cogenerator
   simp only [Comonoid.Hom.comp_toLens, Comonoid.Hom.tensor_toLens,
-    Comonoid.Hom.id_toLens, mapHom_toLens,
-    Comonoid.tensorUnitRightIso_hom_toLens]
+    Comonoid.Hom.id_toLens, mapHom_toLens, laxTensorHom_toLens,
+    laxUnitHom_toLens, Comonoid.tensorUnitRightIso_hom_toLens]
   calc
     cogenerator P ∘ₗ
           (map ((Lens.Equiv.tensorX (P := P)).toLens) ∘ₗ
@@ -370,7 +385,7 @@ theorem laxTensorHom_assoc
           (P := P) (Q := Q) (R := R)).toLens)) := by
   apply hom_ext_cogenerator
   simp only [Comonoid.Hom.comp_toLens, Comonoid.Hom.tensor_toLens,
-    Comonoid.Hom.id_toLens, mapHom_toLens,
+    Comonoid.Hom.id_toLens, mapHom_toLens, laxTensorHom_toLens,
     Comonoid.tensorAssocIso_hom_toLens]
   calc
     cogenerator (P ⊗ (Q ⊗ R)) ∘ₗ

--- a/PolyFun/PFunctor/Cofree/Polynomial.lean
+++ b/PolyFun/PFunctor/Cofree/Polynomial.lean
@@ -64,13 +64,13 @@ def decode (x : (CofreeP P).Obj α) : CofreeC P α :=
   M.corec decodeStep x
 
 /-- Forget the label component of one `constProd P α` node. -/
-@[reducible]
+@[implicit_reducible]
 def forgetLabels (P : PFunctor.{uA, uB}) (α : Type v) :
     Lens (constProd P α) P :=
   Prod.snd ⇆ fun _ => id
 
 /-- Erase all labels from a type-level cofree tree. -/
-@[reducible]
+@[implicit_reducible]
 def erase (tree : CofreeC P α) : M P :=
   M.mapLens (forgetLabels P α) tree
 
@@ -337,7 +337,7 @@ def objEquiv : (CofreeP P).Obj α ≃ CofreeC P α where
 
 /-- Map cofree-polynomial trees covariantly along a generating lens and pull
 their finite vertices back contravariantly. -/
-@[reducible]
+@[implicit_reducible]
 def map {Q : PFunctor.{uA₂, uB₂}} (lens : Lens P Q) :
     Lens (CofreeP P) (CofreeP Q) where
   toFunA := M.mapLens lens
@@ -631,6 +631,12 @@ private theorem cast_composite_direction {Q : PFunctor.{uA, uB}}
   subst h
   rfl
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+the naturality equations below rewrite vertices indexed through `comonoid`
+comultiplication and lens composition, which must unfold there for the
+rewrites to type-check. -/
+attribute [local implicit_reducible] comonoid comult counit Lens.comp
+
 /-- Mapping cofree trees along a generating lens preserves the root counit.
 This theorem uses the common-generator-universe specialization chosen for
 `mapHom`; the underlying `CofreeP.map` remains heterogeneous. -/
@@ -708,8 +714,7 @@ private theorem map_comult_obj {Q : PFunctor.{uA, uB}}
       (M.Vertex.pullMapLens lens
         (M.Vertex.subtree (M.Vertex.pullMapLens lens tree vertex))
         (M.Vertex.castEquiv (congrFun hChildren vertex) next))
-  simpa only [hChildren] using
-    M.Vertex.pullMapLens_append lens tree vertex next
+  rw [M.Vertex.pullMapLens_append]
 
 /-- Mapping cofree trees along a generating lens preserves vertex
 concatenation, hence cofree comultiplication. -/

--- a/PolyFun/PFunctor/Cofree/Universal.lean
+++ b/PolyFun/PFunctor/Cofree/Universal.lean
@@ -45,13 +45,19 @@ def cogenerator (P : PFunctor.{uA, uB}) : Lens (CofreeP P) P where
   toFunB tree direction :=
     .child direction (.root (M.children tree direction))
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+the retrofunctor equations below rewrite through these constants there.
+`implicit_reducible` (unlike `reducible`) leaves the `rfl` simp lemmas on
+`cogenerator` and `comonoid` valid, and needs no `allowUnsafeReducibility`. -/
 attribute [local implicit_reducible] cogenerator comonoid Comonoid.identity Comonoid.target
   Comonoid.compose Lens.comp M.head M.children M.mapLens M.Vertex.subtree M.Vertex.append
   M.Vertex.castEquiv M.Vertex.pullMapLens
 
+@[simp]
 theorem cogenerator_toFunA (tree : M P) : (cogenerator P).toFunA tree = M.head tree :=
   rfl
 
+@[simp]
 theorem cogenerator_toFunB (tree : M P)
     (direction : P.B ((cogenerator P).toFunA tree)) :
     (cogenerator P).toFunB tree direction =
@@ -60,6 +66,7 @@ theorem cogenerator_toFunB (tree : M P)
 
 /-- The cofree generator projection is natural with respect to a generating
 lens, across independent source and target generator universes. -/
+@[simp]
 theorem cogenerator_comp_map {Q : PFunctor.{uA₂, uB₂}}
     (lens : Lens P Q) :
     cogenerator Q ∘ₗ map lens = lens ∘ₗ cogenerator P := by
@@ -81,19 +88,20 @@ theorem cogenerator_comp_map {Q : PFunctor.{uA₂, uB₂}}
     .child (lens.toFunB (M.head tree) direction)
       (.root (M.children tree
         (lens.toFunB (M.head tree) direction)))
-  with_unfolding_all
-    rw [M.Vertex.pullMapLens_child,
-      M.Vertex.cast_root (M.children_mapLens lens tree direction),
-      M.Vertex.pullMapLens_root]
-    rfl
+  rw [M.Vertex.pullMapLens_child,
+    M.Vertex.cast_root (M.children_mapLens lens tree direction),
+    M.Vertex.pullMapLens_root]
+  rfl
 
 /-! ## The outgoing category of the cofree comonoid -/
 
 /-- The categorical identity of a cofree tree is its root vertex. -/
+@[simp]
 theorem comonoid_identity (tree : M P) : Comonoid.identity (comonoid P) tree = .root tree :=
   rfl
 
 /-- The categorical target of a cofree vertex is its selected subtree. -/
+@[simp]
 theorem comonoid_target (tree : M P) (vertex : M.Vertex tree) :
     Comonoid.target (comonoid P) tree vertex =
       M.Vertex.subtree vertex :=
@@ -101,6 +109,7 @@ theorem comonoid_target (tree : M P) (vertex : M.Vertex tree) :
 
 /-- Categorical composition in the cofree comonoid is finite-vertex
 concatenation, in outer-then-inner path order. -/
+@[simp]
 theorem comonoid_compose (tree : M P) (first : M.Vertex tree)
     (second : M.Vertex (M.Vertex.subtree first)) :
     Comonoid.compose (comonoid P) tree first second =
@@ -111,7 +120,7 @@ variable (C : Comonoid.{uCA, uCB})
 
 /-- The cofree tree generated from an object of `C` by repeatedly applying
 the chosen generator lens. -/
-@[reducible]
+@[implicit_reducible]
 def unfoldShape (lens : Lens C.carrier P) (object : C.carrier.A) : M P :=
   M.corec
     (fun current =>
@@ -142,7 +151,7 @@ theorem head_unfoldShape (lens : Lens C.carrier P) (object : C.carrier.A) :
 
 /-- Pull a root direction of a coiterated tree back to the corresponding
 outgoing arrow of `C`. -/
-@[reducible]
+@[implicit_reducible]
 def unfoldRootDirection (lens : Lens C.carrier P)
     (object : C.carrier.A)
     (direction : P.B (M.head (unfoldShape C lens object))) :
@@ -172,7 +181,7 @@ theorem children_unfoldShape (lens : Lens C.carrier P)
 
 /-- Pull a finite vertex of a coiterated tree back to the composite outgoing
 arrow of `C` represented by that path. -/
-@[reducible]
+@[implicit_reducible]
 def unfoldDirection (lens : Lens C.carrier P) :
     (object : C.carrier.A) →
       M.Vertex (unfoldShape C lens object) → C.carrier.B object
@@ -352,6 +361,7 @@ theorem unfoldDirection_append (lens : Lens C.carrier P) :
             Comonoid.compose C object (Comonoid.identity C object)
               (unfoldDirection C lens identityTarget canonicalVertex) :=
         compose_heq C object (heq_of_eq hdirection) htail
+      simp only [M.Vertex.append_root]
       exact (hcompose.trans (by
         rw [hcanonical]
         exact Comonoid.identity_compose C object
@@ -420,7 +430,7 @@ theorem unfoldDirection_append (lens : Lens C.carrier P) :
                   (Comonoid.target C object first)
                   (M.Vertex.castEquiv childEq
                     (M.Vertex.append next suffix))) := by
-            with_unfolding_all rw [M.Vertex.append_child, unfoldDirection_child]
+            rw [M.Vertex.append_child, unfoldDirection_child]
           _ = Comonoid.compose C object first
                 (Comonoid.compose C (Comonoid.target C object first) rest
                   (unfoldDirection C lens final finalVertex)) := by
@@ -470,7 +480,7 @@ theorem unfoldDirection_append (lens : Lens C.carrier P) :
       _ < M.Vertex.depth (.child direction next) := Nat.lt_succ_self _
 
 /-- The carrier lens obtained by coiteration. -/
-@[reducible]
+@[implicit_reducible]
 def unfoldLens (lens : Lens C.carrier P) :
     Lens C.carrier (CofreeP P) where
   toFunA := unfoldShape C lens
@@ -536,6 +546,7 @@ theorem extend_toLens
   rfl
 
 /-- Coiteration is split by the one-layer cogenerator. -/
+@[simp]
 theorem cogenerator_comp_unfoldLens (lens : Lens C.carrier P) :
     cogenerator P ∘ₗ unfoldLens C lens = lens := by
   let hA : ∀ object,
@@ -554,12 +565,11 @@ theorem cogenerator_comp_unfoldLens (lens : Lens C.carrier P) :
       (.child direction
         (.root (M.children (unfoldShape C lens object) direction))) =
     lens.toFunB object direction
-  with_unfolding_all
-    rw [unfoldDirection_child,
-      M.Vertex.cast_root (children_unfoldShape C lens object direction),
-      unfoldDirection_root,
-      Comonoid.compose_identity_right]
-    rfl
+  rw [unfoldDirection_child,
+    M.Vertex.cast_root (children_unfoldShape C lens object direction),
+    unfoldDirection_root,
+    Comonoid.compose_identity_right]
+  rfl
 
 /-- Restricting a cofree extension recovers its generator lens. -/
 @[simp]
@@ -581,12 +591,11 @@ private theorem hom_target_oneLayer
               (.root (M.children
                 (hom.toLens.toFunA object) direction))))) =
       M.children (hom.toLens.toFunA object) direction := by
-  with_unfolding_all
-    simpa only [comonoid_target, M.Vertex.subtree_child,
-      M.Vertex.subtree_root] using
-      hom.map_target object
-        (.child direction
-          (.root (M.children (hom.toLens.toFunA object) direction)))
+  simpa only [comonoid_target, M.Vertex.subtree_child,
+    M.Vertex.subtree_root] using
+    hom.map_target object
+      (.child direction
+        (.root (M.children (hom.toLens.toFunA object) direction)))
 
 /-- The object map of a retrofunctor into the cofree comonoid is the
 coiteration of its restriction to one-layer generators. -/
@@ -654,9 +663,8 @@ private theorem unfoldDirection_restrict
           unfoldDirection_root C (restrict C hom) object
         _ = hom.toLens.toFunB object
               (.root (hom.toLens.toFunA object)) := by
-          with_unfolding_all
-            simpa only [comonoid_identity] using
-              (hom.map_identity object).symm
+          simpa only [comonoid_identity] using
+            (hom.map_identity object).symm
         _ = hom.toLens.toFunB object
               (M.Vertex.castEquiv
                 (unfoldShape_restrict C hom object)
@@ -722,9 +730,8 @@ private theorem unfoldDirection_restrict
                 (hom.toLens.toFunB
                   (Comonoid.target C object
                     (hom.toLens.toFunB object firstVertex)) rawNext) := by
-          with_unfolding_all
-            simpa only [comonoid_compose, rawNext] using
-              hom.map_compose object firstVertex mappedNext
+          simpa only [comonoid_compose, rawNext] using
+            hom.map_compose object firstVertex mappedNext
         have hrawVertices : rawNext ≍ homNext :=
           (cast_heq _ mappedNext).trans (cast_heq _ mappedNext).symm
         have hrawDirections :
@@ -738,7 +745,7 @@ private theorem unfoldDirection_restrict
       have hmappedVertex :
           M.Vertex.castEquiv shapeEq (.child direction next) =
             M.Vertex.append firstVertex mappedNext := by
-        with_unfolding_all rw [M.Vertex.cast_child]
+        rw [M.Vertex.cast_child]
         rfl
       calc
         unfoldDirection C (restrict C hom) object
@@ -830,7 +837,7 @@ theorem homEquiv_naturality_right
       lens ∘ₗ homEquiv (P := P) C hom := by
   change cogenerator Q ∘ₗ (map lens ∘ₗ hom.toLens) =
     lens ∘ₗ (cogenerator P ∘ₗ hom.toLens)
-  with_unfolding_all rw [← Lens.comp_assoc, cogenerator_comp_map, Lens.comp_assoc]
+  rw [← Lens.comp_assoc, cogenerator_comp_map, Lens.comp_assoc]
 
 end CofreeP
 end PFunctor

--- a/PolyFun/PFunctor/Comonoid/Category.lean
+++ b/PolyFun/PFunctor/Comonoid/Category.lean
@@ -155,7 +155,7 @@ def compose (c : C.carrier.A) (d : C.carrier.B c)
     compose (stateComonoid S) state first second = second :=
   rfl
 
-@[reducible]
+@[implicit_reducible]
 private def normalizedComult : Lens C.carrier (C.carrier ◃ C.carrier) where
   toFunA c := ⟨c, target C c⟩
   toFunB c direction := compose C c direction.1 direction.2
@@ -368,6 +368,10 @@ theorem compose_assoc (c : C.carrier.A) (d : C.carrier.B c)
         cast (congrArg (C.carrier ◃ C.carrier).B
           (congrFun childrenEq d)) innerLeft = innerRight := by
       rw [hAtDirection]
+      -- Lean 4.33: the original `calc` through `cast_comp_direction` no longer
+      -- elaborates (its intermediate type needs unfolding beyond implicit
+      -- transparency to pick the `Trans` instance), so the cast is discharged
+      -- by rewriting instead.
       rw [cast_comp_direction]
       · dsimp only [innerRight]
         congr 1

--- a/PolyFun/PFunctor/Display/Category.lean
+++ b/PolyFun/PFunctor/Display/Category.lean
@@ -38,6 +38,12 @@ universe u u' uA uA' uA'' uA''' uC uD uC' uD' uC'' uD'' uC''' uD'''
 namespace PFunctor
 namespace Handler
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency,
+so rewriting through `Extension (FreeP.substMonoid R)` needs `substMonoid`
+(and `PFunctor.Obj` beneath it) to unfold there. `implicit_reducible`
+(not `reducible`) keeps the `substMonoid`-headed goals opaque to typeclass
+resolution, which must recover `Monad (Extension ?M)` without unfolding
+`?M`. -/
 attribute [local implicit_reducible] PFunctor.Obj FreeP.substMonoid
 
 /-- Package a free handler as the corresponding lens into the free

--- a/PolyFun/PFunctor/Display/Free.lean
+++ b/PolyFun/PFunctor/Display/Free.lean
@@ -262,7 +262,6 @@ theorem bind_leaf (S : Display.{uA, uB, uC, uD} P)
           (fun b e =>
             S.bind (rest b) (children b e) FreeM.pure fun x dx =>
               S.leaf F x dx) using 1
-        rfl
       rw [htransport]
       congr
       funext b e
@@ -316,7 +315,6 @@ theorem bind_assoc (S : Display.{uA, uB, uC, uD} P)
           (fun b e =>
             S.bind ((rest b).bind g)
               (S.bind (rest b) (children b e) g dg) h dh) using 1
-        rfl
       rw [htransport]
       congr
       funext b e

--- a/PolyFun/PFunctor/Display/Free.lean
+++ b/PolyFun/PFunctor/Display/Free.lean
@@ -48,6 +48,11 @@ universe uA uB uC uD uE uE' uE'' uF uG uH
 namespace PFunctor
 namespace Display
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+transporting displayed trees along `FreeM.bind_pure` / `FreeM.bind_assoc`
+needs `FreeM.bind` and `FreeM.map` to unfold there. -/
+attribute [local implicit_reducible] PFunctor.FreeM.bind PFunctor.FreeM.map
+
 variable {P : PFunctor.{uA, uB}}
 
 /-- Embed a one-step polynomial display into the generic displayed algebra over

--- a/PolyFun/PFunctor/Display/Handler.lean
+++ b/PolyFun/PFunctor/Display/Handler.lean
@@ -122,7 +122,7 @@ namespace Handler
 
 /-- The identity displayed handler: retain every displayed position and pass
 each displayed direction directly to the corresponding continuation. -/
-@[reducible]
+@[implicit_reducible]
 def id (S : Display.{uA, uB, uC, uD} P) :
     Handler S S (PFunctor.Handler.id P) :=
   fun a c =>
@@ -135,7 +135,7 @@ The source and intermediate interfaces share a response universe because the
 first handler returns a tree whose leaves are source responses and whose nodes
 are intermediate operations. The final target's response universe remains
 independent. -/
-@[reducible]
+@[implicit_reducible]
 def comp
     {Q : PFunctor.{uA', uB}} {R : PFunctor.{uA'', uB'}}
     {S : Display.{uA, uB, uC, uD} P}
@@ -203,6 +203,8 @@ theorem liftM_id
           (fun b e =>
             S.liftM S (rest b) (children b e) (fun a => FreeM.lift a)
               (Handler.id S)) using 1
+        -- Lean 4.33: the transported node goal now simplifies to a
+        -- reflexive `Iff`, which `congr` no longer closes.
         all_goals simp only [FreeM.liftBind_eq, FreeM.bind_eq_bind, FreeM.pure_bind]
         all_goals exact Iff.rfl
       rw [htransport]

--- a/PolyFun/PFunctor/Display/Lens.lean
+++ b/PolyFun/PFunctor/Display/Lens.lean
@@ -28,6 +28,10 @@ universe uA₁ uB₁ uC₁ uD₁ uA₂ uB₂ uC₂ uD₂
 namespace PFunctor
 namespace Display
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+the fiberwise lens equations below rewrite through `Display.total` there.
+`implicit_reducible` (unlike `reducible`) keeps it opaque to simp and
+typeclass resolution, and needs no `allowUnsafeReducibility`. -/
 attribute [local implicit_reducible] Display.total
 
 /-- A fiberwise lift of an ordinary polynomial lens between two displays. -/

--- a/PolyFun/PFunctor/Dynamical/CofreeMate.lean
+++ b/PolyFun/PFunctor/Dynamical/CofreeMate.lean
@@ -31,8 +31,12 @@ universe uS uA uB uα
 namespace PFunctor
 namespace DynSystem
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+the mate equations below rewrite through these constants there.
+`implicit_reducible` (unlike `reducible`) leaves simp validation and instance
+resolution untouched, and needs no `allowUnsafeReducibility`. -/
 attribute [local implicit_reducible] PFunctor.Obj Comonoid.identity Comonoid.target
-  Comonoid.compose
+  Comonoid.compose Lens.mapObj
 
 variable {S : Type uS} {P : PFunctor.{uA, uB}} {α : Type uα}
 
@@ -87,6 +91,9 @@ def mateObj (system : DynSystem S P) (state : S) (label : S → α) : (CofreeP P
   Lens.mapObj (CofreeP.unfoldLens (stateComonoid S) system)
     (⟨state, label⟩ : (selfMonomial S).Obj α)
 
+-- `mateObj_child` rewrites through `mateObj` in the type of a bound direction.
+attribute [local implicit_reducible] mateObj
+
 /-- The unlabeled shape underlying `mateObj` is the existing behavior tree. -/
 @[simp]
 theorem mateObj_shape (system : DynSystem S P) (state : S) (label : S → α) :
@@ -107,22 +114,8 @@ private theorem unfoldDirection_stateComonoid_child (system : DynSystem S P) (st
         (cast (congrArg M.Vertex
           (CofreeP.children_unfoldShape
             (stateComonoid S) system state direction)) next) := by
-  let childEq := CofreeP.children_unfoldShape
-    (stateComonoid S) system state direction
-  let leftVertex := M.Vertex.castEquiv childEq next
-  let rightVertex := cast (congrArg M.Vertex childEq) next
-  have hvertices : leftVertex = rightVertex := eq_of_heq
-    ((M.Vertex.castEquiv_heq childEq next).trans
-      (cast_heq (congrArg M.Vertex childEq) next).symm)
-  calc
-    _ = CofreeP.unfoldDirection (stateComonoid S) system
-        (CofreeP.unfoldRootDirection (stateComonoid S) system state direction)
-        leftVertex := by
-      simpa only [Comonoid.stateComonoid_compose, Comonoid.stateComonoid_target,
-        leftVertex, childEq] using CofreeP.unfoldDirection_child
-          (C := stateComonoid S) system state direction next
-    _ = _ := congrArg (CofreeP.unfoldDirection (stateComonoid S) system
-      (CofreeP.unfoldRootDirection (stateComonoid S) system state direction)) hvertices
+  rw [CofreeP.unfoldDirection.eq_def]
+  rfl
 
 /-- Taking one child of the object-level dynamical mate advances the system
 state by exactly the selected direction, while preserving the state labeling.
@@ -152,8 +145,7 @@ theorem mateObj_child (system : DynSystem S P) (state : S) (label : S → α)
         (CofreeP.unfoldRootDirection
           (stateComonoid S) system state direction)
         (cast (congrArg M.Vertex childEq) leftVertex))
-  exact congrArg label
-    (unfoldDirection_stateComonoid_child system state direction leftVertex)
+  rw [unfoldDirection_stateComonoid_child]
 
 private theorem decodeStep_mateObj (system : DynSystem S P) (state : S) (label : S → α) :
     CofreeP.decodeStep (mateObj system state label) =
@@ -167,9 +159,8 @@ private theorem decodeStep_mateObj (system : DynSystem S P) (state : S) (label :
           (CofreeP.unfoldDirection (stateComonoid S) system state
             (.root (CofreeP.unfoldShape
               (stateComonoid S) system state))) = label state
-      exact congrArg label (by
-        simpa only [Comonoid.stateComonoid_identity] using
-          CofreeP.unfoldDirection_root (C := stateComonoid S) system state)
+      rw [CofreeP.unfoldDirection_root]
+      rfl
     · exact CofreeP.head_unfoldShape
         (stateComonoid S) system state
   apply Sigma.ext hPosition

--- a/PolyFun/PFunctor/Dynamical/DynComputation.lean
+++ b/PolyFun/PFunctor/Dynamical/DynComputation.lean
@@ -179,7 +179,7 @@ private def mapResultLift {γ : Type uγ} (f : β → γ) :
 
 /-- Map the returned value of a computation while preserving its hidden state
 and visible-query interface. -/
-@[reducible]
+@[implicit_reducible]
 def mapResult {γ : Type uγ} (M : DynComputation.{u} p α β) (f : β → γ) :
     DynComputation.{u} p α γ where
   State := M.State
@@ -243,7 +243,7 @@ private def wrapLift {q : PFunctor.{uA₂, uB₂}} (lens : Lens p q) :
 
 /-- Change a returning computation's visible-query interface along a lens while preserving its
 hidden state and return values. -/
-@[reducible]
+@[implicit_reducible]
 def wrap {q : PFunctor.{uA₂, uB₂}} (M : DynComputation.{u} p α β)
     (lens : Lens p q) : DynComputation.{u} q α β where
   State := M.State

--- a/PolyFun/PFunctor/Dynamical/DynComputation/Bounded.lean
+++ b/PolyFun/PFunctor/Dynamical/DynComputation/Bounded.lean
@@ -35,6 +35,10 @@ namespace PFunctor
 
 namespace DynSystem.DynComputation
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+the unrolling equations below rewrite through `seqComp` there.
+`implicit_reducible` (unlike `reducible`) leaves simp validation and instance
+resolution untouched, and needs no `allowUnsafeReducibility`. -/
 attribute [local implicit_reducible] DynComputation.seqComp
 
 variable {p : PFunctor.{uA, uB}} {α : Type uα} {β : Type uβ}
@@ -468,6 +472,7 @@ theorem unroll_seqComp_inr {γ : Type uγ}
           have hcomposite : (M₁.seqComp M₂).view (Sum.inr state₂) =
               Sum.inl result := by
             rw [seqComp_view_inr]
+            simp only [seqComp_State]
             rw [hview]
             rfl
           rw [(M₁.seqComp M₂).unroll_return 0 _ result hcomposite,
@@ -477,6 +482,7 @@ theorem unroll_seqComp_inr {γ : Type uγ}
           have hcomposite : (M₁.seqComp M₂).view (Sum.inr state₂) =
               Sum.inr ⟨position, fun direction => Sum.inr (next direction)⟩ := by
             rw [seqComp_view_inr]
+            simp only [seqComp_State]
             rw [hview]
             rfl
           rw [(M₁.seqComp M₂).unroll_query_zero _ position _ hcomposite,
@@ -487,6 +493,7 @@ theorem unroll_seqComp_inr {γ : Type uγ}
           have hcomposite : (M₁.seqComp M₂).view (Sum.inr state₂) =
               Sum.inl result := by
             rw [seqComp_view_inr]
+            simp only [seqComp_State]
             rw [hview]
             rfl
           rw [(M₁.seqComp M₂).unroll_return (k + 1) _ result hcomposite,
@@ -496,6 +503,7 @@ theorem unroll_seqComp_inr {γ : Type uγ}
           have hcomposite : (M₁.seqComp M₂).view (Sum.inr state₂) =
               Sum.inr ⟨position, fun direction => Sum.inr (next direction)⟩ := by
             rw [seqComp_view_inr]
+            simp only [seqComp_State]
             rw [hview]
             rfl
           rw [(M₁.seqComp M₂).unroll_query_succ k _ position _ hcomposite,
@@ -516,14 +524,19 @@ theorem unroll_seqComp_inl_of_return {γ : Type uγ}
   | inl result =>
       have hcomposite : (M₁.seqComp M₂).view (Sum.inl state₁) =
           Sum.inl result := by
-        simp only [seqComp_view_inl, hview, hview₂, Sum.map_inl]
+        rw [seqComp_view_inl, hview]
+        simp only [seqComp_State]
+        rw [hview₂]
+        rfl
       rw [(M₁.seqComp M₂).unroll_return k _ result hcomposite,
         M₂.unroll_return k _ result hview₂]
   | inr query =>
       rcases query with ⟨position, next⟩
       have hcomposite : (M₁.seqComp M₂).view (Sum.inl state₁) =
           Sum.inr ⟨position, fun direction => Sum.inr (next direction)⟩ := by
-        simp only [seqComp_view_inl, hview, hview₂]
+        rw [seqComp_view_inl, hview]
+        simp only [seqComp_State]
+        rw [hview₂]
         rfl
       cases k with
       | zero =>

--- a/PolyFun/PFunctor/Dynamical/DynComputation/Bounded.lean
+++ b/PolyFun/PFunctor/Dynamical/DynComputation/Bounded.lean
@@ -315,16 +315,12 @@ theorem unroll_eq_map_some_of_resolvesIn {M : DynComputation.{u} p α β} :
       ∃ program : FreeM p β, M.unroll k state = FreeM.map some program
   | 0, state, h => by
       obtain ⟨value, hview⟩ := (M.resolvesIn_zero state).mp h
-      exact ⟨FreeM.pure value, by
-        rw [unroll_return M 0 state value hview, ← FreeM.bind_pure_comp]
-        exact (FreeM.pure_bind value (FreeM.pure ∘ some)).symm⟩
+      exact ⟨FreeM.pure value, by rw [unroll_return M 0 state value hview]; rfl⟩
   | k + 1, state, h => by
       cases hview : M.view state with
       | inl value =>
           exact ⟨FreeM.pure value,
-            by rw [unroll_return M (k + 1) state value hview,
-              ← FreeM.bind_pure_comp]
-               exact (FreeM.pure_bind value (FreeM.pure ∘ some)).symm⟩
+            by rw [unroll_return M (k + 1) state value hview]; rfl⟩
       | inr query =>
           rcases query with ⟨position, next⟩
           have hnext : ∀ direction, M.ResolvesIn k (next direction) :=
@@ -645,8 +641,7 @@ theorem unroll_seqComp_inl_of_resolvesIn {γ : Type uγ}
       simp only [Nat.zero_add]
       rw [unroll_seqComp_inl_of_return M₁ M₂ k₂ state₁ value hview,
         M₁.unroll_return 0 state₁ value hview]
-      symm
-      apply FreeM.pure_bind
+      rfl
   | succ k₁ ih =>
       cases hview : M₁.view state₁ with
       | inl value =>

--- a/PolyFun/PFunctor/Dynamical/DynComputation/Termination.lean
+++ b/PolyFun/PFunctor/Dynamical/DynComputation/Termination.lean
@@ -43,6 +43,10 @@ bound. -/
 def TerminatesFrom (M : DynComputation.{u} p α β) (state : M.State) : Prop :=
   Acc M.QueryChild state
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+the recursion below rewrites through `TerminatesFrom` there.
+`implicit_reducible` (unlike `reducible`) leaves simp validation and instance
+resolution untouched, and needs no `allowUnsafeReducibility`. -/
 attribute [local implicit_reducible] TerminatesFrom
 
 theorem queryChild_of_view (M : DynComputation.{u} p α β)
@@ -53,7 +57,7 @@ theorem queryChild_of_view (M : DynComputation.{u} p α β)
     M.QueryChild (next direction) state :=
   ⟨position, next, direction, hview, rfl⟩
 
-theorem terminatesFrom_return (M : DynComputation.{u} p α β)
+@[simp] theorem terminatesFrom_return (M : DynComputation.{u} p α β)
     (state : M.State) (value : β) (hview : M.view state = Sum.inl value) :
     M.TerminatesFrom state := by
   constructor
@@ -180,13 +184,13 @@ theorem behavior_eq_toResumption_toFreeMFrom
       cases hview : M.view state with
       | inl value =>
           apply Resumption.eq_of_dest_eq
-          with_unfolding_all rw [M.dest_behavior_view, hview,
+          rw [M.dest_behavior_view, hview,
             M.toFreeMFrom_return state _ value hview]
           rfl
       | inr query =>
           rcases query with ⟨position, next⟩
           apply Resumption.eq_of_dest_eq
-          with_unfolding_all rw [M.dest_behavior_view, hview,
+          rw [M.dest_behavior_view, hview,
             M.toFreeMFrom_query state _ position next hview]
           simp only [FreeM.dest_toResumption_liftBind]
           apply congrArg Sum.inr

--- a/PolyFun/PFunctor/Dynamical/Responder/Behavior.lean
+++ b/PolyFun/PFunctor/Dynamical/Responder/Behavior.lean
@@ -1044,7 +1044,9 @@ theorem reindexDisplayedBehavior_comp
         have hCompositeToM' :=
           (Display.M.toM_transport (S := Display.responder S) _ _).symm.trans hCompositeToM
         change (respondDisplayed S composite query precondition).2.toM = _
-        simpa only [Display.Handler.comp_apply, Handler.comp_apply,
+        -- Lean 4.33: `Display.Handler.comp` is only `implicit_reducible`, so
+        -- its unfolding is spelled out for `simp` here.
+        simpa only [Display.Handler.comp, Display.Handler.comp_apply, Handler.comp_apply,
           compositeResult, compositeEvidence, composite, terminalR, terminalD]
           using hCompositeToM'
   · exact ⟨behavior, displayedBehavior, rfl, rfl⟩

--- a/PolyFun/PFunctor/Dynamical/Responder/Behavior.lean
+++ b/PolyFun/PFunctor/Dynamical/Responder/Behavior.lean
@@ -726,6 +726,9 @@ theorem reindexDisplayedBehavior_id
           (Handler.id P) (Display.Handler.id S) current displayed
           query precondition
         have hToM := congrArg IPFunctor.IM.toM hNext
+        -- Lean 4.33: `simp only [Display.M.toM_transport]` no longer fires here
+        -- (simp validation is blind to `implicit_reducible` indices), so the
+        -- transport is peeled off by explicit `.trans` composition instead.
         have hToM' :=
           (Display.M.toM_transport (S := Display.responder S) _ _).symm.trans hToM
         unfold leftChildren
@@ -1022,6 +1025,9 @@ theorem reindexDisplayedBehavior_comp
         have hOuterNext := respondDisplayed_reindexDisplayedBehavior_next S T first dfirst
           (reindexBehavior second current) middle query precondition
         have hOuterToM := congrArg IPFunctor.IM.toM hOuterNext
+        -- Lean 4.33: `simp only [Display.M.toM_transport]` no longer fires here
+        -- (simp validation is blind to `implicit_reducible` indices), so the
+        -- transport is peeled off by explicit `.trans` composition instead.
         have hOuterToM' :=
           (Display.M.toM_transport (S := Display.responder S) _ _).symm.trans hOuterToM
         calc

--- a/PolyFun/PFunctor/Dynamical/Responder/Parallel/Behavior.lean
+++ b/PolyFun/PFunctor/Dynamical/Responder/Parallel/Behavior.lean
@@ -27,6 +27,10 @@ universe uA₁ uA₂ uB uC₁ uD₁ uC₂ uD₂
 namespace PFunctor
 namespace Responder
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+the parallel-behavior equations below rewrite through `parallelSum` there.
+`implicit_reducible` (unlike `reducible`) leaves simp validation and instance
+resolution untouched, and needs no `allowUnsafeReducibility`. -/
 attribute [local implicit_reducible] PFunctor.parallelSum
 
 variable {P : PFunctor.{uA₁, uB}} {Q : PFunctor.{uA₂, uB}}
@@ -55,6 +59,8 @@ theorem sum_behavior
   apply behavior_eq_of_responderMap terminalSum (Responder.sum left right)
     (fun current => (left.behavior current.1, right.behavior current.2)) <;>
     · intro current operation
+      -- Lean 4.33: `parallelSum` is only `implicit_reducible`, so `simp`
+      -- leaves a residual goal that is closed by `rfl` up to defeq.
       cases operation <;> simp [terminalSum] <;> rfl
 
 @[simp]
@@ -67,7 +73,7 @@ theorem sumBehavior_answer_inl
     (Responder.terminal (P := PFunctor.sum P Q)).answer
       ((Responder.sum (Responder.terminal (P := P))
         (Responder.terminal (P := Q))).behavior (left, right)) (.inl a) = _
-  with_unfolding_all rw [terminal_answer_behavior]
+  rw [terminal_answer_behavior]
   rfl
 
 @[simp]
@@ -80,7 +86,7 @@ theorem sumBehavior_answer_inr
     (Responder.terminal (P := PFunctor.sum P Q)).answer
       ((Responder.sum (Responder.terminal (P := P))
         (Responder.terminal (P := Q))).behavior (left, right)) (.inr b) = _
-  with_unfolding_all rw [terminal_answer_behavior]
+  rw [terminal_answer_behavior]
   rfl
 
 @[simp]
@@ -136,6 +142,7 @@ theorem parallel_behavior
     · intro current operation
       cases operation <;> simp [terminalParallel]
 
+@[simp]
 theorem parallelBehavior_answer_left
     (left : PFunctor.M (P ⊸ X.{uA₁, uB})) (right : PFunctor.M (Q ⊸ X.{uA₂, uB})) (a : P.A) :
     (Responder.terminal (P := P ∥ Q)).answer
@@ -147,9 +154,10 @@ theorem parallelBehavior_answer_left
       ((Responder.parallel (Responder.terminal (P := P))
         (Responder.terminal (P := Q))).behavior (left, right))
       (ParallelChoice.left a : (P ∥ Q).A) = _
-  with_unfolding_all rw [terminal_answer_behavior]
+  rw [terminal_answer_behavior]
   rfl
 
+@[simp]
 theorem parallelBehavior_answer_right
     (left : PFunctor.M (P ⊸ X.{uA₁, uB})) (right : PFunctor.M (Q ⊸ X.{uA₂, uB})) (b : Q.A) :
     (Responder.terminal (P := P ∥ Q)).answer
@@ -164,6 +172,7 @@ theorem parallelBehavior_answer_right
   rw [terminal_answer_behavior]
   rfl
 
+@[simp]
 theorem parallelBehavior_answer_both
     (left : PFunctor.M (P ⊸ X.{uA₁, uB})) (right : PFunctor.M (Q ⊸ X.{uA₂, uB}))
     (a : P.A) (b : Q.A) :
@@ -191,7 +200,7 @@ theorem parallelBehavior_child_left
     ((Responder.parallel (Responder.terminal (P := P))
       (Responder.terminal (P := Q))).behavior (left, right)).children
         ⟨(ParallelChoice.left a : (P ∥ Q).A), PUnit.unit⟩ = _
-  with_unfolding_all rw [behavior_child]
+  rw [behavior_child]
   rfl
 
 @[simp]
@@ -205,7 +214,7 @@ theorem parallelBehavior_child_right
     ((Responder.parallel (Responder.terminal (P := P))
       (Responder.terminal (P := Q))).behavior (left, right)).children
         ⟨(ParallelChoice.right b : (P ∥ Q).A), PUnit.unit⟩ = _
-  with_unfolding_all rw [behavior_child]
+  rw [behavior_child]
   rfl
 
 @[simp]
@@ -221,7 +230,7 @@ theorem parallelBehavior_child_both
     ((Responder.parallel (Responder.terminal (P := P))
       (Responder.terminal (P := Q))).behavior (left, right)).children
         ⟨(ParallelChoice.both a b : (P ∥ Q).A), PUnit.unit⟩ = _
-  with_unfolding_all rw [behavior_child]
+  rw [behavior_child]
   rfl
 
 /-! ## Canonical proof-relevant terminal presentations -/

--- a/PolyFun/PFunctor/Dynamical/Responder/Parallel/DisplayedAssociativity.lean
+++ b/PolyFun/PFunctor/Dynamical/Responder/Parallel/DisplayedAssociativity.lean
@@ -356,6 +356,9 @@ theorem mapDisplayedBehavior_parallel_assoc
         ((displayedLeft, displayedMiddle), displayedRight)
     change Display.M.transport _ publicLeftDisplayed = rawLeftDisplayed at h
     exact (Display.M.transport_proof_irrel leftEq _ publicLeftDisplayed).trans h
+  -- Lean 4.33: split from main's single calc; the `Trans` instance for chaining
+  -- compares defeq-only-equal index types too strictly, while term-level `.trans`
+  -- unifies at default transparency.
   have hRawToPublic : Display.M.transport leftEq.symm rawLeftDisplayed =
       publicLeftDisplayed := by
     exact (congrArg (Display.M.transport leftEq.symm) hLeft.symm).trans

--- a/PolyFun/PFunctor/Dynamical/Responder/Parallel/DisplayedCoherence.lean
+++ b/PolyFun/PFunctor/Dynamical/Responder/Parallel/DisplayedCoherence.lean
@@ -819,6 +819,9 @@ theorem mapDisplayedBehavior_parallel_comm
       parallelDisplayedBehavior S T left displayedLeft right displayedRight := by
     exact displayedBehavior_parallel_comm_presented S T
       left displayedLeft right displayedRight
+  -- Lean 4.33: split from main's single calc; the `Trans` instance for chaining
+  -- compares defeq-only-equal index types too strictly, while term-level `.trans`
+  -- unifies at default transparency.
   have hChainToRaw :
       Display.M.transport (presentationEq.trans rawEq) mappedDisplayed =
         Display.M.transport rawEq rawMapped := by
@@ -937,6 +940,9 @@ theorem mapDisplayedBehavior_parallel_zero_right
       Display.M.transport terminalEq publicDisplayed = rawDisplayed := by
     exact displayedBehavior_parallel_zero_right_presentation.{uA₁, uA₂,
       uB, uC₁, uD₁, uC₂, uD₂, 0, 0} S left displayedLeft
+  -- Lean 4.33: split from main's single calc; the `Trans` instance for chaining
+  -- compares defeq-only-equal index types too strictly, while term-level `.trans`
+  -- unifies at default transparency.
   have hRawToPublic :
       Display.M.transport terminalEq.symm rawDisplayed = publicDisplayed := by
     exact (congrArg (Display.M.transport terminalEq.symm) hTerminal.symm).trans
@@ -1073,6 +1079,9 @@ theorem mapDisplayedBehavior_parallel_zero_left
       Display.M.transport terminalEq publicDisplayed = rawDisplayed := by
     exact displayedBehavior_parallel_zero_left_presentation.{uA₁, uA₂,
       uB, uC₁, uD₁, uC₂, uD₂, 0, 0} S right displayedRight
+  -- Lean 4.33: split from main's single calc; the `Trans` instance for chaining
+  -- compares defeq-only-equal index types too strictly, while term-level `.trans`
+  -- unifies at default transparency.
   have hRawToPublic :
       Display.M.transport terminalEq.symm rawDisplayed = publicDisplayed := by
     exact (congrArg (Display.M.transport terminalEq.symm) hTerminal.symm).trans

--- a/PolyFun/PFunctor/Dynamical/Simulation.lean
+++ b/PolyFun/PFunctor/Dynamical/Simulation.lean
@@ -101,11 +101,9 @@ theorem isSimulation_graph_coalgHom {S₂' : Type u₁}
     letI := D₂.coalg
     ∀ f : @Coalg.Hom p.Obj (PFunctor.instFunctorObj p) S₁ S₂' D₁.coalg D₂.coalg,
       IsSimulation D₁ D₂ (fun st₁ st₂ => f st₁ = st₂) := by
-  let functor : Functor p.Obj := PFunctor.instFunctorObj p
-  exact fun f =>
-    let toFun := @Coalg.Hom.toFun p.Obj functor S₁ S₂' D₁.coalg D₂.coalg f
-    let comm := @Coalg.Hom.comm p.Obj functor S₁ S₂' D₁.coalg D₂.coalg f
-    isSimulation_graph toFun fun st => (congrFun comm st).symm
+  let _ := D₁.coalg
+  let _ := D₂.coalg
+  exact fun f => isSimulation_graph f fun st => (congrFun f.comm st).symm
 
 /-- Coalgebra morphisms preserve behaviour trees. -/
 theorem behavior_coalgHom {S₂' : Type u₁}
@@ -114,12 +112,10 @@ theorem behavior_coalgHom {S₂' : Type u₁}
     letI := D₂.coalg
     ∀ f : @Coalg.Hom p.Obj (PFunctor.instFunctorObj p) S₁ S₂' D₁.coalg D₂.coalg,
       ∀ st : S₁, D₂.behavior (f st) = D₁.behavior st := by
-  let functor : Functor p.Obj := PFunctor.instFunctorObj p
+  let _ := D₁.coalg
+  let _ := D₂.coalg
   exact fun f st =>
-    let toFun := @Coalg.Hom.toFun p.Obj functor S₁ S₂' D₁.coalg D₂.coalg f
-    let comm := @Coalg.Hom.comm p.Obj functor S₁ S₂' D₁.coalg D₂.coalg f
-    (behavior_eq_of_isSimulation
-      (isSimulation_graph toFun fun state => (congrFun comm state).symm) rfl).symm
+    (behavior_eq_of_isSimulation (isSimulation_graph_coalgHom f) rfl).symm
 
 end DynSystem
 

--- a/PolyFun/PFunctor/Dynamical/Simulation.lean
+++ b/PolyFun/PFunctor/Dynamical/Simulation.lean
@@ -99,7 +99,7 @@ theorem isSimulation_graph_coalgHom {S₂' : Type u₁}
     {D₁ : DynSystem S₁ p} {D₂ : DynSystem S₂' p} :
     letI := D₁.coalg
     letI := D₂.coalg
-    ∀ f : @Coalg.Hom p.Obj (PFunctor.instFunctorObj p) S₁ S₂' D₁.coalg D₂.coalg,
+    ∀ f : Coalg.Hom p.Obj S₁ S₂',
       IsSimulation D₁ D₂ (fun st₁ st₂ => f st₁ = st₂) := by
   let _ := D₁.coalg
   let _ := D₂.coalg
@@ -110,7 +110,7 @@ theorem behavior_coalgHom {S₂' : Type u₁}
     {D₁ : DynSystem S₁ p} {D₂ : DynSystem S₂' p} :
     letI := D₁.coalg
     letI := D₂.coalg
-    ∀ f : @Coalg.Hom p.Obj (PFunctor.instFunctorObj p) S₁ S₂' D₁.coalg D₂.coalg,
+    ∀ f : Coalg.Hom p.Obj S₁ S₂',
       ∀ st : S₁, D₂.behavior (f st) = D₁.behavior st := by
   let _ := D₁.coalg
   let _ := D₂.coalg

--- a/PolyFun/PFunctor/Dynamical/Trajectory.lean
+++ b/PolyFun/PFunctor/Dynamical/Trajectory.lean
@@ -63,11 +63,7 @@ are the exposed position, and the children are the successor trajectories. -/
 theorem dest_trajectory (s : DynSystem S p) (st : S) :
     M.dest (trajectory s st)
       = ⟨(s.expose st, s.expose st), fun d => trajectory s (s.update st d)⟩ := by
-  let g : S → constProd p p.A S :=
-    fun state => ⟨(s.expose state, s.expose state), fun d => s.update state d⟩
-  change M.dest (M.corec g st) =
-    ⟨(s.expose st, s.expose st), fun d => M.corec g (s.update st d)⟩
-  rw [M.dest_corec_apply]
+  simp only [trajectory, M.dest_corec_apply]
 
 @[simp] theorem head_trajectory (s : DynSystem S p) (st : S) :
     (trajectory s st).head = s.expose st := by
@@ -130,7 +126,7 @@ theorem trajectory_eq_selfLabel_behavior (s : DynSystem S p) (st : S) :
     s.trajectory st = M.selfLabel (s.behavior st) := by
   refine congrFun (Eq.symm (M.corec_unique _ (fun st => M.selfLabel (s.behavior st)) ?_)) st
   intro st
-  simp only [M.selfLabel]
+  simp only [M.selfLabel, M.dest_corec_apply]
   rfl
 
 /-! ## Closed-system spine

--- a/PolyFun/PFunctor/Dynamical/Trajectory.lean
+++ b/PolyFun/PFunctor/Dynamical/Trajectory.lean
@@ -36,6 +36,11 @@ universe u u₁ u₂ u₃ uA uB w
 
 namespace PFunctor
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+the trajectory unfolding equations below rewrite corecursive `constProd`
+objects there, so `P.Obj` must unfold to its sigma form in those checks. -/
+attribute [local implicit_reducible] PFunctor.Obj
+
 /-- The unique successor of a node in a unary (`X`-)cofree tree: read off the single
 child indexed by the lone direction `PUnit.unit`. -/
 def CofreeC.next {α : Type w} (t : CofreeC X.{uA, uB} α) : CofreeC X.{uA, uB} α :=

--- a/PolyFun/PFunctor/Free/Basic.lean
+++ b/PolyFun/PFunctor/Free/Basic.lean
@@ -109,7 +109,7 @@ polynomial `Q` is the concrete/runtime interface. At each `P`-node, the lens
 chooses a `Q`-position by `toFunA`; when runtime supplies a `Q`-direction,
 `toFunB` maps it back to the corresponding `P`-direction selecting the
 control continuation. -/
-@[reducible]
+@[implicit_reducible]
 protected def mapLens (l : Lens P Q) : FreeM P α → FreeM Q α
   | .pure x => .pure x
   | .liftBind a rest => .liftBind (l.toFunA a) fun d =>

--- a/PolyFun/PFunctor/Free/Cursor.lean
+++ b/PolyFun/PFunctor/Free/Cursor.lean
@@ -28,6 +28,13 @@ universe uA uB v
 
 namespace PFunctor.FreeM
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+the trace calc steps below move between the `TraceList` carrier (reducibly
+`FreeMonoid (Idx _)`) and its `List` normal form there. `implicit_reducible`
+(unlike `reducible`) stays invisible to simp and instance search, and needs
+no `allowUnsafeReducibility`. -/
+attribute [local implicit_reducible] FreeMonoid PFunctor.Idx
+
 variable {P : PFunctor.{uA, uB}} {α : Type v}
 
 namespace Cursor

--- a/PolyFun/PFunctor/Free/Cursor.lean
+++ b/PolyFun/PFunctor/Free/Cursor.lean
@@ -22,18 +22,16 @@ attach protocol-specific meaning to the visited prefix.
 
 @[expose] public section
 
-attribute [local implicit_reducible] PFunctor.Obj FreeMonoid
-
-universe uA uB v
-
-namespace PFunctor.FreeM
-
 /- Lean 4.33 compares assigned metavariable types at implicit transparency;
 the trace calc steps below move between the `TraceList` carrier (reducibly
 `FreeMonoid (Idx _)`) and its `List` normal form there. `implicit_reducible`
 (unlike `reducible`) stays invisible to simp and instance search, and needs
 no `allowUnsafeReducibility`. -/
-attribute [local implicit_reducible] FreeMonoid PFunctor.Idx
+attribute [local implicit_reducible] PFunctor.Obj FreeMonoid PFunctor.Idx
+
+universe uA uB v
+
+namespace PFunctor.FreeM
 
 variable {P : PFunctor.{uA, uB}} {α : Type v}
 

--- a/PolyFun/PFunctor/Free/Cursor/Fork.lean
+++ b/PolyFun/PFunctor/Free/Cursor/Fork.lean
@@ -27,6 +27,11 @@ attribute [local implicit_reducible] PFunctor.Obj
 
 open PFunctor.TraceList
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+rewriting `locateAt?` goals whose `Path` indices sit over `FreeM.liftBind`
+trees needs `FreeM.bind` and `FreeM.map` to unfold there. -/
+attribute [local implicit_reducible] PFunctor.FreeM.bind PFunctor.FreeM.map
+
 variable {P : PFunctor.{uA, uB}} {α : Type v}
 
 /-! ## Locating an occurrence on an existing path -/

--- a/PolyFun/PFunctor/Free/Cursor/Fork.lean
+++ b/PolyFun/PFunctor/Free/Cursor/Fork.lean
@@ -29,8 +29,11 @@ open PFunctor.TraceList
 
 /- Lean 4.33 compares assigned metavariable types at implicit transparency;
 rewriting `locateAt?` goals whose `Path` indices sit over `FreeM.liftBind`
-trees needs `FreeM.bind` and `FreeM.map` to unfold there. -/
+trees needs `FreeM.bind` and `FreeM.map` to unfold there, and the
+occurrence-counting goals rewrite `List.countP` over `Idx`-typed events
+inside the `TraceList` carrier (reducibly `FreeMonoid (Idx _)`). -/
 attribute [local implicit_reducible] PFunctor.FreeM.bind PFunctor.FreeM.map
+  FreeMonoid PFunctor.Idx
 
 variable {P : PFunctor.{uA, uB}} {α : Type v}
 

--- a/PolyFun/PFunctor/Free/Cursor/Occurrence.lean
+++ b/PolyFun/PFunctor/Free/Cursor/Occurrence.lean
@@ -62,7 +62,7 @@ def toSpine : {program : FreeM P α} → {n : Nat} → (occ : Occurrence target 
   | _, _, .stepOther _ answer tail => .down answer tail.toSpine
 
 /-- Forget occurrence counting while retaining its typed structural prefix. -/
-@[reducible]
+@[implicit_reducible]
 def toCursor (occ : Occurrence target program n) : Cursor program :=
   ⟨FreeM.liftBind target occ.resume, occ.toSpine⟩
 
@@ -103,6 +103,9 @@ def plug (occ : Occurrence target program n) (answer : P.B target)
   | stepSame answer tail ih =>
       change occurrences target
         ((⟨target, answer⟩ : P.Idx) :: tail.before) = _
+      -- Lean 4.33: unfolding `occurrences` now exposes the `countP` `if`
+      -- directly, so the cons step is discharged by `if_pos` instead of
+      -- `List.countP_cons_of_pos`.
       simp only [occurrences, ih]
       rw [if_pos trivial]
   | stepOther hne answer tail ih =>

--- a/PolyFun/PFunctor/Free/Cursor/Occurrence.lean
+++ b/PolyFun/PFunctor/Free/Cursor/Occurrence.lean
@@ -27,6 +27,13 @@ namespace PFunctor.FreeM.Cursor
 
 open PFunctor.TraceList
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+the occurrence-counting proofs below rewrite `List.countP` over `Idx`-typed
+events inside the `TraceList` carrier (reducibly `FreeMonoid (Idx _)`) there.
+`implicit_reducible` (unlike `reducible`) stays invisible to simp and
+instance search, and needs no `allowUnsafeReducibility`. -/
+attribute [local implicit_reducible] FreeMonoid PFunctor.Idx
+
 variable {P : PFunctor.{uA, uB}} {α : Type v}
 
 /-! ## Occurrence contexts and completions -/
@@ -103,11 +110,9 @@ def plug (occ : Occurrence target program n) (answer : P.B target)
   | stepSame answer tail ih =>
       change occurrences target
         ((⟨target, answer⟩ : P.Idx) :: tail.before) = _
-      -- Lean 4.33: unfolding `occurrences` now exposes the `countP` `if`
-      -- directly, so the cons step is discharged by `if_pos` instead of
-      -- `List.countP_cons_of_pos`.
-      simp only [occurrences, ih]
-      rw [if_pos trivial]
+      rw [occurrences, List.countP_cons_of_pos (by simp)]
+      change occurrences target tail.before + 1 = _
+      rw [ih]
   | stepOther hne answer tail ih =>
       change occurrences target
         ((⟨_, answer⟩ : P.Idx) :: tail.before) = _

--- a/PolyFun/PFunctor/Free/Displayed.lean
+++ b/PolyFun/PFunctor/Free/Displayed.lean
@@ -68,7 +68,7 @@ Evaluate a displayed algebra over a concrete `FreeM` tree.
 This generates the displayed fiber at every tree by recursion on the free
 polynomial structure.
 -/
-@[reducible]
+@[implicit_reducible]
 def Displayed (D : Displayed.Algebra P α) :
     FreeM P α → Sort w
   | .pure x => D.leaf x
@@ -114,7 +114,7 @@ Evaluate a dependent displayed algebra over concrete displayed data.
 This is the dependent analogue of `Displayed`: the base displayed data chooses
 which second-layer fiber is available at every node.
 -/
-@[reducible]
+@[implicit_reducible]
 def Over (E : Over.Algebra D) :
     (s : FreeM P α) → Displayed D s → Sort w₂
   | .pure x, d => E.leaf x d
@@ -465,6 +465,7 @@ variable
     {S' : _root_.PFunctor.FreeM.Displayed.Over.Algebra.{uA, uB, v, w, w₆} D}
 
 /-- The recursive function underlying `FiberLocalMap.toHom`. -/
+@[implicit_reducible]
 def toHomFun (η : FiberLocalMap R' S') :
     (s : FreeM P α) →
     (d : Displayed D s) →
@@ -478,7 +479,7 @@ def toHomFun (η : FiberLocalMap R' S') :
         (fun b d => toHomFun η (rest b) d) d r
 
 /-- Interpret a constructor-local fiber map as a displayed-over morphism. -/
-@[reducible]
+@[implicit_reducible]
 def toHom (η : FiberLocalMap R' S') :
     Displayed.Over.Hom (Displayed.Hom.id (D := D)) R' S' where
   toFun := toHomFun η

--- a/PolyFun/PFunctor/Free/Displayed/Append.lean
+++ b/PolyFun/PFunctor/Free/Displayed/Append.lean
@@ -31,8 +31,13 @@ namespace Decoration
 
 variable {P : PFunctor.{u, v}} {α : Type w} {β : Type w₄}
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+rewriting appended decorations over `FreeM.liftBind` trees needs `FreeM.bind`
+to unfold there so that `(lift a).bind rest` and `liftBind a rest` agree. -/
+attribute [local implicit_reducible] PFunctor.FreeM.bind
+
 /-- Concatenate per-node metadata along `FreeM.append`. -/
-@[reducible]
+@[implicit_reducible]
 def append {Γ : P.A → Type w₂}
     {s₁ : FreeM P α} {s₂ : Path s₁ → FreeM P β}
     (d₁ : Decoration Γ s₁)
@@ -51,7 +56,7 @@ theorem append_pure {Γ : P.A → Type w₂} (x : α)
     append d₁ d₂ = d₂ ⟨⟩ :=
   rfl
 
-@[freeM_unfold]
+@[simp, freeM_unfold]
 theorem append_liftBind {Γ : P.A → Type w₂} (a : P.A) (rest : P.B a → FreeM P α)
     (d₁ : Decoration Γ (FreeM.liftBind a rest))
     (s₂ : Path (FreeM.liftBind a rest) → FreeM P β)
@@ -64,7 +69,7 @@ namespace Over
 
 /-- Concatenate dependent over-decorations along `FreeM.append`, over an
 appended base decoration. -/
-@[reducible]
+@[implicit_reducible]
 def append {Γ : P.A → Type w₂} {F : (a : P.A) → Γ a → Type w₃}
     {s₁ : FreeM P α} {s₂ : Path s₁ → FreeM P β}
     {d₁ : Decoration Γ s₁}
@@ -90,7 +95,7 @@ theorem append_pure {Γ : P.A → Type w₂} {F : (a : P.A) → Γ a → Type w�
       r₁ r₂ = r₂ ⟨⟩ :=
   rfl
 
-@[freeM_unfold]
+@[simp, freeM_unfold]
 theorem append_liftBind {Γ : P.A → Type w₂} {F : (a : P.A) → Γ a → Type w₃}
     (a : P.A) (rest : P.B a → FreeM P α)
     (d₁ : Decoration Γ (FreeM.liftBind a rest))
@@ -119,6 +124,9 @@ theorem map_append {Γ : P.A → Type w₂}
         (fun path₁ => Decoration.Over.map η (s₂ path₁) (d₂ path₁) (r₂ path₁))
   | .pure _, _, _, _, _, _ => rfl
   | .liftBind a rest, s₂, ⟨γ, dRest⟩, d₂, ⟨fd, rRest⟩, r₂ => by
+      -- Lean 4.33: the `toHom_liftBind` rewrite no longer applies here (its
+      -- metavariable assignments fail the implicit-transparency type check),
+      -- so the node layer is exposed by `change` instead.
       change
         (η a γ fd, fun b => Decoration.Over.map η
           (FreeM.append (rest b) (fun path => s₂ ⟨b, path⟩))
@@ -146,6 +154,9 @@ theorem map_append {Γ : P.A → Type w₂} {Δ : P.A → Type w₃}
         (fun path₁ => Decoration.map f (s₂ path₁) (d₂ path₁))
   | .pure _, _, _, _ => rfl
   | .liftBind a rest, s₂, ⟨γ, dRest⟩, d₂ => by
+      -- Lean 4.33: the `toHom_liftBind` rewrite no longer applies here (its
+      -- metavariable assignments fail the implicit-transparency type check),
+      -- so the node layer is exposed by `change` instead.
       change
         (f a γ, fun b => Decoration.map f
           (FreeM.append (rest b) (fun path => s₂ ⟨b, path⟩))

--- a/PolyFun/PFunctor/Free/Displayed/Decoration.lean
+++ b/PolyFun/PFunctor/Free/Displayed/Decoration.lean
@@ -51,8 +51,14 @@ namespace Displayed
 
 variable {P : PFunctor.{u, v}} {α : Type w}
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+rewriting nested `map` applications over `FreeM.liftBind` trees needs
+`FreeM.bind` to unfold there so that `(lift a).bind rest` and
+`liftBind a rest` agree. -/
+attribute [local implicit_reducible] PFunctor.FreeM.bind
+
 /-- Displayed algebra for node-local metadata over a polynomial tree. -/
-@[reducible]
+@[implicit_reducible]
 def Decoration.algebra (Γ : P.A → Type w₂) :
     Displayed.Algebra P α where
   leaf := fun _ => PUnit.{max v w₂ + 1}
@@ -73,7 +79,7 @@ Dependent displayed algebra over a polynomial decoration.
 At a node with base metadata `γ : Γ a`, the over-layer stores data in
 `F a γ` and recursively stores over-data over each decorated child.
 -/
-@[reducible]
+@[implicit_reducible]
 def Decoration.Over.algebra (Γ : P.A → Type w₂) (F : (a : P.A) → Γ a → Type w₃) :
     Over.Algebra (Decoration.algebra (P := P) (α := α) Γ) where
   leaf := fun _ _ => PUnit.{max v w₃ + 1}
@@ -146,7 +152,7 @@ theorem map_id {Γ : P.A → Type w₂} :
     map (fun _ γ => γ) s d = d
   | .pure _, ⟨⟩ => rfl
   | .liftBind _ rest, ⟨γ, dRest⟩ => by
-      change (γ, fun b => map (fun _ γ => γ) (rest b) (dRest b)) = (γ, dRest)
+      simp only [FreeM.liftBind_eq, map_liftBind]
       congr 1
       funext b
       exact map_id (rest b) (dRest b)
@@ -157,8 +163,7 @@ theorem map_comp {Γ : P.A → Type w₂} {Δ : P.A → Type w₃} {Λ : P.A →
     map g s (map f s d) = map (fun a => g a ∘ f a) s d
   | .pure _, ⟨⟩ => rfl
   | .liftBind _ rest, ⟨γ, dRest⟩ => by
-      change (g _ (f _ γ), fun b => map g (rest b) (map f (rest b) (dRest b))) =
-        ((g _ ∘ f _) γ, fun b => map (fun a => g a ∘ f a) (rest b) (dRest b))
+      simp only [FreeM.liftBind_eq, map_liftBind]
       congr 1
       funext b
       exact map_comp g f (rest b) (dRest b)
@@ -193,8 +198,8 @@ theorem map_id {Γ : P.A → Type w₂} {F : (a : P.A) → Γ a → Type w₃} :
     map (fun _ _ x => x) s d r = r
   | .pure _, ⟨⟩, ⟨⟩ => rfl
   | .liftBind _ rest, ⟨γ, dRest⟩, ⟨fd, rRest⟩ => by
-      change (fd, fun b => map (fun _ _ x => x) (rest b) (dRest b) (rRest b)) =
-        (fd, rRest)
+      simp only [FreeM.liftBind_eq, map, fiberLocalMap,
+        Displayed.Over.FiberLocalMap.toHom_liftBind]
       congr 1
       funext b
       exact map_id (rest b) (dRest b) (rRest b)
@@ -210,10 +215,8 @@ theorem map_comp {Γ : P.A → Type w₂}
       map (fun a γ => g a γ ∘ f a γ) s d r
   | .pure _, ⟨⟩, ⟨⟩ => rfl
   | .liftBind _ rest, ⟨γ, dRest⟩, ⟨fd, rRest⟩ => by
-      change (g _ _ (f _ _ fd), fun b =>
-          map g (rest b) (dRest b) (map f (rest b) (dRest b) (rRest b))) =
-        ((g _ _ ∘ f _ _) fd, fun b =>
-          map (fun a γ => g a γ ∘ f a γ) (rest b) (dRest b) (rRest b))
+      simp only [FreeM.liftBind_eq, map, fiberLocalMap,
+        Displayed.Over.FiberLocalMap.toHom_liftBind]
       congr 1
       funext b
       exact map_comp g f (rest b) (dRest b) (rRest b)
@@ -254,7 +257,8 @@ theorem mapBase_id {Γ : P.A → Type w₂} {A : (a : P.A) → Γ a → Type w�
     HEq (mapBase (fun _ γ => γ) (fun _ _ x => x) s d r) r
   | .pure _, ⟨⟩, ⟨⟩ => HEq.rfl
   | .liftBind _ rest, ⟨γ, dRest⟩, ⟨a, rRest⟩ => by
-      simp only [mapBase, baseLocalMap]
+      simp only [FreeM.liftBind_eq, mapBase, baseLocalMap,
+        Displayed.Over.LocalMap.toHom_liftBind]
       refine Prod.mk_heq ?_
       refine Function.hfunext rfl ?_
       intro b y hby
@@ -278,7 +282,8 @@ theorem mapBase_comp {Γ : P.A → Type w₂} {Δ : P.A → Type w₃} {Λ : P.A
         (fun a γ => gOver a (f a γ) ∘ fOver a γ) s d r)
   | .pure _, ⟨⟩, ⟨⟩ => HEq.rfl
   | .liftBind _ rest, ⟨γ, dRest⟩, ⟨a, rRest⟩ => by
-      simp only [mapBase, baseLocalMap]
+      simp only [FreeM.liftBind_eq, mapBase, baseLocalMap,
+        Displayed.Over.LocalMap.toHom_liftBind]
       refine Prod.mk_heq ?_
       refine Function.hfunext rfl ?_
       intro b y hby

--- a/PolyFun/PFunctor/Free/Path.lean
+++ b/PolyFun/PFunctor/Free/Path.lean
@@ -61,12 +61,19 @@ namespace FreeM
 
 variable {P : PFunctor.{uA, uB}} {α : Type v}
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+rewriting path-indexed goals over `FreeM.liftBind` trees needs `FreeM.bind`
+to unfold there so that `(lift a).bind rest` and `liftBind a rest` agree;
+`projectPathAlong` must likewise unfold on `liftBind` scrutinees when
+runtime-path indices are compared. -/
+attribute [local implicit_reducible] PFunctor.FreeM.bind
+
 /-! ## Canonical paths -/
 
 variable {Q : PFunctor.{uA₂, uB₂}}
 
 /-- Displayed algebra for canonical root-to-leaf paths. -/
-@[reducible]
+@[implicit_reducible]
 def Path.algebra (P : PFunctor.{uA, uB}) (α : Type v) :
     Displayed.Algebra.{uA, uB, v, uB+1} P α where
   leaf := fun _ => PUnit.{uB+1}
@@ -119,7 +126,7 @@ end Path
 This is the displayed family over the source control tree whose node directions
 come from the runtime polynomial `Q`. A runtime direction
 `d : Q.B (l.toFunA a)` selects the source branch `l.toFunB a d`. -/
-@[reducible]
+@[implicit_reducible]
 def PathAlong.algebra (l : Lens P Q) :
     Displayed.Algebra.{uA, uB, v, uB₂+1} P α where
   leaf := fun _ => PUnit.{uB₂+1}
@@ -389,7 +396,7 @@ theorem Path.pullMap_lift_bind {β : Type t} (f : α → β) (a : P.A)
   rfl
 
 /-- Dependent sequential composition for `FreeM` trees using canonical paths. -/
-@[reducible]
+@[implicit_reducible]
 def append {β : Type t} :
     (s₁ : FreeM P α) →
     (Path s₁ → FreeM P β) →
@@ -863,6 +870,13 @@ def split {β : Type t} (l : Lens P Q) :
           path
       ⟨⟨d, splitRest.1⟩, splitRest.2⟩
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+relating source and runtime paths across `split`/`append` needs
+`projectPathAlong` (and the `LocalMap.toHom` machinery it elaborates to)
+to unfold there. -/
+attribute [local implicit_reducible] Displayed.LocalMap.toHom
+  Displayed.LocalMap.toHomFun projectPathAlongLocalMap projectPathAlong
+
 /-- `liftAppend` on an appended runtime path reduces to the original
 two-argument family. -/
 @[simp]
@@ -891,10 +905,7 @@ theorem split_append {β : Type t} (l : Lens P Q) :
   | .pure _, _, ⟨⟩, _ => rfl
   | .liftBind a rest, s₂, ⟨d, path₁⟩, path₂ => by
       simp only [append, split]
-      have hsplit := split_append l (rest (l.toFunB a d))
-        (fun path => s₂ (show Path (FreeM.liftBind a rest) from
-          ⟨l.toFunB a d, path⟩)) path₁ path₂
-      rw [hsplit]
+      rw [split_append]
 
 /-- Appending the components produced by `split` recovers the original runtime path. -/
 @[simp]

--- a/PolyFun/PFunctor/Free/Polynomial.lean
+++ b/PolyFun/PFunctor/Free/Polynomial.lean
@@ -236,7 +236,7 @@ def objEquiv : (FreeP P).Obj α ≃ FreeM P α where
 
 /-- Relabel the payload stored at every path of a `FreeP` object without
 changing its tree shape. -/
-@[reducible]
+@[implicit_reducible]
 def relabel {β : Type w} (f : α → β) (x : (FreeP P).Obj α) :
     (FreeP P).Obj β :=
   ⟨x.1, f ∘ x.2⟩
@@ -252,7 +252,7 @@ theorem decode_relabel {β : Type w} (f : α → β)
       cases value
       rfl
   | liftBind a rest ih =>
-      simp only [decode, decodeAt, Function.comp_apply, FreeM.map]
+      simp only [decode, decodeAt, relabel, Function.comp_apply, FreeM.map]
       apply congrArg (FreeM.liftBind a)
       funext direction
       exact ih direction

--- a/PolyFun/PFunctor/Handler/Free.lean
+++ b/PolyFun/PFunctor/Handler/Free.lean
@@ -25,7 +25,7 @@ namespace PFunctor
 namespace Handler
 
 /-- The identity free handler for a polynomial interface. -/
-@[reducible]
+@[implicit_reducible]
 def id (P : PFunctor.{uA, u}) : Handler (FreeM P) P :=
   fun a => FreeM.lift a
 
@@ -51,7 +51,7 @@ def ofLens {P : PFunctor.{uA, u}} {Q : PFunctor.{uA', u'}}
 `second.comp first` first interprets by `first`, then by `second`. The source
 and intermediate direction universes agree because `FreeM.liftM` requires
 them to; the final target direction universe remains independent. -/
-@[reducible]
+@[implicit_reducible]
 def comp {P : PFunctor.{uA, u}} {Q : PFunctor.{uA', u}}
     {R : PFunctor.{uA'', u'}}
     (second : Handler (FreeM R) Q) (first : Handler (FreeM Q) P) :

--- a/PolyFun/PFunctor/InternalHom.lean
+++ b/PolyFun/PFunctor/InternalHom.lean
@@ -124,6 +124,11 @@ add). The target is therefore the categorical product `*`, not the tensor `⊗`:
 the tensor combines directions multiplicatively and does not match the
 coproduct-shaped fibers here. -/
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+the coproduct-splitting equations below rewrite lenses stored as `ihom`
+positions, so `ihom` must unfold there for the rewrites to type-check. -/
+attribute [local implicit_reducible] ihom
+
 /-- The positions of `[q₁ + q₂, r]` split as a product: a lens `q₁ + q₂ ⇆ r` is
 exactly a pair of lenses `(q₁ ⇆ r, q₂ ⇆ r)`, by the universal property of the
 coproduct. This is the position component of `ihomSum`, and equally identifies
@@ -136,7 +141,7 @@ def ihomSumAEquiv (q₁ : PFunctor.{qA₁, qB}) (q₂ : PFunctor.{qA₂, qB})
   left_inv f := Lens.comp_inl_inr f
   right_inv p := by
     obtain ⟨a, b⟩ := p
-    exact congrArg₂ Prod.mk (Lens.sumPair_comp_inl a b) (Lens.sumPair_comp_inr a b)
+    simp only [Lens.sumPair_comp_inl, Lens.sumPair_comp_inr]
 
 /-- The position bijection together with the fiber splitting, packaged as a
 `PFunctor.Equiv`: over a lens `f : q₁ + q₂ ⇆ r` the sigma of `r`-directions over

--- a/PolyFun/PFunctor/Lens/Basic.lean
+++ b/PolyFun/PFunctor/Lens/Basic.lean
@@ -45,7 +45,7 @@ theorem ext {P : PFunctor.{uA₁, uB₁}} {Q : PFunctor.{uA₂, uB₂}} (l₁ l�
   simpa using funext h₂
 
 /-- The identity lens -/
-@[reducible]
+@[implicit_reducible]
 protected def id (P : PFunctor.{uA, uB}) : Lens P P where
   toFunA := id
   toFunB := fun _ => id
@@ -299,7 +299,7 @@ def compMap {P : PFunctor.{uA₁, uB₁}} {Q : PFunctor.{uA₂, uB₂}} {R : PFu
       ⟨pb, qc⟩)
 
 /-- Apply lenses to both sides of a tensor / parallel product: `l₁ ⊗ₗ l₂ : (P ⊗ Q ⇆ R ⊗ W)` -/
-@[reducible]
+@[implicit_reducible]
 def tensorMap {P : PFunctor.{uA₁, uB₁}} {Q : PFunctor.{uA₂, uB₂}} {R : PFunctor.{uA₃, uB₃}}
     {W : PFunctor.{uA₄, uB₄}} (l₁ : Lens P R) (l₂ : Lens Q W) :
     Lens.{max uA₁ uA₂, max uB₁ uB₂, max uA₃ uA₄, max uB₃ uB₄} (P ⊗ Q) (R ⊗ W) :=

--- a/PolyFun/PFunctor/Lens/Basic.lean
+++ b/PolyFun/PFunctor/Lens/Basic.lean
@@ -44,6 +44,20 @@ theorem ext {P : PFunctor.{uA₁, uB₁}} {Q : PFunctor.{uA₂, uB₂}} (l₁ l�
   simp_all only [mk.injEq, heq_eq_eq, true_and]
   simpa using funext h₂
 
+/-- Heterogeneous extensionality for lenses: equal position maps and
+heterogeneously equal direction maps identify two lenses. Useful when the
+direction families are equal only after rewriting along the position map. -/
+theorem ext_heq {P : PFunctor.{uA₁, uB₁}} {Q : PFunctor.{uA₂, uB₂}} (l₁ l₂ : Lens P Q)
+    (hA : l₁.toFunA = l₂.toFunA) (hB : l₁.toFunB ≍ l₂.toFunB) : l₁ = l₂ := by
+  cases l₁ with
+  | mk a₁ b₁ =>
+    cases l₂ with
+    | mk a₂ b₂ =>
+      dsimp only [Lens.toFunA, Lens.toFunB] at hA hB
+      cases hA
+      cases eq_of_heq hB
+      rfl
+
 /-- The identity lens -/
 @[implicit_reducible]
 protected def id (P : PFunctor.{uA, uB}) : Lens P P where

--- a/PolyFun/PFunctor/Lens/Distributivity.lean
+++ b/PolyFun/PFunctor/Lens/Distributivity.lean
@@ -83,6 +83,8 @@ def scalarCompDistrib {A : Type uA} {p : PFunctor.{uA₁, uB₁}} {q : PFunctor.
         | inr pb => rfl
       right_inv := fun _ => rfl }
   equivB := fun x =>
+    -- Lean 4.33: instance search no longer reduces `(C A).B _` to `PEmpty`,
+    -- so the emptiness of the constant-summand sigma is provided explicitly.
     letI : IsEmpty ((i : (C A).B x.1.1) × q.B (x.2 (Sum.inl i))) :=
       ⟨fun y => y.1.elim⟩
     (_root_.Equiv.sumSigmaDistrib (fun b => q.B (x.2 b))).trans

--- a/PolyFun/PFunctor/M.lean
+++ b/PolyFun/PFunctor/M.lean
@@ -45,7 +45,7 @@ variable {P : PFunctor.{uA, uB}} {α : Type v}
 theorem eq_of_dest_eq {u v : M P} (h : M.dest u = M.dest v) : u = v := by
   rw [← M.mk_dest u, ← M.mk_dest v, h]
 
-theorem dest_inj {u v : M P} : M.dest u = M.dest v ↔ u = v :=
+@[simp] theorem dest_inj {u v : M P} : M.dest u = M.dest v ↔ u = v :=
   ⟨eq_of_dest_eq, fun h => h ▸ rfl⟩
 
 /-! ### Corec helpers -/

--- a/PolyFun/PFunctor/M/Vertex.lean
+++ b/PolyFun/PFunctor/M/Vertex.lean
@@ -285,16 +285,20 @@ theorem subtree_append {t : M P} (initial : Vertex t)
   | .root _ => rfl
   | .child _ next => exact subtree_append next suffix
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+the `append` equations below rewrite vertices indexed by `subtree`, which
+must unfold there for the rewrites to type-check. -/
+attribute [local implicit_reducible] subtree
+
 @[simp]
 theorem depth_append {t : M P} (initial : Vertex t)
     (suffix : Vertex (subtree initial)) :
     depth (append initial suffix) = depth initial + depth suffix := by
   match initial with
   | .root _ =>
-      simp only [depth_root, Nat.zero_add]
-      rfl
+      simp only [append_root, depth_root, Nat.zero_add]
   | .child direction next =>
-      change depth (append next suffix) + 1 = depth next + 1 + depth suffix
+      simp only [append_child, depth_child]
       rw [depth_append next suffix]
       exact Nat.add_right_comm (depth next) (depth suffix) 1
 

--- a/PolyFun/PFunctor/PatternRunsOnMatter/Basic.lean
+++ b/PolyFun/PFunctor/PatternRunsOnMatter/Basic.lean
@@ -41,6 +41,11 @@ universe pA pB pA' pB' qA qB qA' qB' v w
 
 namespace PFunctor
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+the synchronized-run definitions below rewrite through the tensor product
+there. `implicit_reducible` (unlike `reducible`) keeps `PFunctor.tensor`
+opaque to simp and typeclass resolution, and needs no
+`allowUnsafeReducibility`. -/
 attribute [local implicit_reducible] PFunctor.tensor
 
 namespace FreeP
@@ -234,7 +239,7 @@ theorem runObj_natural {P' : PFunctor.{pA', pB'}} {Q' : PFunctor.{qA', qB'}}
       have hhead := M.head_mapLens g matter
       cases hhead
       simp only [FreeP.map_toFunA, FreeP.mapShape, CofreeP.map_toFunA,
-        FreeM.map, runObj, FreeP.relabel_node,
+        FreeM.mapLens, FreeM.map, runObj, FreeP.relabel_node,
         FreeP.mapObj_node]
       congr 1
       funext direction

--- a/PolyFun/PFunctor/PatternRunsOnMatter/Display.lean
+++ b/PolyFun/PFunctor/PatternRunsOnMatter/Display.lean
@@ -38,6 +38,11 @@ namespace PFunctor
 
 namespace Responder
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+the responder equations below rewrite through the internal-hom display and
+the terminal dynamical system there. `implicit_reducible` (unlike
+`reducible`) keeps these constants opaque to simp and typeclass resolution,
+and needs no `allowUnsafeReducibility`. -/
 attribute [local implicit_reducible] PFunctor.Obj PFunctor.X PFunctor.monomial
   PFunctor.ihom PFunctor.DynSystem.out PFunctor.DynSystem.expose
   PFunctor.DynSystem.update PFunctor.M.terminalSystem Responder.terminal

--- a/PolyFun/PFunctor/PatternRunsOnMatter/Module.lean
+++ b/PolyFun/PFunctor/PatternRunsOnMatter/Module.lean
@@ -30,6 +30,13 @@ universe u
 namespace PFunctor
 namespace FreeP
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+the module-law equations below rewrite through the tensor substrate and the
+cofree comparison retrofunctors there. `implicit_reducible` (unlike
+`reducible`) keeps these constants opaque to simp and typeclass resolution,
+and needs no `allowUnsafeReducibility`. Constants already
+`implicit_reducible` at their definition sites (the `unfold*` family,
+`relabel`, `Comonoid.tensor`) are omitted. -/
 attribute [local implicit_reducible] PFunctor.X PFunctor.monomial PFunctor.tensor FreeP.node
   Comonoid.Hom.ofCategoryLaws CofreeP.comonoid CofreeP.cogenerator CofreeP.extend
   CofreeP.laxTensorHom CofreeP.laxTensor
@@ -171,13 +178,13 @@ theorem xi_unit (P : PFunctor.{u, u}) :
 
 /-! ## Associativity -/
 
-@[reducible] private def vertexPairObj {Q R : PFunctor.{u, u}}
+@[implicit_reducible] private def vertexPairObj {Q R : PFunctor.{u, u}}
     (matterQ : (CofreeP Q).A) (matterR : (CofreeP R).A) :
     (CofreeP Q ⊗ CofreeP R).Obj
       (M.Vertex matterQ × M.Vertex matterR) :=
   ⟨(matterQ, matterR), id⟩
 
-@[reducible] private def laxTensorVertexObj {Q R : PFunctor.{u, u}}
+@[implicit_reducible] private def laxTensorVertexObj {Q R : PFunctor.{u, u}}
     (matterQ : (CofreeP Q).A) (matterR : (CofreeP R).A) :
     (CofreeP (Q ⊗ R)).Obj (M.Vertex matterQ × M.Vertex matterR) :=
   Lens.mapObj (CofreeP.laxTensor Q R) (vertexPairObj matterQ matterR)
@@ -232,6 +239,7 @@ private theorem runObj_assoc (P Q R : PFunctor.{u, u})
   | liftBind a rest ih =>
       rw [FreeP.runLabeled_liftBind, FreeP.relabel_node]
       simp only [runObj_liftBind, FreeP.relabel_relabel]
+      rw [FreeP.runObj_node]
       simp only [FreeP.mapObj_relabel]
       let rightChildren := fun direction :
           (P.B a × Q.B (M.head matterQ)) × R.B (M.head matterR) =>
@@ -258,6 +266,10 @@ private theorem runObj_assoc (P Q R : PFunctor.{u, u})
       have hmap := FreeP.mapObj_node
         (Lens.Equiv.tensorAssoc (P := P) (Q := Q) (R := R)).toLens
         ((a, M.head matterQ), M.head matterR) rightChildren
+      -- Lean 4.33: `M.head (laxTensorVertexObj ..)` is only propositionally
+      -- `(M.head matterQ, M.head matterR)` (`laxTensor_head`), which the
+      -- original rewrites relied on definitionally; the head equation is now
+      -- destructed explicitly before rewriting.
       have hmap' :
           Lens.mapObj (FreeP.map
               (Lens.Equiv.tensorAssoc (P := P) (Q := Q) (R := R)).toLens)

--- a/PolyFun/PFunctor/PatternRunsOnMatter/Module.lean
+++ b/PolyFun/PFunctor/PatternRunsOnMatter/Module.lean
@@ -37,9 +37,9 @@ cofree comparison retrofunctors there. `implicit_reducible` (unlike
 and needs no `allowUnsafeReducibility`. Constants already
 `implicit_reducible` at their definition sites (the `unfold*` family,
 `relabel`, `Comonoid.tensor`) are omitted. -/
-attribute [local implicit_reducible] PFunctor.X PFunctor.monomial PFunctor.tensor FreeP.node
-  Comonoid.Hom.ofCategoryLaws CofreeP.comonoid CofreeP.cogenerator CofreeP.extend
-  CofreeP.laxTensorHom CofreeP.laxTensor
+attribute [local implicit_reducible] PFunctor.Obj PFunctor.X PFunctor.monomial
+  PFunctor.tensor FreeP.node Comonoid.Hom.ofCategoryLaws CofreeP.comonoid
+  CofreeP.cogenerator CofreeP.extend CofreeP.laxTensorHom CofreeP.laxTensor
 
 private theorem runObj_unit (P : PFunctor.{u, u})
     (pattern : (FreeP P).A) :

--- a/PolyFun/PFunctor/PatternRunsOnMatter/Operational.lean
+++ b/PolyFun/PFunctor/PatternRunsOnMatter/Operational.lean
@@ -24,6 +24,11 @@ universe pA pB qA qB u v
 
 namespace PFunctor.FreeP
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+the synchronized-decoding equations below rewrite through the tensor product
+there. `implicit_reducible` (unlike `reducible`) keeps `PFunctor.tensor`
+opaque to simp and typeclass resolution, and needs no
+`allowUnsafeReducibility`. -/
 attribute [local implicit_reducible] PFunctor.tensor
 
 variable {P : PFunctor.{pA, pB}} {Q : PFunctor.{qA, qB}}

--- a/PolyFun/PFunctor/SubstMonoid/Extension.lean
+++ b/PolyFun/PFunctor/SubstMonoid/Extension.lean
@@ -54,7 +54,6 @@ def bind {α β : Type uB} (x : Extension M α) (f : α → Extension M β) : Ex
 instance instMonad : Monad (Extension M) where
   pure := pure M
   bind := bind M
-  map f x := bind M x (fun y => pure M (f y))
 
 @[simp]
 theorem pure_def {α : Type uB} (x : α) : (Pure.pure x : Extension M α) = pure M x :=

--- a/PolyFun/PFunctor/SubstMonoid/Extension.lean
+++ b/PolyFun/PFunctor/SubstMonoid/Extension.lean
@@ -85,12 +85,9 @@ theorem bind_assoc {α β γ : Type uB} (x : Extension M α) (f : α → Extensi
 instance instLawfulMonad : LawfulMonad (Extension M) := LawfulMonad.mk'
   (bind_pure_comp := by
     intro α β f x
-    change bind M x (fun y => pure M (f y)) = bind M x (fun y => pure M (f y))
-    rfl)
-  (id_map := by
-    intro α x
-    change bind M x (fun y => pure M y) = x
-    exact bind_pure M x)
+    exact congrArg
+      (fun lens => Lens.mapObj lens (⟨x.1, f ∘ x.2⟩ : M.carrier.Obj β)) M.unit_right)
+  (id_map := fun _ => rfl)
   (pure_bind := pure_bind M)
   (bind_assoc := bind_assoc M)
 

--- a/PolyFun/PFunctor/Trace.lean
+++ b/PolyFun/PFunctor/Trace.lean
@@ -8,8 +8,6 @@ module
 public import Mathlib.Algebra.FreeMonoid.Basic
 public import PolyFun.Control.Trace
 public import PolyFun.PFunctor.Chart.Basic
-import all Mathlib.Algebra.FreeMonoid.Basic
-import all Mathlib.Data.PFunctor.Univariate.Basic
 
 /-!
 # Traces of polynomial-functor events
@@ -65,7 +63,13 @@ universe uA uB uA₁ uB₁ uA₂ uB₂ uA₃ uB₃ v w
 
 namespace PFunctor
 
-attribute [local implicit_reducible] FreeMonoid
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+the trace API below moves between `TraceList` and its `List` normal form and
+between `Idx` and its `Sigma` normal form there.  Mathlib's `FreeMonoid` and
+`Idx` are plain semireducible definitions; `implicit_reducible` (unlike
+`reducible`) keeps them opaque to simp and typeclass resolution, and needs no
+`allowUnsafeReducibility`. -/
+attribute [local implicit_reducible] FreeMonoid PFunctor.Idx
 
 /--
 The free monoid on `P`-events.  Definitionally `FreeMonoid (Idx P)`, which
@@ -99,30 +103,9 @@ theorem directionsWithin_cons {P : PFunctor.{uA, uB}}
   List.forall_mem_cons
 
 /-- Number of events at a given position in an erased execution trace. -/
-def occurrences {P : PFunctor.{uA, uB}} [DecidableEq P.A] (target : P.A) :
-    TraceList P → Nat
-  | [] => 0
-  | ⟨a, _⟩ :: tail =>
-      if a = target then occurrences target tail + 1 else occurrences target tail
-
-theorem occurrences_cons {P : PFunctor.{uA, uB}} [DecidableEq P.A]
-    (event : P.Idx) (tail : TraceList P) (target : P.A) :
-    occurrences target (event :: tail) =
-      if event.1 = target then occurrences target tail + 1 else occurrences target tail := by
-  rcases event with ⟨a, answer⟩
-  rfl
-
-@[simp] theorem occurrences_cons_self {P : PFunctor.{uA, uB}} [DecidableEq P.A]
-    (target : P.A) (answer : P.B target) (tail : TraceList P) :
-    occurrences target (⟨target, answer⟩ :: tail) =
-      occurrences target tail + 1 := by
-  simp [occurrences]
-
-@[simp] theorem occurrences_cons_of_ne {P : PFunctor.{uA, uB}} [DecidableEq P.A]
-    {a target : P.A} (hne : a ≠ target) (answer : P.B a) (tail : TraceList P) :
-    occurrences target (⟨a, answer⟩ :: tail) =
-      occurrences target tail := by
-  simp [occurrences, hne]
+def occurrences {P : PFunctor.{uA, uB}} [DecidableEq P.A]
+    (target : P.A) (events : TraceList P) : Nat :=
+  events.countP fun (event : P.Idx) => event.1 = target
 
 /-- The answer carried by the `n`-th event at `target`, if that occurrence exists. -/
 def getAt? {P : PFunctor.{uA, uB}} [DecidableEq P.A] :
@@ -173,46 +156,25 @@ theorem getAt?_cons_succ {P : PFunctor.{uA, uB}} [DecidableEq P.A]
   induction events generalizing n with
   | nil => simp [occurrences]
   | cons event tail ih =>
-      by_cases h : event.1 = target
-      · cases n with
-        | zero =>
-            rw [getAt?_cons_zero, occurrences_cons, dif_pos h, if_pos h]
-            simp
-        | succ n =>
-            rw [getAt?_cons_succ, occurrences_cons, if_pos h, if_pos h]
-            simpa using ih n
-      · cases n with
-        | zero =>
-            rw [getAt?_cons_zero, occurrences_cons, dif_neg h, if_neg h]
-            exact ih 0
-        | succ n =>
-            rw [getAt?_cons_succ, occurrences_cons, if_neg h, if_neg h]
-            exact ih (n + 1)
+      rcases event with ⟨a, answer⟩
+      by_cases h : a = target
+      · subst a
+        cases n <;> simp [occurrences, ih]
+      · simp [occurrences, h, ih]
 
 /-- The event following a prefix is found at the prefix's occurrence count. -/
 theorem getAt?_append_self_occurrences {P : PFunctor.{uA, uB}} [DecidableEq P.A]
     (before after : TraceList P) (target : P.A) (answer : P.B target) :
     getAt? (List.append before (⟨target, answer⟩ :: after)) target
       (occurrences target before) = some answer := by
-  let targetEvent : P.Idx := ⟨target, answer⟩
-  change getAt? (List.append before (targetEvent :: after)) target
-      (occurrences target before) = some answer
   induction before with
-  | nil => exact getAt?_cons_self_zero target answer after
+  | nil => simp [occurrences]
   | cons event before ih =>
-      change getAt? (event :: (before ++ targetEvent :: after)) target
-          (occurrences target (event :: before)) = some answer
-      by_cases h : event.1 = target
-      · rw [occurrences_cons, if_pos h, getAt?_cons_succ, if_pos h]
-        exact ih
-      · rw [occurrences_cons, if_neg h]
-        cases hocc : occurrences target before with
-        | zero =>
-            rw [getAt?_cons_zero, dif_neg h]
-            simpa [hocc] using ih
-        | succ n =>
-            rw [getAt?_cons_succ, if_neg h]
-            simpa [hocc] using ih
+      rcases event with ⟨a, prefixAnswer⟩
+      by_cases h : a = target
+      · subst a
+        simpa [occurrences] using ih
+      · simpa [occurrences, h] using ih
 
 end TraceList
 

--- a/PolyFunTest/ITree/RecursionEffectsExamples.lean
+++ b/PolyFunTest/ITree/RecursionEffectsExamples.lean
@@ -44,11 +44,7 @@ def stateProgram : ITree (StateE Nat + External) Nat :=
 
 example : runState stateProgram 4 =
     ITree.step (ITree.step (ITree.pure (F := External) (5, 4))) := by
-  -- Lean 4.33: simp no longer keys the state-interpreter equations to this
-  -- goal, so they are rewritten manually.
-  rw [runState_eq_interpState]
-  unfold stateProgram
-  rw [interpState_get, interpState_put, interpState_pure]
+  simp [stateProgram]
 
 /-- The state bind law threads the updated state into the continuation while
 retaining the program's return value. -/
@@ -60,8 +56,7 @@ example : interpState
   simp only [interpState_pure]
   rw [show interpState stateProgram 4 =
     ITree.step (ITree.step (ITree.pure (F := External) (5, 4))) by
-      unfold stateProgram
-      rw [interpState_get, interpState_put, interpState_pure]]
+      simp [stateProgram]]
   rw [bind_step, bind_step, bind_pure_left]
 
 def stateExternal : ITree (StateE Nat + External) Nat :=
@@ -71,25 +66,14 @@ def stateExternal : ITree (StateE Nat + External) Nat :=
 example : runState stateExternal 4 =
     ITree.query ExternalShape.read
       (fun n => ITree.pure (F := External) (4, n)) := by
-  -- Lean 4.33: simp no longer keys the state-interpreter equations to this
-  -- goal, so they are rewritten manually.
-  rw [runState_eq_interpState]
-  unfold stateExternal
-  rw [interpState_query_external]
-  congr 1
-  funext n
-  rw [interpState_pure]
+  simp [stateExternal]
 
 def throws : ITree (ExceptE String + External) Nat :=
   ITree.query (F := ExceptE String + External) (Sum.inl "boom") PEmpty.elim
 
 example : runExcept throws =
     ITree.pure (F := External) (Except.error "boom") := by
-  -- Lean 4.33: simp no longer keys the exception-interpreter equations to
-  -- this goal, so they are rewritten manually.
-  rw [runExcept_eq_interpExcept]
-  unfold throws
-  rw [interpExcept_throw]
+  simp [throws]
 
 /-- The exception bind law bypasses a continuation after the first error. -/
 example : interpExcept
@@ -100,8 +84,7 @@ example : interpExcept
   simp only [interpExcept_pure]
   rw [show interpExcept throws =
     ITree.pure (F := External) (Except.error "boom") by
-      unfold throws
-      rw [interpExcept_throw]]
+      simp [throws]]
   rw [bind_pure_left]
 
 def succeeds : ITree (ExceptE String + External) Nat :=
@@ -111,14 +94,7 @@ def succeeds : ITree (ExceptE String + External) Nat :=
 example : runExcept succeeds =
     ITree.query ExternalShape.read
       (fun n => ITree.pure (F := External) (Except.ok n)) := by
-  -- Lean 4.33: simp no longer keys the exception-interpreter equations to
-  -- this goal, so they are rewritten manually.
-  rw [runExcept_eq_interpExcept]
-  unfold succeeds
-  rw [interpExcept_query_external]
-  congr 1
-  funext n
-  rw [interpExcept_pure]
+  simp [succeeds]
 
 def countdownBody : Nat → ITree (CallE Nat Nat + External) Nat
   | 0 => ITree.pure 0

--- a/PolyFunTest/ITree/RecursionEffectsExamples.lean
+++ b/PolyFunTest/ITree/RecursionEffectsExamples.lean
@@ -19,6 +19,8 @@ and exception interpreters.
 
 namespace PolyFunTest.RecursionEffects
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+the runner examples below unfold these interpreters there. -/
 attribute [local implicit_reducible] ITree.interpState ITree.runState ITree.interpExcept
   ITree.interpMrec ITree.fixRec ITree.CallE
 
@@ -27,11 +29,11 @@ open ITree
 inductive ExternalShape where
   | read
 
+-- Lean 4.33: the examples below unfold `External` at implicit transparency.
+@[implicit_reducible]
 def External : PFunctor where
   A := ExternalShape
   B _ := Nat
-
-attribute [local implicit_reducible] External
 
 def stateProgram : ITree (StateE Nat + External) Nat :=
   ITree.query (F := StateE Nat + External)
@@ -42,6 +44,8 @@ def stateProgram : ITree (StateE Nat + External) Nat :=
 
 example : runState stateProgram 4 =
     ITree.step (ITree.step (ITree.pure (F := External) (5, 4))) := by
+  -- Lean 4.33: simp no longer keys the state-interpreter equations to this
+  -- goal, so they are rewritten manually.
   rw [runState_eq_interpState]
   unfold stateProgram
   rw [interpState_get, interpState_put, interpState_pure]
@@ -67,6 +71,8 @@ def stateExternal : ITree (StateE Nat + External) Nat :=
 example : runState stateExternal 4 =
     ITree.query ExternalShape.read
       (fun n => ITree.pure (F := External) (4, n)) := by
+  -- Lean 4.33: simp no longer keys the state-interpreter equations to this
+  -- goal, so they are rewritten manually.
   rw [runState_eq_interpState]
   unfold stateExternal
   rw [interpState_query_external]
@@ -79,6 +85,8 @@ def throws : ITree (ExceptE String + External) Nat :=
 
 example : runExcept throws =
     ITree.pure (F := External) (Except.error "boom") := by
+  -- Lean 4.33: simp no longer keys the exception-interpreter equations to
+  -- this goal, so they are rewritten manually.
   rw [runExcept_eq_interpExcept]
   unfold throws
   rw [interpExcept_throw]
@@ -103,6 +111,8 @@ def succeeds : ITree (ExceptE String + External) Nat :=
 example : runExcept succeeds =
     ITree.query ExternalShape.read
       (fun n => ITree.pure (F := External) (Except.ok n)) := by
+  -- Lean 4.33: simp no longer keys the exception-interpreter equations to
+  -- this goal, so they are rewritten manually.
   rw [runExcept_eq_interpExcept]
   unfold succeeds
   rw [interpExcept_query_external]
@@ -120,14 +130,9 @@ example (n : Nat) :
       ITree.step (ITree.bind (fixRec countdownBody n)
         (fun r => ITree.pure (F := External) (r + 1))) := by
   rw [fixRec_eq_interpMrec]
-  rw [show countdownBody (n + 1) = ITree.query (F := CallE Nat Nat + External)
-      (Sum.inl n) (fun r : Nat => ITree.pure (r + 1)) from rfl]
-  rw [interpMrec_query_recursive]
-  congr 1
-  rw [interpMrec_bind, ← fixRec_eq_interpMrec]
-  apply congrArg (ITree.bind (fixRec countdownBody n))
-  funext a
-  rw [interpMrec_pure]
+  simp only [countdownBody, interpMrec_query_recursive, interpMrec_bind,
+    interpMrec_pure]
+  rfl
 
 example (n : Nat) :
     ITree.recursiveHandler (D := CallE Nat Nat) (E := External)

--- a/PolyFunTest/ITree/ResumptionExamples.lean
+++ b/PolyFunTest/ITree/ResumptionExamples.lean
@@ -53,11 +53,12 @@ example : ¬ ITree.TauFree
   exact ITree.not_tauFree_step _ hchild
 
 /-- Nullary visible queries are accepted vacuously. -/
+-- Lean 4.33 unifies implicit arguments at implicit transparency; the example
+-- below needs `nullarySpec.B` to unfold there.
+@[implicit_reducible]
 def nullarySpec : PFunctor.{0, 0} where
   A := Unit
   B _ := PEmpty
-
-attribute [local implicit_reducible] nullarySpec
 
 example : ITree.TauFree
     (ITree.query (F := nullarySpec) () (fun direction =>

--- a/PolyFunTest/Interaction/Basic/ChainAppendExamples.lean
+++ b/PolyFunTest/Interaction/Basic/ChainAppendExamples.lean
@@ -120,6 +120,8 @@ example :
 
 example :
     Chain.liftThen prefixChain middle boundaryFamily combinedPath = Fin 12 := by
+  -- Lean 4.33: simp stops before the final `liftThen` boundary reduction;
+  -- close it with `rfl`.
   simp [combinedPath, prefixPath, middlePath]
   rfl
 

--- a/PolyFunTest/PFunctor/Adjunctions.lean
+++ b/PolyFunTest/PFunctor/Adjunctions.lean
@@ -97,6 +97,8 @@ projections to `simp` without unfolding the constructors. -/
 example {p : PFunctor.{pA, pB}} (a : p.A) (d : p.B a) :
     (Lens.positionCounit p).toFunA a = a ∧
       (Lens.positionCounit p).toFunB a d = PUnit.unit := by
+  -- Lean 4.33: simp stops at a universe-polymorphic `PUnit.unit = PUnit.unit`;
+  -- close it with `rfl`.
   simp
   rfl
 

--- a/PolyFunTest/PFunctor/CofreeLaxMonoidal.lean
+++ b/PolyFunTest/PFunctor/CofreeLaxMonoidal.lean
@@ -28,9 +28,14 @@ universe pA₁ pB₁ qA₁ qB₁ rA₁ rB₁
 namespace PFunctor
 namespace CofreeLaxMonoidalTest
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+the lax-monoidal examples below unfold these constants there.  The `unfold*`
+family, `Lens.tensorMap`, and the comonoid tensor and unit carry the attribute
+at their definition sites. -/
 attribute [local implicit_reducible] PFunctor.X PFunctor.monomial PFunctor.tensor
-  Comonoid.Hom.ofCategoryLaws CofreeP.comonoid CofreeP.cogenerator CofreeP.extend
-  CofreeP.laxUnitHom CofreeP.laxUnit CofreeP.laxTensorHom CofreeP.laxTensor
+  Comonoid.Hom.ofCategoryLaws CofreeP.comonoid CofreeP.cogenerator
+  CofreeP.extend CofreeP.laxUnitHom CofreeP.laxUnit CofreeP.laxTensorHom
+  CofreeP.laxTensor
 
 /-! ## Universe and theorem-surface canaries -/
 
@@ -190,9 +195,9 @@ example :
           (Comonoid.tensor (CofreeP.comonoid leftP)
             (CofreeP.comonoid rightP))
           (leftTree, rightTree) := by
-      rw [← CofreeP.comonoid_identity]
-      exact (CofreeP.laxTensorHom leftP rightP).map_identity
-        (leftTree, rightTree)
+      simpa [synchronizedTree] using
+        (CofreeP.laxTensorHom leftP rightP).map_identity
+          (leftTree, rightTree)
     _ = (.root leftTree, .root rightTree) := rfl
 
 /-- One synchronized edge pulls back to the matching edge in each source

--- a/PolyFunTest/PFunctor/CofreePolynomial.lean
+++ b/PolyFunTest/PFunctor/CofreePolynomial.lean
@@ -21,6 +21,8 @@ universe uA uB uA₂ uB₂ uA₃ uB₃
 namespace PFunctor
 namespace CofreePolynomialTest
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+the vertex examples below unfold these constants there. -/
 attribute [local implicit_reducible] M.Vertex.append M.Vertex.subtree M.children
 
 /-- A binary signature whose positions and directions are both bits. -/

--- a/PolyFunTest/PFunctor/CofreeUniversal.lean
+++ b/PolyFunTest/PFunctor/CofreeUniversal.lean
@@ -155,6 +155,9 @@ example : listTree =
 
 /-- The root path is the identity arrow, hence the empty list. -/
 example : listExtension.toLens.toFunB listObject (.root listTree) = [] := by
+  -- Lean 4.33: `calc` cannot synthesize its `Trans` instance across the
+  -- list-monoid carrier at instance transparency, so `Eq.trans` is applied
+  -- directly.
   have h : listExtension.toLens.toFunB listObject (.root listTree) =
       Comonoid.identity boolListComonoid listObject := by
     rw [← CofreeP.comonoid_identity]

--- a/PolyFunTest/PFunctor/Dynamical/CofreeMateExamples.lean
+++ b/PolyFunTest/PFunctor/Dynamical/CofreeMateExamples.lean
@@ -24,6 +24,8 @@ universe uS uA uB uα
 namespace PFunctor
 namespace CofreeMateTest
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+the mate examples below unfold these constants there. -/
 attribute [local implicit_reducible] CofreeP.comonoid Comonoid.identity
 
 open ComonoidCategoryTest
@@ -133,8 +135,8 @@ example : branchingSystem.cofreeMate.toLens.toFunB .source
     branchingSystem.cofreeMate.toLens.toFunB .source
         (.root (branchingSystem.cofreeMate.toLens.toFunA .source)) =
         Comonoid.identity (stateComonoid ThreeState) .source := by
-      rw [← CofreeP.comonoid_identity]
-      exact branchingSystem.cofreeMate.map_identity ThreeState.source
+      simpa only [CofreeP.comonoid_identity] using
+        branchingSystem.cofreeMate.map_identity ThreeState.source
     _ = .source := rfl
 
 /-- The `false` branch reaches the observably distinct middle state. -/

--- a/PolyFunTest/PFunctor/Dynamical/DynComputationBoundedExamples.lean
+++ b/PolyFunTest/PFunctor/Dynamical/DynComputationBoundedExamples.lean
@@ -15,6 +15,8 @@ open PFunctor
 
 namespace PFunctor.DynSystem.DynComputation
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+the boundary examples below unfold these constants there. -/
 attribute [local implicit_reducible] PFunctor.X PFunctor.monomial FreeM.IsTotalRollBound
 
 /-! ## Boundary behavior and universes -/
@@ -156,6 +158,7 @@ def collatzMachine : DynComputation X.{0, 0} ℕ ℕ where
 @[simp] theorem closedStutterStep_collatzMachine (n : ℕ) :
     collatzMachine.closedStutterStep n =
       if n = 1 then n else collatzNext n := by
+  -- Lean 4.33: simp stops at literal goals `1 = 1` here; close them with `rfl`.
   by_cases h : n = 1 <;> simp [closedStutterStep, collatzView, h] <;> rfl
 
 example : collatzMachine.view (collatzMachine.init 1) = Sum.inl 1 := by
@@ -164,11 +167,14 @@ example : collatzMachine.view (collatzMachine.init 1) = Sum.inl 1 := by
 
 example : collatzMachine.closedStutterStep (collatzMachine.init 1) =
     collatzMachine.init 1 := by
+  -- Lean 4.33: simp stops at the literal goal `1 = 1`; close it with `rfl`.
   simp
   rfl
 
 example : collatzMachine.closedStutterIterate (collatzMachine.init 6) 8 =
     collatzMachine.init 1 := by
+  -- Lean 4.33: `Function.iterate_succ_apply` no longer fires from `norm_num`'s
+  -- default simp set here, and the final step needs `rfl`.
   norm_num [closedStutterIterate, Function.iterate_succ_apply, collatzNext]
   rfl
 

--- a/PolyFunTest/PFunctor/Dynamical/DynComputationExamples.lean
+++ b/PolyFunTest/PFunctor/Dynamical/DynComputationExamples.lean
@@ -219,6 +219,8 @@ example (f g : Nat → Nat) :
       emptyOfFn.contramapInput (f ∘ g) :=
   contramapInput_comp emptyOfFn f g
 
+-- Lean 4.33: the example unfolds these constants at implicit transparency
+-- (`mapResult` carries the attribute at its definition site).
 attribute [local implicit_reducible] emptyOfFn ofFn in
 example : (emptyOfFn.mapResult (· % 2)).view (emptyOfFn.init 4) = Sum.inl 1 := by
   simp [emptyOfFn]
@@ -283,8 +285,11 @@ def branchMachine : DynComputation branchSource Unit Nat where
       | true => PEmpty.elim
   init := fun _ => false
 
-attribute [local implicit_reducible] PFunctor.monomial branchSource branchTarget branchFinal
-  branchLens branchLens₂ branchMachine seqComp
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+the branch-machine examples below unfold these constants there (`wrap`
+carries the attribute at its definition site). -/
+attribute [local implicit_reducible] PFunctor.monomial branchSource branchTarget
+  branchFinal branchLens branchLens₂ branchMachine seqComp
 
 def handoffResult (answer : Bool) : Nat := if answer = true then 11 else 7
 
@@ -305,6 +310,7 @@ def handoffSecond : DynComputation branchSource Bool Nat where
 def handoffFirst : DynComputation branchSource Unit Bool :=
   ofFn fun _ => true
 
+-- Lean 4.33: the handoff examples below unfold these at implicit transparency.
 attribute [local implicit_reducible] handoffFirst handoffSecond
 
 /-- A returned intermediate value exposes the second phase's actual query in
@@ -341,6 +347,7 @@ def answerFirst : DynComputation branchSource Unit Bool where
 def answerSecond : DynComputation branchSource Bool Nat :=
   ofFn fun answer => if answer then 1 else 2
 
+-- Lean 4.33: the answer examples below unfold these at implicit transparency.
 attribute [local implicit_reducible] answerFirst answerSecond
 
 /-- A first-phase answer stays tagged as phase one until its returned value is
@@ -425,7 +432,10 @@ def sourceTree (trueResult : Nat) : Resumption lossySource Nat :=
 def sourceMachine (trueResult : Nat) : DynComputation lossySource Unit Nat :=
   ofResumption fun _ => sourceTree trueResult
 
-attribute [local implicit_reducible] PFunctor.X lossySource lossyLens sourceTree sourceMachine
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+the observation examples below unfold these constants there. -/
+attribute [local implicit_reducible] PFunctor.X lossySource lossyLens sourceTree
+  sourceMachine
 
 def observeTrueResult (tree : Resumption lossySource Nat) : Option Nat :=
   match Resumption.dest tree with

--- a/PolyFunTest/PFunctor/Dynamical/DynComputationExamples.lean
+++ b/PolyFunTest/PFunctor/Dynamical/DynComputationExamples.lean
@@ -446,7 +446,10 @@ example : ObsEq
     ((sourceMachine 2).wrap lossyLens) := by
   intro input
   cases input
-  simp [sourceMachine, sourceTree, lossyLens, lossySource]
+  -- Lean 4.33: `DynComputation.wrap` is only `implicit_reducible`, so
+  -- `wrap_denote` is passed to `simp` explicitly.
+  simp [sourceMachine, sourceTree, lossyLens, lossySource,
+    DynComputation.wrap_denote]
 
 example : (ofFreeM oneQuery).mapResult (· + 1) ⊨
     (fun input => FreeM.map (· + 1) (oneQuery input)) :=

--- a/PolyFunTest/PFunctor/Dynamical/SimulationExamples.lean
+++ b/PolyFunTest/PFunctor/Dynamical/SimulationExamples.lean
@@ -50,14 +50,16 @@ example {S₁ : Type u} {S₂ : Type v} {D₁ : DynSystem S₁ p} {D₂ : DynSys
 structure is the system's own, supplied locally via `letI := D.coalg`. -/
 example (D : DynSystem S p) :
     letI := D.coalg
-    DynSystem.IsSimulation D D (fun s₁ s₂ => s₁ = s₂) :=
-  idSim D
+    DynSystem.IsSimulation D D (fun s₁ s₂ => Coalg.Hom.id (F := p.Obj) s₁ = s₂) :=
+  letI := D.coalg
+  DynSystem.isSimulation_graph_coalgHom (Coalg.Hom.id)
 
 /-- Coalgebra morphisms preserve behaviour trees. -/
 example (D : DynSystem S p) (s : S) :
     letI := D.coalg
-    D.behavior s = D.behavior s :=
-  rfl
+    D.behavior (Coalg.Hom.id (F := p.Obj) (S₁ := S) s) = D.behavior s :=
+  letI := D.coalg
+  DynSystem.behavior_coalgHom Coalg.Hom.id s
 
 /-- A step-synchronized simulation is an operational forward simulation at
 `StepRel.sync`. -/

--- a/PolyFunTest/PFunctor/FreeCursorExamples.lean
+++ b/PolyFunTest/PFunctor/FreeCursorExamples.lean
@@ -15,6 +15,8 @@ universe uA uB v
 
 namespace PFunctor.FreeM.CursorExamples
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+the cursor examples below unfold these constants there. -/
 attribute [local implicit_reducible] FreeM.Cursor.plug FreeM.Cursor.trace
   FreeM.Path.trace
 
@@ -74,8 +76,10 @@ def unitEdge : Cursor.Edge afterIndexCursor.residual :=
 def trueLeaf : Cursor program :=
   afterIndexCursor.comp unitEdge.toCursor
 
-attribute [local implicit_reducible] Interface Answer afterIndex afterChoice program internal
-  indexEdge afterIndexCursor unitEdge trueLeaf
+/- Lean 4.33: the examples below unfold this file's worked cursor data at
+implicit transparency. -/
+attribute [local implicit_reducible] Interface Answer afterIndex afterChoice program
+  internal indexEdge afterIndexCursor unitEdge trueLeaf
 
 example : trueLeaf.residual = FreeM.pure 11 := rfl
 
@@ -97,6 +101,8 @@ example : internal.plug (⟨selectedIndex, PUnit.unit, ⟨⟩⟩ : Path internal
 example : Path.trace program truePath = trueLeaf.trace := by
   change Path.trace program
       (trueLeaf.plug (⟨⟩ : Path trueLeaf.residual)) = trueLeaf.trace
+  -- Lean 4.33: `rw` rejects the changed target at implicit transparency, so
+  -- the law is applied as a term.
   exact (Cursor.trace_plug trueLeaf (⟨⟩ : Path trueLeaf.residual)).trans (by rfl)
 
 example : FreeM.map (output program) (withPath program) = program :=
@@ -116,18 +122,15 @@ example : falseTerminal.output = 7 := rfl
 
 example : trueTerminal.output ≠ falseTerminal.output := by decide
 
-example : Cursor.pathOfTerminal trueTerminal = truePath :=
-  Cursor.pathOfTerminal_terminalOfPath program truePath
+example : Cursor.pathOfTerminal trueTerminal = truePath := by simp [trueTerminal]
 
-example : Cursor.pathOfTerminal falseTerminal = falsePath :=
-  Cursor.pathOfTerminal_terminalOfPath program falsePath
+example : Cursor.pathOfTerminal falseTerminal = falsePath := by simp [falseTerminal]
 
 example : Cursor.terminalOfPath program (Cursor.pathOfTerminal trueTerminal) =
-    trueTerminal := Cursor.terminalOfPath_pathOfTerminal trueTerminal
+    trueTerminal := by simp
 
 example : Cursor.terminalEquivPath program trueTerminal = truePath := by
-  change Cursor.pathOfTerminal trueTerminal = truePath
-  exact Cursor.pathOfTerminal_terminalOfPath program truePath
+  simp [Cursor.terminalEquivPath, trueTerminal]
 
 /-! The producer tests below name the public algebraic laws explicitly, so
 their availability and simp orientation remain part of the regression surface. -/

--- a/PolyFunTest/PFunctor/FreeCursorExamples.lean
+++ b/PolyFunTest/PFunctor/FreeCursorExamples.lean
@@ -154,7 +154,6 @@ example : trueLeaf.trace =
     List.append (List.append internal.trace indexEdge.toCursor.trace)
       unitEdge.toCursor.trace := by
   simp only [trueLeaf, afterIndexCursor, Cursor.trace_comp]
-  rfl
 
 example (path : Path unitEdge.residual) :
     (afterIndexCursor.comp unitEdge.toCursor).plug path =

--- a/PolyFunTest/PFunctor/FreeCursorExamples.lean
+++ b/PolyFunTest/PFunctor/FreeCursorExamples.lean
@@ -16,9 +16,10 @@ universe uA uB v
 namespace PFunctor.FreeM.CursorExamples
 
 /- Lean 4.33 compares assigned metavariable types at implicit transparency;
-the cursor examples below unfold these constants there. -/
+the cursor examples below unfold these constants there, and the trace
+examples cross the `TraceList` carrier (reducibly `FreeMonoid (Idx _)`). -/
 attribute [local implicit_reducible] FreeM.Cursor.plug FreeM.Cursor.trace
-  FreeM.Path.trace
+  FreeM.Path.trace FreeMonoid PFunctor.Idx
 
 /-- Cursor construction keeps all three relevant universes independent. -/
 example {P : PFunctor.{uA, uB}} {α : Type v} (program : FreeM P α) :

--- a/PolyFunTest/PFunctor/FreeResumptionExamples.lean
+++ b/PolyFunTest/PFunctor/FreeResumptionExamples.lean
@@ -53,6 +53,7 @@ example : Resumption.dest (toResumption program) =
 example : toResumption program ≠ toResumption (FreeM.pure 7) := by
   intro h
   have hdest := congrArg Resumption.dest h
+  -- Lean 4.33: `Resumption.dest_query` no longer fires here and is omitted.
   simp only [program, toResumption, Resumption.dest_pure] at hdest
   cases hdest
 

--- a/PolyFunTest/PFunctor/Handler/Normalization.lean
+++ b/PolyFunTest/PFunctor/Handler/Normalization.lean
@@ -21,6 +21,8 @@ changes the observed result.
 
 namespace PFunctor.Handler.Normalization.Examples
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+the handler examples below unfold `monomial` there. -/
 attribute [local implicit_reducible] PFunctor.monomial
 
 abbrev Query : PFunctor.{0, 0} := monomial Bool Nat
@@ -47,7 +49,7 @@ example {m : Type → Type} [Monad m] [LawfulMonad m] {S α : Type}
     (query : Bool) (next : Nat → FreeM Query α) (state : S) :
     h.run (FreeM.lift query >>= next) state =
       (h query).run state >>= fun result => h.run (next result.1) result.2 := by
-  rw [Handler.Stateful.run_bind, Handler.Stateful.run_lift]
+  simp only [handler_nf]
 
 /-- Transformer run equations are part of the same explicit normal form. -/
 example {m : Type → Type} [Monad m] {S α β : Type} (x : StateT S m α)

--- a/PolyFunTest/PFunctor/ResponderBehavior.lean
+++ b/PolyFunTest/PFunctor/ResponderBehavior.lean
@@ -18,25 +18,29 @@ is checked after transport along the ordinary behavior-child equation.
 
 namespace PFunctor.ResponderBehaviorExample
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+the behavior examples below unfold these constants there. -/
 attribute [local implicit_reducible] PFunctor.X PFunctor.monomial PFunctor.ihom
   PFunctor.DynSystem.out PFunctor.DynSystem.expose PFunctor.DynSystem.update
   PFunctor.M.terminalSystem PFunctor.Responder.terminal
 
-@[reducible]
+-- Lean 4.33: the examples below unfold `Interface` at implicit transparency.
+@[implicit_reducible]
 def Interface : PFunctor where
   A := Unit
   B := fun _ => Bool
 
 def query : Interface.A := ()
 
-@[reducible]
+-- Lean 4.33: the examples below unfold `contract` at implicit transparency.
+@[implicit_reducible]
 def contract : Display Interface where
   position _ := Bool
   direction _ expected answer := if expected = answer then Fin 2 else Fin 3
 
 def directionFromNat (expected answer : Bool) (value : Nat) :
     contract.direction () expected answer := by
-  simp only
+  simp only [contract]
   split
   · exact ⟨value % 2, Nat.mod_lt _ (by decide)⟩
   · exact ⟨value % 3, Nat.mod_lt _ (by decide)⟩
@@ -81,10 +85,13 @@ def displayed :
 
 def initialWitness : Invariant false := invariantFromNat false 1
 
-@[reducible]
+-- Lean 4.33: the examples below unfold `behavior` at implicit transparency.
+@[implicit_reducible]
 def behavior := responder.behavior false
 
-@[reducible]
+-- Lean 4.33: the examples below unfold `toDisplayedBehavior` at implicit
+-- transparency.
+@[implicit_reducible]
 def toDisplayedBehavior :=
   Responder.toDisplayedBehavior contract responder Invariant displayed
     false initialWitness

--- a/PolyFunTest/PFunctor/ResponderDisplay.lean
+++ b/PolyFunTest/PFunctor/ResponderDisplay.lean
@@ -24,18 +24,22 @@ inductive Query where
   | bit
   | choice
 
+-- Lean 4.33: the examples below unfold `Response` at implicit transparency.
+@[implicit_reducible]
 def Response : Query → Type
   | .bit => Bool
   | .choice => Fin 3
 
+-- Lean 4.33: the examples below unfold `Interface` at implicit transparency.
+@[implicit_reducible]
 def Interface : PFunctor where
   A := Query
   B := Response
 
-attribute [local implicit_reducible] Response Interface
-
 /-- Contract positions depend on the query, and postcondition evidence depends
 on both the chosen contract position and the actual response. -/
+-- Lean 4.33: the examples below unfold `contract` at implicit transparency.
+@[implicit_reducible]
 def contract : Display Interface where
   position
     | .bit => Bool
@@ -43,8 +47,6 @@ def contract : Display Interface where
   direction
     | .bit, expected, answer => if expected = answer then Fin 2 else PUnit
     | .choice, bound, answer => Fin (bound.val + answer.val + 1)
-
-attribute [local implicit_reducible] contract
 
 def answer (state : Nat) : (a : Query) → Response a
   | .bit => state % 2 == 0
@@ -64,8 +66,7 @@ def answerContract (state : Nat) :
     (a : Query) → (c : contract.position a) →
       contract.direction a c (system.answer state a)
   | .bit, expected => by
-      change Bool at expected
-      change if expected = (state % 2 == 0) then Fin 2 else PUnit
+      simp only [contract]
       split
       · exact 0
       · exact PUnit.unit

--- a/PolyFunTest/PFunctor/ResponderReindex.lean
+++ b/PolyFunTest/PFunctor/ResponderReindex.lean
@@ -20,12 +20,14 @@ evidence is state-indexed data and affects the next witness.
 
 namespace PFunctor.ResponderReindexExample
 
-@[reducible]
+-- Lean 4.33: the examples below unfold `Interface` at implicit transparency.
+@[implicit_reducible]
 def Interface : PFunctor where
   A := Unit
   B := fun _ => Bool
 
-@[reducible]
+-- Lean 4.33: the examples below unfold `contract` at implicit transparency.
+@[implicit_reducible]
 def contract : Display Interface where
   position _ := Bool
   direction _ expected answer := if expected = answer then Fin 2 else Fin 3
@@ -37,7 +39,7 @@ def directionVal (expected answer : Bool)
 
 def directionFromNat (expected answer : Bool) (value : Nat) :
     contract.direction () expected answer := by
-  simp only
+  simp only [contract]
   split
   · exact ⟨value % 2, Nat.mod_lt _ (by decide)⟩
   · exact ⟨value % 3, Nat.mod_lt _ (by decide)⟩

--- a/PolyFunTest/PFunctor/ResumptionTruncateExamples.lean
+++ b/PolyFunTest/PFunctor/ResumptionTruncateExamples.lean
@@ -15,6 +15,8 @@ open PFunctor
 
 namespace PFunctor.Resumption
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+the truncation examples below unfold these signatures there. -/
 attribute [local implicit_reducible] PFunctor.X PFunctor.monomial
 
 universe uA uB uβ
@@ -34,9 +36,10 @@ example : truncate 1 oneQueryTree =
 example : (truncate 1 oneQueryTree).IsTotalRollBound 1 := isTotalRollBound_truncate 1 oneQueryTree
 
 /-- A nontrivial interface whose two answers select different continuations. -/
+-- Lean 4.33: the truncation examples below unfold `branchP` at implicit
+-- transparency.
+@[implicit_reducible]
 def branchP : PFunctor.{0, 0} := monomial Bool Bool
-
-attribute [local implicit_reducible] branchP
 
 def secondProgram : Bool → FreeM branchP Nat
   | false => FreeM.pure 3
@@ -100,9 +103,10 @@ example : truncate 5 twoLevelTree = FreeM.map some twoLevelProgram :=
 
 /-- A query with no directions is a finite one-node program; its continuation
 obligation and its successful factorization are both vacuous. -/
+-- Lean 4.33: the vacuous-factorization examples below unfold
+-- `emptyDirectionP` at implicit transparency.
+@[implicit_reducible]
 def emptyDirectionP : PFunctor.{0, 0} := monomial Unit PEmpty
-
-attribute [local implicit_reducible] emptyDirectionP
 
 def emptyDirectionProgram : FreeM emptyDirectionP Nat :=
   FreeM.liftBind () PEmpty.elim

--- a/PolyFunTest/PFunctor/TraceAndRootPredicates.lean
+++ b/PolyFunTest/PFunctor/TraceAndRootPredicates.lean
@@ -16,6 +16,8 @@ universe uA uB v w
 
 namespace PFunctor.PredicateExamples
 
+/- Lean 4.33 compares assigned metavariable types at implicit transparency;
+the predicate examples below unfold `PFunctor.Idx` there. -/
 attribute [local implicit_reducible] PFunctor.Idx
 
 variable {P : PFunctor.{uA, uB}} {α : Type v}

--- a/PolyFunTest/PFunctor/TraceAndRootPredicates.lean
+++ b/PolyFunTest/PFunctor/TraceAndRootPredicates.lean
@@ -38,7 +38,7 @@ requiring decidable equality on positions. -/
 example (allowed : (a : P.A) → Set (P.B a)) (a : P.A) (b : P.B a) (tail : TraceList P) :
     TraceList.DirectionsWithin allowed (⟨a, b⟩ :: tail) ↔
       b ∈ allowed a ∧ TraceList.DirectionsWithin allowed tail := by
-  exact TraceList.directionsWithin_cons allowed ⟨a, b⟩ tail
+  simp
 
 /-- Root satisfaction distinguishes leaves from exposed positions. -/
 example (positionPred : P.A → Prop) (leafPred : α → Prop) (result : α) :

--- a/docs/wiki/gotchas.md
+++ b/docs/wiki/gotchas.md
@@ -59,6 +59,35 @@ aggressively. Use the canonical eliminators
 `Decoration` / `Path` analogues) rather than pattern matching on
 `PFunctor.FreeM.pure` / `liftBind` directly.
 
+### 6a. Transparency after Lean 4.33
+
+Lean 4.33 split the transparency ladder (`reducible < instances <
+implicit < default < all`) and compares assigned metavariable types at
+implicit transparency. Semireducible definitions no longer unfold during
+unification in `rw` / `simp` / `subst` / instance-argument positions.
+Symptoms and fixes (see the Transparency Attributes section of
+`CONTRIBUTING.md` for the policy):
+
+- `rw` "did not find an occurrence" though the pattern is visibly there,
+  or a goal is "not type-correct under the implicit transparency level"
+  → `@[implicit_reducible]` on the definition the implicit arguments go
+  through, or `attribute [local implicit_reducible]` (option-free) for
+  imported declarations.
+- "failed to synthesize instance" for an instance that clearly exists →
+  check first whether a `[local reducible]`-style attribute is
+  *over-unfolding* the goal (remove it); otherwise
+  `@[instance_reducible]` on the wrapper the goal's head hides behind.
+- A `rfl` simp lemma rejected as trivial → its LHS head was made
+  `@[reducible]`; demote the head to `@[implicit_reducible]` and the
+  lemma is valid again.
+- A simp lemma silently never fires → its statement may freeze an
+  unreduced projection into the discrimination-tree key (e.g. a
+  `Sum.inl` binder ascribed through `(P + Q).A`); restate the binder
+  with the reduced component types.
+- `calc` failing with a `Trans` instance error where a plain `.trans`
+  works → typeclass resolution runs below implicit transparency; keep
+  the term-level `.trans` form with a comment.
+
 ### 7. Universe polymorphism
 
 `PFunctor` carries two universe parameters `(uA, uB)`; `FreeM`,


### PR DESCRIPTION
## Summary

Iterates on the Lean v4.33 transparency conversion from #128. The merged migration already moved the tree onto option-free `attribute [local implicit_reducible]` blocks and restored the `FreeMonoid`-backed `TraceList`; this PR finishes the conversion by restoring the API and proofs the transition had to sacrifice, and writes the resulting conventions down.

- restore the `@[simp]` attributes dropped during the migration — with the relevant heads at `implicit_reducible` rather than `reducible`, the `rfl` simp lemmas are valid again (`Cofree/Universal.lean` alone goes from 6 back to its original 13; repo-wide only the two `substMonoid_mult` projection lemmas stay un-simped, with comments — their heads are reducible abbrevs, so simpNF correctly rejects them)
- eliminate all 16 remaining `with_unfolding_all` escalations by restoring the original `rw`/`simpa` proofs they had replaced
- return the migration-era proof workarounds (`change` restatements, pre-instantiated `have`-then-`rw` chains, let-barriers, manual calc blocks — concentrated in `ITree/Rec/Facts.lean`, `Interaction/TwoParty/Strategy.lean`, `Cofree/Universal.lean`, `CartesianClosed.lean`) to their pre-bump text wherever they close again; the survivors carry one-line `-- Lean 4.33:` comments naming the verified reason (e.g. `calc`'s `Trans` instance resolving below implicit transparency)
- restore the `letI`-based `Coalg.Hom` statements of `isSimulation_graph_coalgHom` / `behavior_coalgHom`, undoing a public-API change
- restate the `Sum.inl`/`Sum.inr` binders of the `interpState_*` / `interpExcept_*` computation rules with explicit component types: the ascriptions through `(StateE σ + E).A` froze an unreduced projection into their discrimination-tree keys, so simp could never retrieve these lemmas — the root cause of the manual rewrite chains in the interpreter examples. The `simp [stateProgram]`-style one-liners in `PolyFunTest` return (two now close goals that previously also needed `congr`)
- polish: `HAdd`/`Add` instances delegate to `sum` again, `Lens.ext_heq` becomes public API in `Lens/Basic.lean` next to `Lens.ext`, dead `import all` lines dropped, `selfMonomial`'s spelled-out body gets an explanatory docstring
- document the policy: a new Transparency Attributes section in `CONTRIBUTING.md` (which tier to reach for and when, following the `Init.MetaTypes` guidance and mathlib's 4.33 practice) and a symptom-to-fix table in `docs/wiki/gotchas.md`

Net: 89 files changed, +843/−726 vs main; most touched proofs are again byte-identical to their pre-bump form. `allowUnsafeReducibility`, `attribute [local reducible]`, and `with_unfolding_all` all remain/reach zero. Full build time is unchanged from the migration baseline.

## Validation

- `./scripts/validate.sh --lint --test` — passed
- `./scripts/update-lib.sh` — zero diff
- restored simp lemmas pass the Batteries simpNF linter
- no added `sorry`, axioms, disabled checks, linter suppressions, or `maxHeartbeats` changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)