### PR TITLE
feat(PFunctor): a supply run is a path, and substitution is substitution at an occurrence

### DIFF
--- a/PolyFun.lean
+++ b/PolyFun.lean
@@ -226,6 +226,7 @@ public import PolyFun.PFunctor.SubstMonoid
 public import PolyFun.PFunctor.SubstMonoid.Convolution
 public import PolyFun.PFunctor.SubstMonoid.Extension
 public import PolyFun.PFunctor.Supply
+public import PolyFun.PFunctor.Supply.Trace
 public import PolyFun.PFunctor.Trace
 public import PolyFun.PFunctor.Wiring
 public import PolyFun.PFunctor.Wiring.Parallel

--- a/PolyFun/PFunctor/Supply/Trace.lean
+++ b/PolyFun/PFunctor/Supply/Trace.lean
@@ -1,0 +1,238 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+module
+
+public import PolyFun.PFunctor.Supply
+public import PolyFun.PFunctor.Free.Path.Execution
+public import PolyFun.PFunctor.Trace
+
+/-!
+# What a run against a supply reads
+
+`Supply.run` executes a program against a positional answer supply. `Supply.runPath` is that same
+execution retaining the typed `FreeM.Path` it selected, so a run can be compared with the
+path-indexed structures built on top of `Path` — cursors, occurrence contexts, fork views.
+`run_eq_map_runPath` says the two agree: `run` is `runPath` followed by reading off the leaf.
+
+The bridge those comparisons rest on is `getAt?_trace_runPath`: the answer a run took at the `n`-th
+occurrence of a position is the supply's `n`-th answer there. Positional substitution on a supply is
+therefore substitution at an occurrence of the executed trace, which is what makes `Supply.setAt` a
+rewind primitive rather than an arbitrary edit. `getAt?_trace_runPath_setAt` states exactly that,
+and `getAt?_trace_runPath_setAt_of_ne` states that every other answer the run takes is untouched —
+the same shared-prefix property that `Cursor.ForkView` gets by construction from retaining its
+occurrence context.
+
+`apply_eq_drop_occurrences` is the accounting behind all of it: a run leaves behind exactly what it
+did not read, so the supply that remains at a position is that position's list with as many answers
+dropped as the trace has events there.
+-/
+
+@[expose] public section
+
+universe uA uB v
+
+namespace PFunctor
+
+namespace Supply
+
+/- Lean 4.33 compares assigned metavariable types at implicit transparency; the rewrites below move
+between `TraceList` — reducibly `FreeMonoid (Idx _)` — and its `List` normal form.
+`implicit_reducible` (unlike `reducible`) stays invisible to simp and instance search, and needs no
+`allowUnsafeReducibility`. -/
+attribute [local implicit_reducible] FreeMonoid PFunctor.Idx
+
+variable {P : PFunctor.{uA, uB}} {α : Type v}
+
+/-- `FreeM.Path.trace_liftBind` in the `liftBind` spelling the definitions below produce. -/
+private theorem trace_liftBind' {a : P.A} (next : P.B a → FreeM P α) (answer : P.B a)
+    (tail : FreeM.Path (next answer)) :
+    FreeM.Path.trace (FreeM.liftBind a next) ⟨answer, tail⟩
+      = (⟨a, answer⟩ : P.Idx) :: FreeM.Path.trace (next answer) tail := rfl
+
+/-! ### Running for a path -/
+
+variable [DecidableEq P.A]
+
+/-- One event at the counted position. -/
+private theorem occurrences_cons_self (a : P.A) (answer : P.B a) (tail : TraceList P) :
+    TraceList.occurrences a ((⟨a, answer⟩ : P.Idx) :: tail)
+      = TraceList.occurrences a tail + 1 := by
+  simp [TraceList.occurrences]
+
+/-- An event elsewhere is not counted. -/
+private theorem occurrences_cons_of_ne {a b : P.A} (hb : b ≠ a) (answer : P.B a)
+    (tail : TraceList P) :
+    TraceList.occurrences b ((⟨a, answer⟩ : P.Idx) :: tail)
+      = TraceList.occurrences b tail := by
+  simp [TraceList.occurrences, Ne.symm hb]
+
+/-- Run a program against a supply, retaining the typed path the answers selected. -/
+def runPath : (program : FreeM P α) → Supply P → Option (FreeM.Path program × Supply P)
+  | .pure _, s => some (⟨⟩, s)
+  | .liftBind a next, s =>
+      match s a with
+      | [] => none
+      | u :: us =>
+          (runPath (next u) (Function.update s a us)).map fun r => (⟨u, r.1⟩, r.2)
+
+@[simp] lemma runPath_pure (x : α) (s : Supply P) :
+    runPath (pure x : FreeM P α) s = some (⟨⟩, s) := rfl
+
+lemma runPath_liftBind_of_nil {a : P.A} (next : P.B a → FreeM P α) {s : Supply P} (hs : s a = []) :
+    runPath (FreeM.liftBind a next) s = none := by
+  rw [runPath]; rw [hs]
+
+lemma runPath_liftBind_of_cons {a : P.A} (next : P.B a → FreeM P α) {s : Supply P} {u : P.B a}
+    {us : List (P.B a)} (hs : s a = u :: us) :
+    runPath (FreeM.liftBind a next) s
+      = (runPath (next u) (s.update a us)).map fun r => (⟨u, r.1⟩, r.2) := by
+  rw [runPath]; rw [hs]; rfl
+
+/-- **`run` is `runPath` with the path forgotten.** Reading the leaf off the selected path recovers
+exactly the value the plain run returns, so every statement about `runPath` is a statement about
+`run`. -/
+theorem run_eq_map_runPath : ∀ (program : FreeM P α) (s : Supply P),
+    run program s = (runPath program s).map fun r => (FreeM.output program r.1, r.2)
+  | .pure y, s => by
+      rw [show run (FreeM.pure y : FreeM P α) s = some (y, s) from rfl,
+        show runPath (FreeM.pure y : FreeM P α) s = some (⟨⟩, s) from rfl]
+      rfl
+  | .liftBind a next, s => by
+      cases hs : s a with
+      | nil => rw [run_liftBind_of_nil next hs, runPath_liftBind_of_nil next hs]; rfl
+      | cons u us =>
+          rw [run_liftBind_of_cons next hs, runPath_liftBind_of_cons next hs,
+            run_eq_map_runPath (next u) (s.update a us), Option.map_map]
+          rfl
+
+/-! ### What the run consumed -/
+
+/-- **A run leaves behind exactly what it did not read.** At every position, the remaining supply
+is that position's list with one answer dropped per event the executed trace has there. -/
+theorem apply_eq_drop_occurrences : ∀ (program : FreeM P α) {s s' : Supply P}
+    {path : FreeM.Path program}, runPath program s = some (path, s') → ∀ b : P.A,
+      s' b = (s b).drop (TraceList.occurrences b (FreeM.Path.trace program path))
+  | .pure y, s, s', path, h, b => by
+      rw [show runPath (FreeM.pure y : FreeM P α) s = some (⟨⟩, s) from rfl, Option.some.injEq,
+        Prod.mk.injEq] at h
+      obtain ⟨-, rfl⟩ := h
+      rfl
+  | .liftBind a next, s, s', path, h, b => by
+      classical
+      cases hs : s a with
+      | nil => rw [runPath_liftBind_of_nil next hs] at h; simp at h
+      | cons u us =>
+          rw [runPath_liftBind_of_cons next hs, Option.map_eq_some_iff] at h
+          obtain ⟨r, hrec, heq⟩ := h
+          obtain ⟨tail, s''⟩ := r
+          simp only [Prod.mk.injEq] at heq
+          obtain ⟨rfl, rfl⟩ := heq
+          have hih := apply_eq_drop_occurrences (next u) hrec b
+          by_cases hb : b = a
+          · subst hb
+            rw [hih, update_apply_self, trace_liftBind', occurrences_cons_self, hs,
+              List.drop_succ_cons]
+          · rw [hih, update_apply_of_ne _ _ _ hb, trace_liftBind', occurrences_cons_of_ne hb]
+
+/-- **The bridge to the trace.** The answer a run took at the `n`-th occurrence of a position is
+the supply's `n`-th answer there. A supply therefore *positionally* determines the trace, which is
+what lets the occurrence and cursor layers reason about it. -/
+theorem getAt?_trace_runPath (program : FreeM P α) : ∀ (b : P.A) (n : Nat) (s s' : Supply P)
+    (path : FreeM.Path program), runPath program s = some (path, s') →
+      n < TraceList.occurrences b (FreeM.Path.trace program path) →
+        TraceList.getAt? (FreeM.Path.trace program path) b n = (s b)[n]? := by
+  classical
+  induction program with
+  | pure y =>
+      intro b n s s' path h hn
+      rw [runPath_pure, Option.some.injEq, Prod.mk.injEq] at h
+      obtain ⟨rfl, rfl⟩ := h
+      simp [TraceList.occurrences] at hn
+  | lift_bind a next ih =>
+      intro b n s s' path h hn
+      -- The recursor presents the node as `(FreeM.lift a).bind next`; name it by its constructor.
+      replace h : runPath (FreeM.liftBind a next) s = some (path, s') := h
+      replace hn : n < TraceList.occurrences b
+        (FreeM.Path.trace (FreeM.liftBind a next) path) := hn
+      suffices hgoal : TraceList.getAt? (FreeM.Path.trace (FreeM.liftBind a next) path) b n
+          = (s b)[n]? from hgoal
+      cases hs : s a with
+      | nil => rw [runPath_liftBind_of_nil next hs] at h; simp at h
+      | cons u us =>
+          rw [runPath_liftBind_of_cons next hs] at h
+          obtain ⟨r, hrec, heq⟩ := Option.map_eq_some_iff.mp h
+          obtain ⟨tail, s''⟩ := r
+          simp only at heq
+          obtain ⟨rfl, rfl⟩ := heq
+          rw [trace_liftBind'] at hn ⊢
+          by_cases hb : b = a
+          · subst hb
+            cases n with
+            | zero => rw [TraceList.getAt?_cons_self_zero, hs]; rfl
+            | succ n =>
+                rw [occurrences_cons_self] at hn
+                have hih := ih u b n (s.update b us) s' tail hrec (by omega)
+                rw [TraceList.getAt?_cons_self_succ, hih, update_apply_self, hs]
+                rfl
+          · rw [occurrences_cons_of_ne hb] at hn
+            have hih := ih u b n (s.update a us) s' tail hrec hn
+            rw [TraceList.getAt?_cons_of_ne (fun h : a = b => hb h.symm), hih,
+              update_apply_of_ne _ _ _ hb]
+
+/-- A run never reads more answers at a position than the supply offers there. -/
+theorem occurrences_le_length {program : FreeM P α} {s s' : Supply P} {path : FreeM.Path program}
+    (h : runPath program s = some (path, s')) (b : P.A) :
+    TraceList.occurrences b (FreeM.Path.trace program path) ≤ (s b).length := by
+  rcases Nat.eq_zero_or_pos (TraceList.occurrences b (FreeM.Path.trace program path)) with hz | hp
+  · omega
+  · have hlt : TraceList.occurrences b (FreeM.Path.trace program path) - 1 <
+        TraceList.occurrences b (FreeM.Path.trace program path) := by omega
+    have hsome := TraceList.getAt?_isSome_iff_lt_occurrences
+      (events := FreeM.Path.trace program path) (target := b)
+      (n := TraceList.occurrences b (FreeM.Path.trace program path) - 1) |>.mpr hlt
+    rw [getAt?_trace_runPath program b _ s s' path h hlt] at hsome
+    obtain ⟨x, hx⟩ := Option.isSome_iff_exists.mp hsome
+    obtain ⟨hlt', -⟩ := List.getElem?_eq_some_iff.mp hx
+    omega
+
+/-- The run's consumption, as a length. -/
+theorem length_add_occurrences {program : FreeM P α} {s s' : Supply P} {path : FreeM.Path program}
+    (h : runPath program s = some (path, s')) (b : P.A) :
+    (s' b).length + TraceList.occurrences b (FreeM.Path.trace program path) = (s b).length := by
+  have hle := occurrences_le_length h b
+  rw [apply_eq_drop_occurrences program h b, List.length_drop]
+  omega
+
+/-! ### Substitution is substitution at an occurrence -/
+
+variable {program : FreeM P α} {s s' : Supply P} {a : P.A} {n : Nat} {u : P.B a}
+
+/-- **Substituting the supply substitutes the trace.** If the run reaches the `n`-th occurrence of
+`a` at all, the answer it takes there is the substituted one. -/
+theorem getAt?_trace_runPath_setAt (hn : n < (s a).length) {path : FreeM.Path program}
+    (h : runPath program (s.setAt a n u) = some (path, s'))
+    (hocc : n < TraceList.occurrences a (FreeM.Path.trace program path)) :
+    TraceList.getAt? (FreeM.Path.trace program path) a n = some u := by
+  rw [getAt?_trace_runPath program a n _ s' path h hocc, getElem?_setAt_self s a u hn]
+
+/-- Every other answer at the substituted position is untouched. -/
+theorem getAt?_trace_runPath_setAt_of_ne {m : Nat} (hm : m ≠ n) {path : FreeM.Path program}
+    (h : runPath program (s.setAt a n u) = some (path, s'))
+    (hocc : m < TraceList.occurrences a (FreeM.Path.trace program path)) :
+    TraceList.getAt? (FreeM.Path.trace program path) a m = (s a)[m]? := by
+  rw [getAt?_trace_runPath program a m _ s' path h hocc, setAt_apply_self,
+    List.getElem?_set_ne (Ne.symm hm)]
+
+/-- And so is every answer at every other position. -/
+theorem getAt?_trace_runPath_setAt_of_pos_ne {b : P.A} (hb : b ≠ a) {m : Nat}
+    {path : FreeM.Path program} (h : runPath program (s.setAt a n u) = some (path, s'))
+    (hocc : m < TraceList.occurrences b (FreeM.Path.trace program path)) :
+    TraceList.getAt? (FreeM.Path.trace program path) b m = (s b)[m]? := by
+  rw [getAt?_trace_runPath program b m _ s' path h hocc, setAt_apply_of_ne _ _ _ _ hb]
+
+end Supply
+
+end PFunctor

--- a/PolyFunTest/PFunctor/SupplyTraceExamples.lean
+++ b/PolyFunTest/PFunctor/SupplyTraceExamples.lean
@@ -1,0 +1,99 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+module
+
+public import PolyFun.PFunctor.Supply.Trace
+public import PolyFunTest.PFunctor.SupplyExamples
+
+/-! # What a run against a supply reads — examples
+
+`exampleSupply` answers `target` with `[true, true]`, so the run takes the branch that asks
+`target` twice. Substituting the first of those answers sends it down the branch that asks only
+once, so the substituted run reads a *shorter* trace — which is what makes the statements below
+about the untouched positions worth checking rather than reading off a common prefix.
+-/
+
+@[expose] public section
+
+open PFunctor
+
+namespace PFunctor.FreeM.Cursor
+
+/-- The path the supply selects. -/
+example : (Supply.runPath nestedProgram exampleSupply).map Prod.fst
+    = some nestedTrueTruePath := rfl
+
+/-- `run` is `runPath` with the path forgotten. -/
+example : Supply.run nestedProgram exampleSupply
+    = (Supply.runPath nestedProgram exampleSupply).map fun r =>
+        (output nestedProgram r.1, r.2) :=
+  Supply.run_eq_map_runPath nestedProgram exampleSupply
+
+/-- Its trace: one `noise` event and two `target` events. -/
+example : Path.trace nestedProgram nestedTrueTruePath
+    = [(⟨ExampleOp.noise, noiseOne⟩ : ExampleQuery.Idx),
+      ⟨ExampleOp.target, true⟩, ⟨ExampleOp.target, true⟩] := rfl
+
+example : PFunctor.TraceList.occurrences ExampleOp.target
+    (Path.trace nestedProgram nestedTrueTruePath) = 2 := by decide
+
+/-- **The bridge at concrete data.** The answer taken at the second `target` occurrence is the
+supply's second `target` answer. -/
+example : PFunctor.TraceList.getAt? (Path.trace nestedProgram nestedTrueTruePath)
+      ExampleOp.target 1 = (exampleSupply ExampleOp.target)[1]? := by
+  obtain ⟨s', hs'⟩ : ∃ s', Supply.runPath nestedProgram exampleSupply
+      = some (nestedTrueTruePath, s') := ⟨_, rfl⟩
+  exact Supply.getAt?_trace_runPath nestedProgram ExampleOp.target 1 exampleSupply s'
+    nestedTrueTruePath hs' (by decide)
+
+/-! ## Substituting one answer -/
+
+/-- Substituting the first `target` answer sends the run down the shorter branch. -/
+example : (Supply.runPath nestedProgram
+      (exampleSupply.setAt ExampleOp.target 0 false)).map Prod.fst
+    = some nestedFalsePath := rfl
+
+/-- That branch reads only one `target` answer, so the substituted supply's second answer is never
+looked at. -/
+example : PFunctor.TraceList.occurrences ExampleOp.target
+    (Path.trace nestedProgram nestedFalsePath) = 1 := by decide
+
+/-- **Substituting the supply substitutes the trace.** -/
+example : PFunctor.TraceList.getAt? (Path.trace nestedProgram nestedFalsePath)
+      ExampleOp.target 0 = some false := by
+  obtain ⟨s', hs'⟩ : ∃ s', Supply.runPath nestedProgram
+      (exampleSupply.setAt ExampleOp.target 0 false) = some (nestedFalsePath, s') := ⟨_, rfl⟩
+  exact Supply.getAt?_trace_runPath_setAt (by decide) hs' (by decide)
+
+/-- **And leaves every other position alone.** The `noise` answer is still the supply's own, even
+though the substituted run follows a different branch from here on. -/
+example : PFunctor.TraceList.getAt? (Path.trace nestedProgram nestedFalsePath)
+      ExampleOp.noise 0 = (exampleSupply ExampleOp.noise)[0]? := by
+  obtain ⟨s', hs'⟩ : ∃ s', Supply.runPath nestedProgram
+      (exampleSupply.setAt ExampleOp.target 0 false) = some (nestedFalsePath, s') := ⟨_, rfl⟩
+  exact Supply.getAt?_trace_runPath_setAt_of_pos_ne (by decide) hs' (by decide)
+
+/-- The completion the occurrence layer builds from that same substituted answer carries it at the
+same index, so the two accounts of "the answer at occurrence `0` of `target`" agree. -/
+example : PFunctor.TraceList.getAt? (Path.trace nestedProgram nestedFork.first.path)
+      ExampleOp.target 0 = PFunctor.TraceList.getAt?
+        (Path.trace nestedProgram nestedFalsePath) ExampleOp.target 0 := rfl
+
+/-! ## What the run consumed -/
+
+/-- The shorter run leaves one `target` answer behind, and the accounting lemma says so. -/
+example : ∀ s' : Supply ExampleQuery, Supply.runPath nestedProgram
+      (exampleSupply.setAt ExampleOp.target 0 false) = some (nestedFalsePath, s') →
+    (s' ExampleOp.target).length + 1 = 2 := by
+  intro s' h
+  have hlen := Supply.length_add_occurrences h ExampleOp.target
+  rw [show PFunctor.TraceList.occurrences ExampleOp.target
+      (Path.trace nestedProgram nestedFalsePath) = 1 from by decide,
+    show ((exampleSupply.setAt ExampleOp.target 0 false) ExampleOp.target).length = 2 from rfl]
+    at hlen
+  exact hlen
+
+end PFunctor.FreeM.Cursor


### PR DESCRIPTION
## Summary

Follow-up to #133. `Supply.run` returns only the leaf, so nothing it does can be compared with the path-indexed layers above it — cursors, occurrence contexts, fork views. This adds `Supply.runPath`, the same execution retaining the typed `FreeM.Path` it selected, and the laws that make positional substitution on a supply *mean* substitution at an occurrence of the executed trace.

## What is new

`PolyFun/PFunctor/Supply/Trace.lean`:

- `Supply.runPath` and its evaluation lemmas, with `run_eq_map_runPath`: `run` is `runPath` followed by reading the leaf off the path, so every statement below is a statement about `run`.
- **The bridge**, `getAt?_trace_runPath`:
  ```lean
  getAt? (Path.trace program path) b n = (s b)[n]?
  ```
  for every occurrence the run reaches. The answer taken at the `n`-th occurrence of a position *is* the supply's `n`-th answer there, so a supply positionally determines the executed trace.
- The rewind laws that follow. `getAt?_trace_runPath_setAt`: the substituted run takes the substituted answer at exactly that occurrence. `getAt?_trace_runPath_setAt_of_ne` and `getAt?_trace_runPath_setAt_of_pos_ne`: every other answer it takes is the one it would have taken anyway. That is the shared-prefix property `Cursor.ForkView` gets by construction from retaining its occurrence context, now available for supplies.
- `apply_eq_drop_occurrences`, the accounting underneath: a run leaves behind exactly what it did not read, so the remaining supply at a position is that position's list with one answer dropped per trace event there. `length_add_occurrences` and `occurrences_le_length` are its numeric corollaries.

`PolyFunTest/PFunctor/SupplyTraceExamples.lean` exercises all of it on the existing nested fixture. Substituting the first `target` answer there sends the run down a *shorter* branch, so the untouched-position statements are not just reading off a common prefix.

## Why

Downstream (VCVio) has two independent forking developments — a seeded one that truncates and appends a `QuerySeed`, and a replay one built on `Cursor.ForkView` — that today share no prefix-invariance reasoning at all. `QuerySeed` is definitionally a `Supply`, so this is the shared core: it is the statement that lets the seeded side inherit what the cursor side knows.

## Notes for review

- The file carries the same `attribute [local implicit_reducible] FreeMonoid PFunctor.Idx` as `Cursor/Occurrence.lean`, for the same Lean 4.33 reason.
- `getAt?_trace_runPath` is a tactic induction rather than equation-compiler recursion: the recursive call's proof argument mentions `path`, whose type depends on `program`, and the structural checker cannot eliminate it.
- `trace_liftBind'` restates `Path.trace_liftBind` in the `FreeM.liftBind` spelling; `Path.trace_liftBind` is stated with `(FreeM.lift a).bind next` and does not match syntactically.

## Validation

- `./scripts/validate.sh` (build, module scopes, umbrella imports, docs integrity)
- `./scripts/validate.sh --lint --test`
- `./scripts/validate.sh --axioms` — zero axiom/sorry debt

🤖 Generated with [Claude Code](https://claude.com/claude-code)