### PR TITLE
fix(scripts): use grep for the broad-expose ban in check-modules.sh

### DIFF
--- a/scripts/check-modules.sh
+++ b/scripts/check-modules.sh
@@ -23,7 +23,7 @@ while IFS= read -r file; do
   fi
 done < <(git ls-files -- 'PolyFun/Interaction/*.lean')
 
-if rg -n '@\[expose\][[:space:]]+public section' PolyFun/Interaction --glob '*.lean'; then
+if grep -rEn --include='*.lean' '@\[expose\][[:space:]]+public section' PolyFun/Interaction; then
   echo "ERROR: Broad exposed public sections are forbidden in PolyFun/Interaction." >&2
   echo "Expose individual definitions, or use 'import all' in proof modules." >&2
   status=1


### PR DESCRIPTION
The `@[expose] public section` ban in `scripts/check-modules.sh` shelled out to
`rg`. Since the call sits in an `if` condition, a missing binary is
indistinguishable from "no matches" — the script prints its success line and
exits 0 without ever having run the check:

```
$ ./scripts/check-modules.sh
./scripts/check-modules.sh: line 26: rg: command not found
✓ Module scopes and Interaction API boundaries are valid.
```

Silence from a linter should mean the invariant holds, not that the tool was
missing. `rg` is not part of a POSIX base system and is absent on at least some
development machines, so this switches to `grep -rEn --include='*.lean'`.

The rest of the script already depends only on `grep`, and the ERE pattern is
the one `rg` was already matching, so behavior is unchanged wherever `rg` was in
fact installed — including CI, whose `ubuntu-latest` image ships ripgrep. The
gap this closes is local runs of `./scripts/validate.sh`, where the check was
silently skipped.

## Verification

Injecting `@[expose] public section` into an Interaction module now reports the
offending location and fails:

```
PolyFun/Interaction/Multiparty/Observation.lean:105:@[expose] public section
ERROR: Broad exposed public sections are forbidden in PolyFun/Interaction.
Expose individual definitions, or use 'import all' in proof modules.
exit=1
```

and a clean tree still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
