### PR TITLE
feat(uc): add family-indexed structural theories

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,6 +249,8 @@ too specific or too changeable to keep at the repo root.
   framework (`TypeTree`, two-party, multiparty, concurrent, UC).
 - [`docs/wiki/realizability.md`](docs/wiki/realizability.md): step classes and
   realizability of free programs by admissible state machines.
+- [`docs/wiki/uc.md`](docs/wiki/uc.md): UC semantic contract, paper-to-code
+  ledger, observation boundaries, and the PolyFun/VCVio split.
 - [`docs/wiki/notation.md`](docs/wiki/notation.md): notation reference (UC
   composition operators).
 - [`docs/wiki/gotchas.md`](docs/wiki/gotchas.md): recurring traps and

--- a/PolyFun.lean
+++ b/PolyFun.lean
@@ -117,6 +117,7 @@ public import PolyFun.Interaction.UC.OpenSyntax.Expr
 public import PolyFun.Interaction.UC.OpenSyntax.Interp
 public import PolyFun.Interaction.UC.OpenSyntax.Raw
 public import PolyFun.Interaction.UC.OpenTheory
+public import PolyFun.Interaction.UC.OpenTheory.Family
 public import PolyFun.Interaction.UC.SubTheory
 public import PolyFun.Logic.HEq
 public import PolyFun.PFunctor.Adjunctions

--- a/PolyFun/Interaction/UC/OpenTheory/Family.lean
+++ b/PolyFun/Interaction/UC/OpenTheory/Family.lean
@@ -1,0 +1,167 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+
+module
+
+public import PolyFun.Interaction.UC.SubTheory
+
+/-!
+# Pointwise families of open theories
+
+This module packages an indexed family `T : ι → OpenTheory` as one open
+theory whose systems are indexed families of systems. All structural
+operations act pointwise, so every tier of the `OpenTheory` lawfulness
+hierarchy lifts componentwise.
+
+The construction is structural and does not assign any computational
+meaning to the index. A downstream development may instantiate `ι` with a
+security parameter and put an asymptotic observation on the resulting
+closed-system families without introducing probability or complexity into
+PolyFun.
+
+`SubTheory.pi` similarly packages a family of allowed-system predicates as
+one sub-theory. Its membership condition is uniform at the family level:
+callers may instead define a custom sub-theory when admissibility relates
+different indices, as polynomial-time realizability normally does.
+-/
+
+public section
+
+universe u v
+
+namespace Interaction
+namespace UC
+
+namespace OpenTheory
+
+/-- The pointwise open theory associated to a family `T : ι → OpenTheory`.
+
+An object at boundary `Δ` selects an object of `T i` at the same boundary for
+every index `i`. Boundary adaptation, parallel composition, wiring, and
+plugging are all performed pointwise. -/
+@[expose]
+def pi {ι : Type v} (T : ι → UC.OpenTheory.{u}) : UC.OpenTheory.{max u v} where
+  Obj Δ := ∀ i, (T i).Obj Δ
+  map f W i := (T i).map f (W i)
+  par W₁ W₂ i := (T i).par (W₁ i) (W₂ i)
+  wire W₁ W₂ i := (T i).wire (W₁ i) (W₂ i)
+  plug W K i := (T i).plug (W i) (K i)
+
+instance {ι : Type v} {T : ι → UC.OpenTheory.{u}}
+    [∀ i, HasUnit (T i)] : HasUnit (pi T) where
+  unit i := HasUnit.unit (T := T i)
+
+instance {ι : Type v} {T : ι → UC.OpenTheory.{u}}
+    [∀ i, HasIdWire (T i)] : HasIdWire (pi T) where
+  idWire Γ i := HasIdWire.idWire (T := T i) Γ
+
+instance {ι : Type v} {T : ι → UC.OpenTheory.{u}}
+    [∀ i, IsLawfulMap (T i)] : IsLawfulMap (pi T) where
+  map_id W := funext fun i => OpenTheory.map_id (T := T i) (W i)
+  map_comp g f W := funext fun i => OpenTheory.map_comp (T := T i) g f (W i)
+
+instance {ι : Type v} {T : ι → UC.OpenTheory.{u}}
+    [∀ i, IsLawfulPar (T i)] : IsLawfulPar (pi T) where
+  map_id W := funext fun i => OpenTheory.map_id (T := T i) (W i)
+  map_comp g f W := funext fun i => OpenTheory.map_comp (T := T i) g f (W i)
+  map_par f₁ f₂ W₁ W₂ :=
+    funext fun i => OpenTheory.map_par (T := T i) f₁ f₂ (W₁ i) (W₂ i)
+
+instance {ι : Type v} {T : ι → UC.OpenTheory.{u}}
+    [∀ i, IsLawfulWire (T i)] : IsLawfulWire (pi T) where
+  map_id W := funext fun i => OpenTheory.map_id (T := T i) (W i)
+  map_comp g f W := funext fun i => OpenTheory.map_comp (T := T i) g f (W i)
+  map_wire f₁ f₂ W₁ W₂ :=
+    funext fun i => OpenTheory.map_wire (T := T i) f₁ f₂ (W₁ i) (W₂ i)
+
+instance {ι : Type v} {T : ι → UC.OpenTheory.{u}}
+    [∀ i, IsLawfulPlug (T i)] : IsLawfulPlug (pi T) where
+  map_id W := funext fun i => OpenTheory.map_id (T := T i) (W i)
+  map_comp g f W := funext fun i => OpenTheory.map_comp (T := T i) g f (W i)
+  map_plug f W K := funext fun i => OpenTheory.map_plug (T := T i) f (W i) (K i)
+
+instance {ι : Type v} {T : ι → UC.OpenTheory.{u}}
+    [∀ i, IsLawful (T i)] : IsLawful (pi T) where
+  map_id W := funext fun i => OpenTheory.map_id (T := T i) (W i)
+  map_comp g f W := funext fun i => OpenTheory.map_comp (T := T i) g f (W i)
+  map_par f₁ f₂ W₁ W₂ :=
+    funext fun i => OpenTheory.map_par (T := T i) f₁ f₂ (W₁ i) (W₂ i)
+  map_wire f₁ f₂ W₁ W₂ :=
+    funext fun i => OpenTheory.map_wire (T := T i) f₁ f₂ (W₁ i) (W₂ i)
+  map_plug f W K := funext fun i => OpenTheory.map_plug (T := T i) f (W i) (K i)
+
+instance {ι : Type v} {T : ι → UC.OpenTheory.{u}}
+    [∀ i, IsMonoidal (T i)] : IsMonoidal (pi T) where
+  toIsLawful := inferInstance
+  toHasUnit := inferInstance
+  par_assoc W₁ W₂ W₃ :=
+    funext fun i => OpenTheory.par_assoc (T := T i) (W₁ i) (W₂ i) (W₃ i)
+  par_comm W₁ W₂ :=
+    funext fun i => OpenTheory.par_comm (T := T i) (W₁ i) (W₂ i)
+  par_leftUnit W :=
+    funext fun i => OpenTheory.par_leftUnit (T := T i) (W i)
+  par_rightUnit W :=
+    funext fun i => OpenTheory.par_rightUnit (T := T i) (W i)
+
+instance {ι : Type v} {T : ι → UC.OpenTheory.{u}}
+    [∀ i, IsTraced (T i)] : IsTraced (pi T) where
+  toIsMonoidal := inferInstance
+  wire_assoc W₁ W₂ W₃ :=
+    funext fun i => OpenTheory.wire_assoc (T := T i) (W₁ i) (W₂ i) (W₃ i)
+  wire_par_superpose W₁ W₂ W₃ :=
+    funext fun i => OpenTheory.wire_par_superpose (T := T i) (W₁ i) (W₂ i) (W₃ i)
+  wire_comm W₁ W₂ :=
+    funext fun i => OpenTheory.wire_comm (T := T i) (W₁ i) (W₂ i)
+
+instance {ι : Type v} {T : ι → UC.OpenTheory.{u}}
+    [∀ i, IsCompactClosed (T i)] : IsCompactClosed (pi T) where
+  toIsTraced := inferInstance
+  toHasIdWire := inferInstance
+  wire_idWire _Γ _ W₂ :=
+    funext fun i => OpenTheory.wire_idWire (T := T i) (W₂ i)
+  wire_idWire_right _Γ _ W₁ :=
+    funext fun i => OpenTheory.wire_idWire_right (T := T i) (W₁ i)
+  unit_eq := funext fun i => OpenTheory.unit_eq (T := T i)
+
+instance {ι : Type v} {T : ι → UC.OpenTheory.{u}}
+    [∀ i, HasPlugWireFactor (T i)] : HasPlugWireFactor (pi T) where
+  toIsCompactClosed := inferInstance
+  plug_eq_wire W K :=
+    funext fun i => OpenTheory.plug_eq_wire (T := T i) (W i) (K i)
+  plug_par_left W₁ W₂ K :=
+    funext fun i => OpenTheory.plug_par_left (T := T i) (W₁ i) (W₂ i) (K i)
+  plug_wire_left W₁ W₂ K :=
+    funext fun i => OpenTheory.plug_wire_left (T := T i) (W₁ i) (W₂ i) (K i)
+
+end OpenTheory
+
+namespace SubTheory
+
+/-- The pointwise sub-theory of an indexed family of sub-theories. -/
+@[expose]
+def pi {ι : Type v} {T : ι → OpenTheory.{u}} (D : ∀ i, SubTheory (T i)) :
+    SubTheory (OpenTheory.pi T) where
+  mem W := ∀ i, (D i).mem (W i)
+  mem_map f hW i := (D i).mem_map f (hW i)
+  mem_par hW₁ hW₂ i := (D i).mem_par (hW₁ i) (hW₂ i)
+  mem_wire hW₁ hW₂ i := (D i).mem_wire (hW₁ i) (hW₂ i)
+
+instance {ι : Type v} {T : ι → OpenTheory.{u}}
+    {D : ∀ i, SubTheory (T i)} [∀ i, (D i).IsPlugClosed] :
+    (pi D).IsPlugClosed where
+  mem_plug hW hK i := SubTheory.IsPlugClosed.mem_plug (D := D i) (hW i) (hK i)
+
+instance {ι : Type v} {T : ι → OpenTheory.{u}}
+    {D : ∀ i, SubTheory (T i)} [∀ i, OpenTheory.HasUnit (T i)]
+    [∀ i, OpenTheory.HasIdWire (T i)] [∀ i, (D i).IsStructural] :
+    (pi D).IsStructural where
+  mem_unit i := SubTheory.IsStructural.mem_unit (D := D i)
+  mem_idWire Γ i := SubTheory.IsStructural.mem_idWire (D := D i) Γ
+
+end SubTheory
+
+end UC
+end Interaction

--- a/PolyFunTest/Interaction/UC/FamilyExamples.lean
+++ b/PolyFunTest/Interaction/UC/FamilyExamples.lean
@@ -1,0 +1,53 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+
+module
+
+public import PolyFun.Interaction.UC.OpenSyntax.Expr
+public import PolyFun.Interaction.UC.OpenTheory.Family
+
+/-!
+# Pointwise open-theory family examples
+
+These examples pin the intended use of `OpenTheory.pi`: structural laws and
+allowed-system predicates lift componentwise while the family index remains
+semantically uninterpreted by PolyFun.
+-/
+
+public section
+
+universe u
+
+namespace Interaction.UC.OpenTheoryFamilyExamples
+
+variable {Atom : PortBoundary → Type u}
+
+abbrev ExprFamily : OpenTheory :=
+  OpenTheory.pi (fun _ : Nat => OpenSyntax.Expr.theory Atom)
+
+example : OpenTheory.HasPlugWireFactor (ExprFamily (Atom := Atom)) := inferInstance
+
+abbrev TopFamily : SubTheory (ExprFamily (Atom := Atom)) :=
+  SubTheory.pi (fun _ : Nat => SubTheory.top (OpenSyntax.Expr.theory Atom))
+
+example : (TopFamily (Atom := Atom)).IsPlugClosed := inferInstance
+
+example : (TopFamily (Atom := Atom)).IsStructural := inferInstance
+
+example {Δ : PortBoundary} (W : (ExprFamily (Atom := Atom)).Obj Δ) :
+    (ExprFamily (Atom := Atom)).map (PortBoundary.Hom.id Δ) W = W :=
+  OpenTheory.map_id W
+
+example {Δ₁ Δ₂ : PortBoundary}
+    {W₁ : (ExprFamily (Atom := Atom)).Obj Δ₁}
+    {W₂ : (ExprFamily (Atom := Atom)).Obj Δ₂}
+    (hW₁ : (TopFamily (Atom := Atom)).mem W₁)
+    (hW₂ : (TopFamily (Atom := Atom)).mem W₂) :
+    (TopFamily (Atom := Atom)).mem ((ExprFamily (Atom := Atom)).par W₁ W₂) :=
+  (TopFamily (Atom := Atom)).mem_par hW₁ hW₂
+
+end Interaction.UC.OpenTheoryFamilyExamples
+

--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -150,6 +150,90 @@ schema/context distinction underlies node-context schemas.
 
 Used in: `PolyFun/Interaction/Basic/Node.lean`.
 
+### FKKKT26 — Farshim, Karvonen, Knispel, Kohlweiss, Tyagi, *UC, Categorically*
+
+Pooya Farshim, Martti Karvonen, André Knispel, Markulf Kohlweiss, and
+Shravan Tyagi.
+*UC, Categorically: Rigorous Diagrammatic Proofs*.
+Cryptology ePrint Archive, Report 2026/1605; arXiv:2608.04521, 2026.
+
+A categorical account of static/simple universal composability in which
+computational indistinguishability is an equivalence on resources closed
+under sequential and parallel composition. It supplies the external
+instantiation contract tracked in `docs/wiki/uc.md`; probability and
+efficiency remain downstream obligations.
+
+Used in: `docs/wiki/uc.md`.
+
+### CSV19 — Canetti, Stoughton, Varia, *EasyUC*
+
+Ran Canetti, Alley Stoughton, and Mayank Varia.
+*EasyUC: Using EasyCrypt to Mechanize Proofs of Universally Composable
+Security*.
+IEEE Computer Security Foundations Symposium (CSF), pp. 167–183, 2019.
+DOI: <https://doi.org/10.1109/CSF.2019.00019>; ePrint 2019/582.
+
+An EasyCrypt realization of a restricted UC model and a composed secure
+messaging case study. Its experience with routing boilerplate and the mismatch
+between procedure calls and coroutine communication informs the typed-boundary
+and control-transfer requirements in the UC audit.
+
+Used in: `docs/wiki/uc.md`.
+
+### KTR20 — Küsters, Tuengerthal, Rausch, *The IITM Model*
+
+Ralf Küsters, Max Tuengerthal, and Daniel Rausch.
+*The IITM Model: A Simple and Expressive Model for Universal Composability*.
+*Journal of Cryptology* 33, pp. 1461–1584, 2020.
+DOI: <https://doi.org/10.1007/s00145-020-09352-1>.
+
+A UC model with named tapes, explicit environmental boundedness, dummy
+forwarding, and theorems relating networks of IITMs to single machines. It is
+the main comparison point for the efficiency and addressing obligations that
+PolyFun deliberately leaves to an instantiation.
+
+Used in: `docs/wiki/uc.md`.
+
+### HARM+23 — Haselwarter et al., *SSProve*
+
+Philipp G. Haselwarter, Exequiel Rivas, Antoine Van Muylder, Théo
+Winterhalter, Carmine Abate, Nikolaj Sidorenco, Cătălin Hrițcu, Kenji
+Maillard, and Bas Spitters.
+*SSProve: A Foundational Framework for Modular Cryptographic Proofs in Coq*.
+*ACM Transactions on Programming Languages and Systems* 45(3), 2023.
+DOI: <https://doi.org/10.1145/3594735>; ePrint 2021/397.
+
+Free-monad cryptographic packages, sequential and parallel composition, and
+machine-checked algebraic package laws connected to a probabilistic relational
+program logic.
+
+Used in: `docs/wiki/uc.md`.
+
+### LS25-N — Larsen and Schürmann, *Nominal State-Separating Proofs*
+
+Markus Krabbe Larsen and Carsten Schürmann.
+*Nominal State-Separating Proofs*.
+IEEE Computer Security Foundations Symposium (CSF), 2025; ePrint 2025/598.
+
+A nominal extension of SSProve in which packages receive local state-name
+spaces and composition automatically avoids capture. It makes explicit the
+modularity cost of globally named mutable state.
+
+Used in: `docs/wiki/uc.md`.
+
+### PKWC24 — Patrignani, Künnemann, Wahby, Cecchetti, *Universal Composability Is Robust Compilation*
+
+Marco Patrignani, Robert Künnemann, Riad S. Wahby, and Ethan Cecchetti.
+*Universal Composability Is Robust Compilation*.
+*ACM Transactions on Programming Languages and Systems* 46(4), Article 13,
+pp. 1–64, 2024. DOI: <https://doi.org/10.1145/3698234>;
+arXiv:1910.08634.
+
+An axiomatic comparison between UC and robust compilation, including explicit
+interface and composition requirements and mechanized symbolic case studies.
+
+Used in: `docs/wiki/uc.md`.
+
 ### FGMPS07 — Foster, Greenwald, Moore, Pierce, Schmitt, *Combinators for bidirectional tree transformations*
 
 J. Nathan Foster, Michael B. Greenwald, Jonathan T. Moore,

--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -49,6 +49,8 @@ See the *Wiki Maintenance Contract* section in
 - [`realizability.md`](realizability.md): realizability of free programs by
   state machines whose transition functions satisfy a given predicate
   (`StepClass`, `Realization`, `IsRealizableBy`).
+- [`uc.md`](uc.md): UC semantic contract, paper-to-code traceability ledger,
+  observation boundaries, and PolyFun/VCVio ownership split.
 
 ## Cross-Cutting Notes
 
@@ -73,6 +75,7 @@ See the *Wiki Maintenance Contract* section in
   - `itree.md` for interaction trees, bisimulation, and handlers.
   - `interaction.md` for the interaction framework above `FreeM`.
   - `realizability.md` for step classes and machine realizability.
+  - `uc.md` for the UC semantic contract and external-model alignment.
   - `notation.md` for notation cross-references.
   - `gotchas.md` for recurring traps.
 - Add new pages when a recurring topic no longer fits cleanly in an existing

--- a/docs/wiki/interaction.md
+++ b/docs/wiki/interaction.md
@@ -1,5 +1,8 @@
 # Interaction Framework
 
+For the UC paper-to-code ledger, observation boundary, and precise
+PolyFun/VCVio ownership split, see [`uc.md`](uc.md).
+
 General-purpose protocol interaction theory: sequential type trees, two-party
 roles, multiparty local views, and concurrent process semantics. PolyFun's
 [`PolyFun/Interaction/`](../../PolyFun/Interaction/) is intentionally

--- a/docs/wiki/repo-map.md
+++ b/docs/wiki/repo-map.md
@@ -188,6 +188,8 @@ Interaction/{Concurrent, Basic} -> Interaction/UC/{Interface,
                                    MomentaryCorruption, Leakage}
 
 Interaction/UC/OpenTheory -> Interaction/UC/SubTheory
+Interaction/UC/{OpenTheory, SubTheory}
+  -> Interaction/UC/OpenTheory/Family
 Interaction/UC/{Emulates, SubTheory} -> Interaction/UC/EmulatesWithin
 Interaction/UC/{OpenSyntax/Expr, SubTheory}
   -> Interaction/UC/OpenSyntax/AtomSubTheory

--- a/docs/wiki/uc.md
+++ b/docs/wiki/uc.md
@@ -1,0 +1,137 @@
+# UC Semantic Contract
+
+This page is the traceability ledger for PolyFun's structural UC layer. Lean
+source remains authoritative. The external comparison target is Farshim,
+Karvonen, Knispel, Kohlweiss, and Tyagi, *UC, Categorically: Rigorous
+Diagrammatic Proofs* (ePrint 2026/1605; arXiv:2608.04521).
+
+## Scope And Dependency Boundary
+
+PolyFun owns typed boundaries, open systems, structural composition,
+contextual equivalence, corruption-event vocabularies, and classes of allowed
+systems. It does not define probability, distinguishing advantage,
+negligibility, polynomial time, or cryptographic security games. Those are
+VCVio instantiations.
+
+The current comparison target is the paper's static/simple UC fragment.
+Dynamic party or session creation, adaptive topology, and a full translation
+to Canetti ITMs are not claimed by the present layer.
+
+## Three Relations That Must Remain Distinct
+
+1. `OpenProcessActivationEquiv` compares coarse activation structure. It
+   hides internal scheduler steps and forgets packet/action identity and
+   sampler effects.
+2. Boundary or execution equivalence preserves whatever a chosen admissible
+   observer exposes. A downstream semantics must prove its own invariance
+   under scheduler reassociation and structural factorization.
+3. Asymptotic computational indistinguishability relates security-parameter
+   families when their distinguishing distance is negligible.
+
+There is no general implication from (1) to (2), or from (2) to a particular
+computational execution, without a named adequacy theorem. In particular,
+the activation-equivalence factorization theorems in
+`OpenProcessFactorization.lean` are not UC security observations.
+
+## Paper-To-Code Ledger
+
+| Paper surface | PolyFun surface | Status |
+| --- | --- | --- |
+| symmetric monoidal category `C` of interactive systems | `OpenTheory`, with `par`, `wire`, and a granular lawfulness ladder | Candidate model; the free syntax models satisfy the strict laws, while `openTheory` is only `IsLawful` |
+| backdoor category `C_bd` | adversarial ports can be represented by ordinary typed boundary components | Representation strategy only; no equivalence with the paper's backdoor construction or quotient is proved |
+| nested `D_real ⊆ D_bd` | ordered `SubTheory` values | Structural carrier available; no default membership predicate connects it to corruption, realizability, or efficiency |
+| corruption restriction defining `D_real` | `CorruptionModel`, `MomentaryCorruption` | Vocabulary only; no bridge to `SubTheory.mem` |
+| resources/states | open objects closed against contexts | Conceptual correspondence; no translation theorem to the paper's state category |
+| Definition III.3 equivalence closed by composition | `Observation` plus `RespectsPlugComm` and `RespectsFactorization` | Structural interface implemented; equality is the only in-repo observation constructor |
+| Definition III.4 secure emulation | `Emulates`, `EmulatesWithin`, `UCSecure`, `UCSecureWithin` | Implemented structurally; computational instantiation belongs in VCVio |
+| Theorems III.11--III.12 composition | `Emulates{,Within}.{par,wire,plug}_compose` | Proved from observation-level laws |
+| Theorem III.7 and Lemma IV.3 dummy/mux | no generic dummy/mux theorem | Open |
+| Theorem III.14 global subroutines | no global-subroutine instantiation | Open |
+| Section IV-C efficient networks | `SubTheory` is the target interface; `Realizability/StepClass` is under review | Open; qualitative realizability is not a PPT or network-collapse theorem |
+| Theorem IV.6 ITM translation | generic `Party`; optional `MachineId (sid,pid)` frontend | Open; identities are not part of core `OpenTheory` semantics |
+
+`Leakage` is deliberately absent from the `C_bd` row: snapshot leakage and an
+explicit adversarial output interface are not interchangeable constructions.
+
+## Family Construction
+
+`OpenTheory.pi` packages `T : ι → OpenTheory` pointwise. It lets a downstream
+cryptographic development put one equivalence relation on closed-system
+families while keeping the index semantically opaque in PolyFun. Every tier of
+the strict lawfulness hierarchy lifts pointwise. `SubTheory.pi` lifts
+pointwise membership, but polynomial-time membership will normally be a
+custom family-level predicate because one witness and one bound must control
+all security parameters.
+
+## Long-Term Behavior Carrier
+
+The family construction does not choose between process presentations and an
+extensional behavior carrier. VCVio's long-term design proposes mapping open
+processes into cofree behavior and defining a lawful `OpenTheory` there, so
+coherence is proved once by finality instead of carried as activation
+equivalences through every client. `OpenTheory.pi`, `Observation`, and
+`EmulatesWithin` are intentionally parametric in that choice: the same
+asymptotic observation bridge should consume the behavior theory when it
+exists.
+
+This is not a license to identify activation equivalence with distributional
+equivalence. The behavior map needs a named adequacy theorem into VCVio's
+evaluation semantics, and sampling-order transformations that preserve
+distributions may still be coarser than equality of cofree behaviors.
+
+## Equation Surfaces Across The VCVio Seam
+
+Cross-repository proofs should end in named structural or semantic laws. If a
+chain of rewrites still needs a final `rfl`, reduction is supplying part of the
+contract without naming it. Add the missing equation to the layer that owns
+the representation, then consume that equation downstream. Reducer-stable
+constructors explicitly documented as such are the exception.
+
+This matters especially for bundled monad instances, dependent function
+updates, pointwise theory families, and the passage from a closed structural
+system to its observed distribution. The contract should survive changes in
+module exposure and instance elaboration without asking VCVio to unfold
+PolyFun internals.
+
+## Instantiation Gates
+
+The process model supports a computational UC claim only after all of the
+following have named proofs:
+
+1. scheduler reassociation transports the scheduler sampler;
+2. chosen initial states correspond across the structural factorization;
+3. the observer returns the same distribution on corresponding final states;
+4. packet and action identities exposed at the boundary are preserved;
+5. the resulting observation supplies `RespectsFactorization`.
+
+Efficiency is a separate gate. `StepClass` membership constrains which step
+functions are admissible but carries no quantitative total-cost bound.
+Allowed PPT contexts require a family-level machine witness, canonical or
+provably translatable boundary encodings, state-size accounting, and closure
+under the structural compositions consumed by `SubTheory`.
+
+For the quantitative successor, the transition witness must be stated over
+the partial `update?` interface, not the junk-state convention `updateFlat`, so
+sequential bind remains expressible. State growth must either be charged
+additively or be restricted by an explicit cap whose completeness cost is
+documented. Boundary encodings additionally need polynomial translation
+invariance and a word-level coding retraction; injectivity alone is not a
+complexity-invariant interface.
+
+## Related-Model Lessons
+
+- EasyUC (CSV19) made general structural induction over EasyCrypt modules
+  unavailable and required extensive routing loops; its later DSL uses types
+  to reject malformed addresses and coroutine violations. Boundaries and
+  control transfer therefore remain explicit data here.
+- IITM (KTR20) isolates dummy forwarding and replacement of a machine network by one
+  efficient machine as real model properties. PolyFun does not assume either
+  silently.
+- SSProve (HARM+23) demonstrates the value of proving package algebra once;
+  Nominal SSProve (LS25-N) demonstrates the modularity cost of global, non-renamable state
+  names. `MachineId` is consequently an optional policy/translation surface,
+  not the identity notion of the structural core.
+- Robust-compilation accounts (PKWC24) derive UC composition and dummy results from
+  explicit interface axioms. PolyFun follows the same audit discipline:
+  abstractions are added when a theorem consumes them, and failed axioms get
+  regression counterexamples rather than permissive defaults.


### PR DESCRIPTION
Introduces the structural family layer needed to state computational UC over a
security parameter without putting probability, complexity, or cryptographic
games into PolyFun.

## Code

- `OpenTheory.pi` packages `T : ι -> OpenTheory` pointwise.
- Every existing lawfulness tier lifts componentwise: lawful map/par/wire/plug,
  monoidal, traced, compact-closed, and plug/wire factorization.
- `SubTheory.pi` lifts pointwise allowed-system predicates, plug closure, and
  structural membership.
- Tests exercise the family theory and subtheory using the free open syntax.

The index remains semantically opaque. In VCVio it can be a security parameter;
the computational observation and uniform PPT membership predicate remain
downstream. `SubTheory.pi` is intentionally only pointwise: a polynomial-time
family normally needs one family-level witness/bound, so VCVio may define a
stronger custom subtheory.

## Semantic/literature alignment

`docs/wiki/uc.md` is a paper-to-code ledger against Farshim--Karvonen--Knispel--
Kohlweiss--Tyagi, *UC, Categorically* (ePrint 2026/1605), and records the strict
separation between:

1. coarse activation equivalence;
2. boundary/execution observations with explicit adequacy laws; and
3. asymptotic computational indistinguishability of indexed families.

It also records lessons and open gates from EasyUC, IITM, SSProve/Nominal
SSProve, and robust-compilation accounts: typed routing and control transfer,
explicit dummy/network-collapse properties, local/renamable state ownership,
and named interface axioms rather than implicit model conventions.

The page pins the PolyFun/VCVio ownership split and the downstream gates for a
computational observation: scheduler-sampler transport, initial-state
correspondence, distributional adequacy, packet/action preservation, and
`RespectsFactorization`. It also incorporates the quantitative stress results:
cost partial `update?` and `head`, account for reachable-state growth, and demand
translation invariance plus a word-level coding retraction at representation
boundaries.

## Validation

- `./scripts/validate.sh --lint --test --axioms`
- 2,030 library build jobs and 2,092 test jobs passed
- module scopes, umbrella imports, docs integrity, and both lint layers passed
- 8,661 declarations across 237 modules have zero `sorryAx` and zero
  non-standard-axiom taint
