### PR TITLE
feat(control): exact monadic support over core's MonadAttach

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,7 +95,9 @@ and depend on this library.
   and concrete complexity classes live downstream.
 - `PolyFun/Control/`: monad and comonad infrastructure transitively
   required by the above (coalgebra, comonad, free / freecont monad
-  algebra, monad iter / hom, lawful re-exports).
+  algebra, monad iter / hom, lawful re-exports), plus exact monadic
+  support over core's `MonadAttach` and the always/some/never judgments
+  (`Monad/Support`).
 - `PolyFun/Control/LTS/Trace.lean`: generic finite visible traces over the
   silent/visible `Control.LTS` layer and preservation by weak simulation.
 - `PolyFun/Logic/`: small logic helpers (`HEq`).

--- a/PolyFun.lean
+++ b/PolyFun.lean
@@ -12,6 +12,7 @@ public import PolyFun.Control.Monad.FreeCont
 public import PolyFun.Control.Monad.Hom
 public import PolyFun.Control.Monad.Indexed
 public import PolyFun.Control.Monad.Iter
+public import PolyFun.Control.Monad.Support
 public import PolyFun.Control.Trace
 public import PolyFun.IPFunctor.Basic
 public import PolyFun.IPFunctor.Chart.Basic
@@ -194,6 +195,7 @@ public import PolyFun.PFunctor.Free.Path.Execution
 public import PolyFun.PFunctor.Free.Polynomial
 public import PolyFun.PFunctor.Free.Replicate
 public import PolyFun.PFunctor.Free.Resumption
+public import PolyFun.PFunctor.Free.Support
 public import PolyFun.PFunctor.Free.Universal
 public import PolyFun.PFunctor.Handler
 public import PolyFun.PFunctor.Handler.Free

--- a/PolyFun/Control/Monad/Support.lean
+++ b/PolyFun/Control/Monad/Support.lean
@@ -35,8 +35,10 @@ introduction rules exclude the empty model. Between them the support is exact.
 
 `AllOutputs` induces the demonic `Prop`-carrier ordered monad algebra `MAlgOrdered m Prop`,
 identifying "always" with the trivial-precondition Hoare triple
-(`triple_top_iff_allOutputs`); `SomeOutput` gives the angelic companion
-(`mAlgOrderedPropAngelic`, not an instance, since the two share an instance head).
+(`triple_top_iff_allOutputs`); `SomeOutput` gives the angelic companion. Both
+algebras are named definitions rather than global instances: transformer
+algebras such as `MAlgOrdered.instOptionT` give failures a different meaning,
+so a generic global support instance would be incoherent with them.
 
 ## Scope
 
@@ -260,13 +262,20 @@ variable {m : Type → Type v} [Monad m] [LawfulMonad m] [MonadAttach m] [ExactM
 variable {α : Type}
 
 /-- The demonic `Prop`-carrier ordered monad algebra of a monad with exact support:
-`μ` asserts that every possible output is a true proposition. -/
-instance instMAlgOrderedProp : MAlgOrdered m Prop where
+`μ` asserts that every possible output is a true proposition. This is deliberately
+not a global instance: for example, the existing `OptionT` algebra interprets
+`none` as `⊥`, whereas exact-support partial correctness interprets its empty
+support vacuously. Install this definition locally when support semantics is
+intended. -/
+@[instance_reducible]
+def mAlgOrderedPropDemonic : MAlgOrdered m Prop where
   μ x := AllOutputs id x
   μ_pure x := propext (allOutputs_pure id x)
   μ_bind_mono f g hfg x := by
     simp only [allOutputs_bind]
     exact fun h a ha => hfg a (h a ha)
+
+attribute [local instance] mAlgOrderedPropDemonic
 
 /-- Support-based characterization of the demonic `Prop`-valued weakest precondition. -/
 theorem wp_iff_forall_support (x : m α) (post : α → Prop) :
@@ -296,7 +305,7 @@ theorem triple_top_not_iff_noOutput (x : m α) (post : α → Prop) :
 
 /-- The angelic `Prop`-carrier ordered monad algebra: `μ` asserts that some possible output
 is a true proposition. Not an instance — it shares an instance head with the demonic
-`instMAlgOrderedProp`. -/
+`mAlgOrderedPropDemonic`. -/
 @[instance_reducible]
 def mAlgOrderedPropAngelic : MAlgOrdered m Prop where
   μ x := SomeOutput id x

--- a/PolyFun/Control/Monad/Support.lean
+++ b/PolyFun/Control/Monad/Support.lean
@@ -1,0 +1,456 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+module
+
+public import PolyFun.Control.Monad.Algebra
+public import Mathlib.Data.Set.Functor
+
+/-!
+# Exact Monadic Support
+
+Lean core's `MonadAttach` already provides the notion this layer needs: a predicate
+`MonadAttach.CanReturn x a`, meaning `a` is a possible return value of `x`, together with
+`attach`, which decorates a computation's results with proofs of that predicate.
+`LawfulMonadAttach` further pins `CanReturn` down as *the* strongest postcondition. This
+file adds the missing half and the `Set`-valued view:
+
+* `ExactMonadAttach` — the *introduction* rules for `CanReturn`. Core proves only
+  elimination rules (`canReturn_bind_imp'`, `eq_of_canReturn_pure`, `canReturn_map_imp'`),
+  which bound the support from above. Those alone do not pin it down: the monad
+  `fun _ => PUnit` with `CanReturn := fun _ _ => False` satisfies `LawfulMonadAttach`
+  vacuously, since every core law is an implication *out of* `CanReturn`. Assuming the two
+  introduction rules turns each of core's implications into an equivalence, which is what
+  support reasoning actually rewrites with.
+* `MonadAttach.support x : Set α` — the `Set`-valued view of `CanReturn`, definitionally
+  the predicate itself, so `a ∈ support x ↔ CanReturn x a` is `Iff.rfl`.
+* The qualitative judgments `AllOutputs` ("always"), `SomeOutput`, and `NoOutput`
+  ("never"), with scoped notation `x ⊨ₐ p`, `x ⊨ₛ p`, and `x ⊭ p`.
+
+`ExactMonadAttach` extends `LawfulMonadAttach` rather than the weak class: that excludes
+`MonadAttach.trivial` (`CanReturn := fun _ _ => True`, i.e. `support = univ`), while the
+introduction rules exclude the empty model. Between them the support is exact.
+
+`AllOutputs` induces the demonic `Prop`-carrier ordered monad algebra `MAlgOrdered m Prop`,
+identifying "always" with the trivial-precondition Hoare triple
+(`triple_top_iff_allOutputs`); `SomeOutput` gives the angelic companion
+(`mAlgOrderedPropAngelic`, not an instance, since the two share an instance head).
+
+## Scope
+
+Support is a *value*-level notion here. Core states the limitation directly: `CanReturn`
+"neither depends on the prior internal state of the monad, nor does it contain information
+about how the state of the monad changes". Concretely, `StateT σ m` and `ReaderT ρ m` do
+have `MonadAttach` instances — quantifying existentially over the initial state — and those
+supports are canonical, so the elimination theory applies. But `ExactMonadAttach` is *false*
+for them: possible outputs do not compose along `bind` when the continuation may observe a
+state the prefix did not produce. Reason about those per run instead, via
+`mem_support_stateT_iff` / `mem_support_readerT_iff`; `PolyFunTest` pins the failure with a
+counterexample. Oracle- and state-relative supports belong at the specification layer
+(`PolyFun.PFunctor.Free.WP`), which indexes the notion by a per-operation answer assignment.
+
+A second limitation is inherited from `MonadAttach`: obtaining an instance requires
+producing `attach`, which for continuation-passing monads is impossible to do
+non-trivially. CPS encodings such as `PolyFun.Control.Monad.FreeContT` therefore cannot be
+`ExactMonadAttach`, matching core's treatment of `StateCpsT` and `ExceptCpsT`.
+-/
+
+@[expose] public section
+
+universe u v
+
+/-- A monad whose `MonadAttach.CanReturn` predicate is *exact*: besides being the strongest
+postcondition (`LawfulMonadAttach`), it is closed under the monad's introduction rules, so
+the possible outputs of `pure` and `bind` are exactly what one expects.
+
+Core assumes only the elimination direction of each law, which leaves `CanReturn` free to be
+uniformly `False`. These two fields rule that out; together with the `LawfulMonadAttach`
+parent — which rules out the uniformly-`True` model — they determine the support exactly. -/
+class ExactMonadAttach (m : Type u → Type v) [Monad m] [MonadAttach m]
+    extends LawfulMonadAttach m where
+  /-- A pure computation can return its own value. -/
+  canReturn_pure {α : Type u} (a : α) : MonadAttach.CanReturn (pure a : m α) a
+  /-- Possible outputs compose along `bind`. -/
+  canReturn_bind {α β : Type u} {x : m α} {f : α → m β} {a : α} {b : β} :
+    MonadAttach.CanReturn x a → MonadAttach.CanReturn (f a) b →
+      MonadAttach.CanReturn (x >>= f) b
+
+namespace MonadAttach
+
+variable {m : Type u → Type v} {α β : Type u}
+
+/-- The set of possible outputs of a monadic computation: the `Set`-valued view of
+`CanReturn`. Available for any `MonadAttach`; the structural equations are gated behind
+`ExactMonadAttach`. -/
+def support [MonadAttach m] (x : m α) : Set α :=
+  {a | CanReturn x a}
+
+/-- Membership in `support` is `CanReturn`, definitionally.
+
+Stated as a simp lemma because `Set.ofPred` and `Set.Mem` are `implicit_reducible`: `rfl`
+and `exact` see through them, but `simp`'s reducible-transparency discharge does not. -/
+@[simp]
+theorem mem_support [MonadAttach m] {x : m α} {a : α} :
+    a ∈ support x ↔ CanReturn x a :=
+  Iff.rfl
+
+section Laws
+
+variable [Monad m] [LawfulMonad m] [MonadAttach m] [ExactMonadAttach m]
+
+@[simp]
+theorem support_pure (b : α) : support (pure b : m α) = {b} := by
+  ext c
+  refine ⟨fun h => (LawfulMonadAttach.eq_of_canReturn_pure h).symm, fun h => ?_⟩
+  rw [Set.mem_singleton_iff] at h
+  subst h
+  exact ExactMonadAttach.canReturn_pure c
+
+@[simp]
+theorem support_bind (x : m α) (f : α → m β) :
+    support (x >>= f) = ⋃ a ∈ support x, support (f a) := by
+  ext b
+  simp only [Set.mem_iUnion]
+  refine ⟨fun h => ?_, fun ⟨a, ha, hb⟩ => ExactMonadAttach.canReturn_bind ha hb⟩
+  obtain ⟨a, ha, hb⟩ := LawfulMonadAttach.canReturn_bind_imp' h
+  exact ⟨a, ha, hb⟩
+
+theorem mem_support_pure {a b : α} : a ∈ support (pure b : m α) ↔ a = b := by
+  simp
+
+theorem mem_support_bind {x : m α} {f : α → m β} {b : β} :
+    b ∈ support (x >>= f) ↔ ∃ a ∈ support x, b ∈ support (f a) := by
+  simp
+
+@[simp]
+theorem support_map (g : α → β) (x : m α) : support (g <$> x) = g '' support x := by
+  rw [← bind_pure_comp, support_bind]
+  ext b
+  simp [eq_comm]
+
+end Laws
+
+/-! ## Always / some / never output judgments -/
+
+/-- Every possible output of `x` satisfies `p` — the "always true" judgment.
+Definitionally the bounded quantifier `∀ a ∈ support x, p a`. -/
+def AllOutputs [MonadAttach m] (p : α → Prop) (x : m α) : Prop :=
+  ∀ a ∈ support x, p a
+
+/-- Some possible output of `x` satisfies `p`.
+Definitionally the bounded quantifier `∃ a ∈ support x, p a`. -/
+def SomeOutput [MonadAttach m] (p : α → Prop) (x : m α) : Prop :=
+  ∃ a ∈ support x, p a
+
+/-- No possible output of `x` satisfies `p` — the "never true" judgment. -/
+def NoOutput [MonadAttach m] (p : α → Prop) (x : m α) : Prop :=
+  AllOutputs (fun a => ¬ p a) x
+
+@[inherit_doc AllOutputs]
+scoped notation:50 x:51 " ⊨ₐ " p:51 => MonadAttach.AllOutputs p x
+
+@[inherit_doc SomeOutput]
+scoped notation:50 x:51 " ⊨ₛ " p:51 => MonadAttach.SomeOutput p x
+
+@[inherit_doc NoOutput]
+scoped notation:50 x:51 " ⊭ " p:51 => MonadAttach.NoOutput p x
+
+section Judgments
+
+variable [MonadAttach m]
+
+theorem allOutputs_iff_forall_support (p : α → Prop) (x : m α) :
+    AllOutputs p x ↔ ∀ a ∈ support x, p a :=
+  Iff.rfl
+
+theorem someOutput_iff_exists_support (p : α → Prop) (x : m α) :
+    SomeOutput p x ↔ ∃ a ∈ support x, p a :=
+  Iff.rfl
+
+theorem noOutput_iff_forall_support (p : α → Prop) (x : m α) :
+    NoOutput p x ↔ ∀ a ∈ support x, ¬ p a :=
+  Iff.rfl
+
+theorem allOutputs_iff_forall_canReturn (p : α → Prop) (x : m α) :
+    AllOutputs p x ↔ ∀ a, CanReturn x a → p a :=
+  Iff.rfl
+
+theorem not_someOutput_iff_noOutput (p : α → Prop) (x : m α) :
+    ¬ SomeOutput p x ↔ NoOutput p x := by
+  simp [SomeOutput, NoOutput, AllOutputs]
+
+theorem allOutputs_and (p q : α → Prop) (x : m α) :
+    AllOutputs (fun a => p a ∧ q a) x ↔ AllOutputs p x ∧ AllOutputs q x :=
+  ⟨fun h => ⟨fun a ha => (h a ha).1, fun a ha => (h a ha).2⟩,
+    fun ⟨hp, hq⟩ a ha => ⟨hp a ha, hq a ha⟩⟩
+
+theorem allOutputs_mono {p q : α → Prop} (h : ∀ a, p a → q a) {x : m α}
+    (hx : AllOutputs p x) : AllOutputs q x :=
+  fun a ha => h a (hx a ha)
+
+theorem someOutput_mono {p q : α → Prop} (h : ∀ a, p a → q a) {x : m α}
+    (hx : SomeOutput p x) : SomeOutput q x :=
+  hx.imp fun a ⟨ha, hpa⟩ => ⟨ha, h a hpa⟩
+
+theorem noOutput_mono {p q : α → Prop} (h : ∀ a, q a → p a) {x : m α}
+    (hx : NoOutput p x) : NoOutput q x :=
+  fun a ha hqa => hx a ha (h a hqa)
+
+end Judgments
+
+section JudgmentLaws
+
+variable [Monad m] [LawfulMonad m] [MonadAttach m] [ExactMonadAttach m]
+
+@[simp]
+theorem allOutputs_pure (p : α → Prop) (a : α) :
+    AllOutputs p (pure a : m α) ↔ p a := by
+  simp [AllOutputs]
+
+@[simp]
+theorem allOutputs_bind (p : β → Prop) (x : m α) (f : α → m β) :
+    AllOutputs p (x >>= f) ↔ ∀ a ∈ support x, AllOutputs p (f a) := by
+  constructor
+  · intro h a ha b hb
+    exact h b (mem_support_bind.mpr ⟨a, ha, hb⟩)
+  · intro h b hb
+    obtain ⟨a, ha, hb⟩ := mem_support_bind.mp hb
+    exact h a ha b hb
+
+@[simp]
+theorem someOutput_pure (p : α → Prop) (a : α) :
+    SomeOutput p (pure a : m α) ↔ p a := by
+  simp [SomeOutput]
+
+@[simp]
+theorem someOutput_bind (p : β → Prop) (x : m α) (f : α → m β) :
+    SomeOutput p (x >>= f) ↔ ∃ a ∈ support x, SomeOutput p (f a) := by
+  constructor
+  · rintro ⟨b, hb, hp⟩
+    obtain ⟨a, ha, hb⟩ := mem_support_bind.mp hb
+    exact ⟨a, ha, b, hb, hp⟩
+  · rintro ⟨a, ha, b, hb, hp⟩
+    exact ⟨b, mem_support_bind.mpr ⟨a, ha, hb⟩, hp⟩
+
+@[simp]
+theorem noOutput_pure (p : α → Prop) (a : α) :
+    NoOutput p (pure a : m α) ↔ ¬ p a := by
+  simp [NoOutput]
+
+@[simp]
+theorem noOutput_bind (p : β → Prop) (x : m α) (f : α → m β) :
+    NoOutput p (x >>= f) ↔ ∀ a ∈ support x, NoOutput p (f a) := by
+  simp [NoOutput]
+
+end JudgmentLaws
+
+/-! ## Induced ordered monad algebras on `Prop`
+
+`AllOutputs` is the demonic `Prop`-carrier ordered monad algebra: its induced
+`MAlgOrdered.wp` is the support-based weakest precondition, and the trivial-precondition
+triple is exactly the "always" judgment. The angelic companion built from `SomeOutput` is
+provided as a plain definition rather than an instance, since the two share an instance
+head. -/
+
+section PropAlgebra
+
+variable {m : Type → Type v} [Monad m] [LawfulMonad m] [MonadAttach m] [ExactMonadAttach m]
+variable {α : Type}
+
+/-- The demonic `Prop`-carrier ordered monad algebra of a monad with exact support:
+`μ` asserts that every possible output is a true proposition. -/
+instance instMAlgOrderedProp : MAlgOrdered m Prop where
+  μ x := AllOutputs id x
+  μ_pure x := propext (allOutputs_pure id x)
+  μ_bind_mono f g hfg x := by
+    simp only [allOutputs_bind]
+    exact fun h a ha => hfg a (h a ha)
+
+/-- Support-based characterization of the demonic `Prop`-valued weakest precondition. -/
+theorem wp_iff_forall_support (x : m α) (post : α → Prop) :
+    MAlgOrdered.wp (l := Prop) x post ↔ ∀ a ∈ support x, post a := by
+  change AllOutputs id (x >>= fun a => pure (post a)) ↔ _
+  rw [allOutputs_bind]
+  exact ⟨fun h a ha => (allOutputs_pure id (post a)).mp (h a ha),
+    fun h a ha => (allOutputs_pure id (post a)).mpr (h a ha)⟩
+
+/-- The demonic `Prop`-valued weakest precondition is the "always" judgment. -/
+theorem wp_iff_allOutputs (x : m α) (post : α → Prop) :
+    MAlgOrdered.wp (l := Prop) x post ↔ AllOutputs post x :=
+  wp_iff_forall_support x post
+
+/-- The trivial-precondition `Prop`-valued triple is exactly the "always" judgment:
+`⊤`-precondition triples assert that every possible output satisfies `post`. -/
+theorem triple_top_iff_allOutputs (x : m α) (post : α → Prop) :
+    MAlgOrdered.Triple (l := Prop) ⊤ x post ↔ AllOutputs post x := by
+  rw [MAlgOrdered.Triple, top_le_iff, ← wp_iff_allOutputs x post]
+  exact ⟨fun h => h ▸ trivial, fun h => eq_true h⟩
+
+/-- The trivial-precondition `Prop`-valued triple against a negated postcondition is
+exactly the "never" judgment. -/
+theorem triple_top_not_iff_noOutput (x : m α) (post : α → Prop) :
+    MAlgOrdered.Triple (l := Prop) ⊤ x (fun a => ¬ post a) ↔ NoOutput post x :=
+  triple_top_iff_allOutputs x fun a => ¬ post a
+
+/-- The angelic `Prop`-carrier ordered monad algebra: `μ` asserts that some possible output
+is a true proposition. Not an instance — it shares an instance head with the demonic
+`instMAlgOrderedProp`. -/
+@[instance_reducible]
+def mAlgOrderedPropAngelic : MAlgOrdered m Prop where
+  μ x := SomeOutput id x
+  μ_pure x := propext (someOutput_pure id x)
+  μ_bind_mono f g hfg x := by
+    simp only [someOutput_bind]
+    exact fun ⟨a, ha, h⟩ => ⟨a, ha, hfg a h⟩
+
+end PropAlgebra
+
+/-! ## Recovering the `MonadLiftT` presentation
+
+Downstream libraries that phrase support as a monad lift into the powerset monad can
+register these; they are deliberately not instances, so that support reasoning does not
+perturb monad-lift instance search. -/
+
+/-- The support map as a monad lift into `SetM`. Not an instance. -/
+@[instance_reducible]
+def toMonadLiftT (m : Type u → Type v) [MonadAttach m] :
+    MonadLiftT m SetM where
+  monadLift x := (support x : SetM _)
+
+/-- The support lift is lawful. Not an instance. -/
+theorem toLawfulMonadLiftT (m : Type u → Type v) [Monad m] [LawfulMonad m] [MonadAttach m]
+    [ExactMonadAttach m] :
+    letI := toMonadLiftT m
+    LawfulMonadLiftT m SetM :=
+  letI := toMonadLiftT m
+  { monadLift_pure := fun a => support_pure a
+    monadLift_bind := fun x f => support_bind x f }
+
+/-! ## Base instances
+
+Core supplies `MonadAttach` and `LawfulMonadAttach` for `Id`, `Option`, `OptionT`,
+`ExceptT`, `StateT`, and `ReaderT`; only the exactness fields are needed here. `Except` and
+`SetM` have no core instance and are supplied below. -/
+
+section Instances
+
+/-- Core provides no `MonadAttach (Except ε)`, only the transformer version; this mirrors
+core's `Option` instance. -/
+instance instMonadAttachExcept {ε : Type u} : MonadAttach (Except ε) where
+  CanReturn x a := x = Except.ok a
+  attach
+    | .ok a => .ok ⟨a, rfl⟩
+    | .error e => .error e
+
+instance instLawfulMonadAttachExcept {ε : Type u} : LawfulMonadAttach (Except ε) where
+  map_attach {_ x} := by cases x <;> rfl
+  canReturn_map_imp {_ _ x _} h := by
+    cases x with
+    | error e => cases h
+    | ok z => cases h; exact z.2
+
+/-- Core's `MonadAttach (ExceptT ε m)` is stated at `max`-joined universes, which blocks
+synthesis in a universe-polymorphic context; this alias instantiates it at a single
+universe. Delete once the upstream declaration is repaired. -/
+instance instMonadAttachExceptT {ε : Type u} {m : Type u → Type v} [Monad m]
+    [MonadAttach m] : MonadAttach (ExceptT ε m) :=
+  instMonadAttachExceptTOfMonad.{u, u, v}
+
+/-- The powerset monad is its own support. -/
+instance instMonadAttachSetM : MonadAttach SetM where
+  CanReturn s a := a ∈ SetM.run s
+  attach _ := (Set.univ : Set _)
+
+instance instLawfulMonadAttachSetM : LawfulMonadAttach SetM where
+  map_attach {_ x} := by
+    change Subtype.val '' (Set.univ : Set {a // a ∈ SetM.run x}) = x
+    ext a
+    simp [SetM.run]
+  canReturn_map_imp {_ _ _ _} h := by
+    obtain ⟨z, -, hz⟩ := h
+    exact hz ▸ z.2
+
+instance instExactMonadAttachId : ExactMonadAttach Id where
+  canReturn_pure _ := rfl
+  canReturn_bind h h' := by
+    simp only [CanReturn, Id.run] at *
+    subst h
+    exact h'
+
+instance instExactMonadAttachOption : ExactMonadAttach Option where
+  canReturn_pure _ := rfl
+  canReturn_bind {_ _ _ _ _ _} h h' := by
+    simp only [CanReturn] at *
+    subst h
+    simpa using h'
+
+instance instExactMonadAttachExcept {ε : Type u} : ExactMonadAttach (Except ε) where
+  canReturn_pure _ := rfl
+  canReturn_bind ha hb := by cases ha; exact hb
+
+instance instExactMonadAttachSetM : ExactMonadAttach SetM where
+  canReturn_pure _ := rfl
+  canReturn_bind {_ _ _ _ a _} ha hb := Set.mem_iUnion.mpr ⟨a, Set.mem_iUnion.mpr ⟨ha, hb⟩⟩
+
+variable {m : Type u → Type v} [Monad m] [LawfulMonad m] [MonadAttach m] [ExactMonadAttach m]
+
+instance instExactMonadAttachOptionT : ExactMonadAttach (OptionT m) where
+  canReturn_pure {α} a := by
+    change CanReturn ((pure a : OptionT m α)).run (some a)
+    rw [OptionT.run_pure]
+    exact ExactMonadAttach.canReturn_pure _
+  canReturn_bind {α β x f a b} h h' := by
+    change CanReturn ((x >>= f : OptionT m β)).run (some b)
+    have hrun : ((x >>= f : OptionT m β)).run = x.run >>= fun o =>
+        match o with
+        | some c => (f c).run
+        | none => pure none := rfl
+    rw [hrun]
+    exact ExactMonadAttach.canReturn_bind (a := some a) h h'
+
+instance instExactMonadAttachExceptT {ε : Type u} : ExactMonadAttach (ExceptT ε m) where
+  canReturn_pure {α} a := by
+    change CanReturn ((pure a : ExceptT ε m α)).run (Except.ok a)
+    rw [ExceptT.run_pure]
+    exact ExactMonadAttach.canReturn_pure _
+  canReturn_bind {α β x f a b} h h' := by
+    change CanReturn ((x >>= f : ExceptT ε m β)).run (Except.ok b)
+    have hrun : ((x >>= f : ExceptT ε m β)).run = x.run >>= fun e =>
+        match e with
+        | Except.ok c => (f c).run
+        | Except.error e => pure (Except.error e) := rfl
+    rw [hrun]
+    exact ExactMonadAttach.canReturn_bind (a := Except.ok a) h h'
+
+/-! ### Stateful monads
+
+`StateT` and `ReaderT` do have core `MonadAttach` instances, existentially quantified over
+the initial state or environment, and those supports are canonical. They are *not*
+`ExactMonadAttach`: possible outputs do not compose along `bind`, because the continuation
+may observe a state the prefix never produced. Reason per run instead. -/
+
+omit [LawfulMonad m] [ExactMonadAttach m] in
+theorem mem_support_stateT_iff {σ : Type u} {x : StateT σ m α} {a : α} :
+    a ∈ support x ↔ ∃ s s', (a, s') ∈ support (x.run s) :=
+  Iff.rfl
+
+omit [LawfulMonad m] [ExactMonadAttach m] in
+theorem mem_support_readerT_iff {ρ : Type u} {x : ReaderT ρ m α} {a : α} :
+    a ∈ support x ↔ ∃ r, a ∈ support (x.run r) :=
+  Iff.rfl
+
+omit [LawfulMonad m] [ExactMonadAttach m] in
+theorem mem_support_of_run_stateT {σ : Type u} {x : StateT σ m α} {a : α} {s s' : σ}
+    (h : (a, s') ∈ support (x.run s)) : a ∈ support x :=
+  ⟨s, s', h⟩
+
+omit [LawfulMonad m] [ExactMonadAttach m] in
+theorem mem_support_of_run_readerT {ρ : Type u} {x : ReaderT ρ m α} {a : α} {r : ρ}
+    (h : a ∈ support (x.run r)) : a ∈ support x :=
+  ⟨r, h⟩
+
+end Instances
+
+end MonadAttach

--- a/PolyFun/PFunctor/Free/Support.lean
+++ b/PolyFun/PFunctor/Free/Support.lean
@@ -1,0 +1,204 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+module
+
+public import PolyFun.Control.Monad.Support
+public import PolyFun.PFunctor.Free.Path
+
+/-!
+# Exact Support of the Free Monad
+
+The free monad `FreeM P` carries a canonical `MonadAttach` instance: the possible outputs of
+a program are the leaf payloads reachable by choosing *some* direction at every operation
+node,
+
+* `supp (pure x) = {x}`,
+* `supp (liftBind a r) = ⋃ b, supp (r b)`,
+
+and `attach` decorates each leaf with its reachability proof by structural recursion. Both
+are computable and axiom-free, so `MonadAttach.pbind` is available for well-founded
+recursion over free programs.
+
+The instance is `ExactMonadAttach`: `supp` really is the strongest postcondition, proved by
+induction rather than assumed. Consequently `MonadAttach.support` on `FreeM P` reduces
+definitionally — `support (pure x) = {x}` and `support (liftBind a r) = ⋃ b, support (r b)`
+are both `rfl` — and the judgments `AllOutputs`/`SomeOutput`/`NoOutput` recurse structurally
+over trees.
+
+Two coherence results connect this to the rest of the library:
+`support_eq_range_output` identifies the support with the range of `FreeM.output` over the
+canonical `FreeM.Path` type, and `support_eq_liftM_univ` identifies it with the fold of the
+"every response possible" handler into the powerset monad.
+-/
+
+@[expose] public section
+
+universe uA uB v
+
+namespace PFunctor.FreeM
+
+open MonadAttach
+
+variable {P : PFunctor.{uA, uB}} {α β : Type v}
+
+/-- The structural support of a free tree: every direction of every operation node is
+possible. -/
+def supp : FreeM P α → Set α
+  | .pure a => {a}
+  | .liftBind _ r => ⋃ b, supp (r b)
+
+/-- Reachability at a child is reachability at the node. -/
+theorem mem_supp_liftBind_of_mem {op : P.A} {r : P.B op → FreeM P α} {b : P.B op} {a : α}
+    (h : a ∈ supp (r b)) : a ∈ supp (FreeM.liftBind op r) :=
+  Set.mem_iUnion.mpr ⟨b, h⟩
+
+/-- Attach the structural-support proof to every leaf, by structural recursion. -/
+def attachSupp : (x : FreeM P α) → FreeM P {a : α // a ∈ supp x}
+  | .pure a => .pure ⟨a, rfl⟩
+  | .liftBind op r => .liftBind op fun b =>
+      FreeM.map (fun z => ⟨z.1, mem_supp_liftBind_of_mem z.2⟩) (attachSupp (r b))
+
+instance instMonadAttach : MonadAttach (FreeM P) where
+  CanReturn x a := a ∈ supp x
+  attach := attachSupp
+
+/-- The structural support is the strongest postcondition: anything reachable in a tree of
+refined values satisfies the refinement. -/
+theorem supp_map {Q : α → Prop} (x : FreeM P {a : α // Q a}) {b : α} :
+    b ∈ supp (Subtype.val <$> x) → Q b := by
+  induction x with
+  | pure a => intro h; cases h; exact a.2
+  | lift_bind op r ih =>
+      intro h
+      change b ∈ supp (FreeM.liftBind op fun c => Subtype.val <$> r c) at h
+      obtain ⟨c, hc⟩ := Set.mem_iUnion.mp h
+      exact ih c hc
+
+theorem map_attachSupp (x : FreeM P α) : Subtype.val <$> attachSupp x = x := by
+  induction x with
+  | pure a => rfl
+  | lift_bind op r ih =>
+      change FreeM.liftBind op (fun b => Subtype.val <$>
+        (FreeM.map (fun z => ⟨z.1, mem_supp_liftBind_of_mem z.2⟩) (attachSupp (r b)))) = _
+      congr 1
+      funext b
+      rw [show (Subtype.val <$> (FreeM.map
+        (fun z : {a // a ∈ supp (r b)} =>
+          (⟨z.1, mem_supp_liftBind_of_mem z.2⟩ :
+            {a // a ∈ supp (FreeM.liftBind op r)}))
+        (attachSupp (r b)))) = Subtype.val <$> attachSupp (r b) from
+        (FreeM.comp_map _ _ _).symm]
+      exact ih b
+
+instance instExactMonadAttach : ExactMonadAttach (FreeM P) where
+  map_attach := map_attachSupp _
+  canReturn_map_imp h := supp_map _ h
+  canReturn_pure _ := rfl
+  canReturn_bind {_ _ x _ _ _} ha hb := by
+    induction x with
+    | pure c => cases ha; exact hb
+    | lift_bind op r ih =>
+        obtain ⟨c, hc⟩ := Set.mem_iUnion.mp ha
+        exact mem_supp_liftBind_of_mem (ih c hc)
+
+/-! ## Structural equations
+
+`MonadAttach.support` on `FreeM P` unfolds to `supp`, so the leaf and node equations hold by
+`rfl`. -/
+
+theorem support_eq_supp (x : FreeM P α) : support x = supp x := rfl
+
+@[simp]
+theorem support_pure' (a : α) : support (pure a : FreeM P α) = {a} := rfl
+
+@[freeM_unfold]
+theorem support_liftBind (a : P.A) (r : P.B a → FreeM P α) :
+    support (FreeM.liftBind a r) = ⋃ b, support (r b) := rfl
+
+@[simp]
+theorem support_lift (a : P.A) :
+    support (FreeM.lift (P := P) a) = Set.univ :=
+  Set.eq_univ_of_forall fun c => Set.mem_iUnion.mpr ⟨c, rfl⟩
+
+theorem mem_support_liftBind {a : P.A} {r : P.B a → FreeM P α} {c : α} :
+    c ∈ support (FreeM.liftBind a r) ↔ ∃ b, c ∈ support (r b) :=
+  Set.mem_iUnion
+
+/-! ## Structural recursion for the satisfaction judgments -/
+
+@[freeM_unfold]
+theorem allOutputs_liftBind (p : α → Prop) (a : P.A) (r : P.B a → FreeM P α) :
+    AllOutputs p (FreeM.liftBind a r) ↔ ∀ b, AllOutputs p (r b) := by
+  constructor
+  · intro h b c hc
+    exact h c (mem_support_liftBind.mpr ⟨b, hc⟩)
+  · intro h c hc
+    obtain ⟨b, hb⟩ := mem_support_liftBind.mp hc
+    exact h b c hb
+
+@[freeM_unfold]
+theorem someOutput_liftBind (p : α → Prop) (a : P.A) (r : P.B a → FreeM P α) :
+    SomeOutput p (FreeM.liftBind a r) ↔ ∃ b, SomeOutput p (r b) := by
+  simp only [SomeOutput, support_liftBind, Set.mem_iUnion]
+  aesop
+
+@[freeM_unfold]
+theorem noOutput_liftBind (p : α → Prop) (a : P.A) (r : P.B a → FreeM P α) :
+    NoOutput p (FreeM.liftBind a r) ↔ ∀ b, NoOutput p (r b) :=
+  allOutputs_liftBind (fun a => ¬ p a) a r
+
+/-! ## Coherence with paths and with the powerset fold -/
+
+/-- The support is exactly the set of leaf payloads reachable along a canonical
+root-to-leaf path. -/
+theorem support_eq_range_output (s : FreeM P α) :
+    support s = Set.range (FreeM.output s) := by
+  induction s with
+  | pure x =>
+      ext c
+      simp only [support_pure', Set.mem_singleton_iff, Set.mem_range]
+      exact ⟨fun h => ⟨⟨⟩, h.symm⟩, fun ⟨_, h⟩ => h.symm⟩
+  | lift_bind a r ih =>
+      change support (FreeM.liftBind a r) =
+        Set.range (FreeM.output (FreeM.liftBind a r))
+      rw [support_liftBind]
+      ext c
+      simp only [Set.mem_iUnion, Set.mem_range]
+      constructor
+      · rintro ⟨b, hb⟩
+        rw [ih b, Set.mem_range] at hb
+        obtain ⟨path, hpath⟩ := hb
+        exact ⟨⟨b, path⟩, hpath⟩
+      · rintro ⟨⟨b, path⟩, hpath⟩
+        refine ⟨b, ?_⟩
+        rw [ih b]
+        exact ⟨path, hpath⟩
+
+/-- The support is the powerset-monad interpretation of the "every response possible"
+handler — the shape a support-as-fold presentation expects. -/
+theorem support_eq_liftM_univ {γ : Type uB} (x : FreeM P γ) :
+    support x = SetM.run (x.liftM (fun _ => (Set.univ : SetM _))) := by
+  induction x with
+  | pure a => rfl
+  | lift_bind op r ih =>
+      change (⋃ b, supp (r b)) = SetM.run (_ >>= _)
+      change _ = ⋃ b ∈ (Set.univ : Set (P.B op)), SetM.run ((r b).liftM _)
+      simp only [Set.mem_univ, Set.iUnion_true]
+      exact iSup_congr ih
+
+/-- Every possible output is witnessed by a path, and conversely. -/
+theorem allOutputs_iff_forall_path (p : α → Prop) (s : FreeM P α) :
+    AllOutputs p s ↔ ∀ path : FreeM.Path s, p (FreeM.output s path) := by
+  rw [allOutputs_iff_forall_support, support_eq_range_output]
+  simp
+
+/-- Some possible output is witnessed by a path, and conversely. -/
+theorem someOutput_iff_exists_path (p : α → Prop) (s : FreeM P α) :
+    SomeOutput p s ↔ ∃ path : FreeM.Path s, p (FreeM.output s path) := by
+  rw [someOutput_iff_exists_support, support_eq_range_output]
+  simp
+
+end PFunctor.FreeM

--- a/PolyFunTest/Control/MonadAttach.lean
+++ b/PolyFunTest/Control/MonadAttach.lean
@@ -135,7 +135,32 @@ variable {α : Type}
 
 /-- The "always" judgment is the trivial-precondition `Prop`-valued triple. -/
 example (x : m α) (p : α → Prop) :
+    letI := mAlgOrderedPropDemonic (m := m)
     MAlgOrdered.Triple (l := Prop) ⊤ x p ↔ (x ⊨ₐ p) :=
   triple_top_iff_allOutputs x p
 
 end TrivialTriple
+
+section AlgebraSelection
+
+/-- A computation used to distinguish transformer failure semantics from
+support-based partial-correctness semantics. -/
+def noResult : OptionT Id Nat := ⟨none⟩
+
+/-- Installing the support algebra only on the base monad leaves PolyFun's
+existing `OptionT` algebra in charge, so `none` is failure (`⊥`). -/
+example :
+    letI := mAlgOrderedPropDemonic (m := Id)
+    ¬ MAlgOrdered.wp noResult (fun _ => True) := by
+  simp [MAlgOrdered.wp, noResult, MAlgOrdered.instOptionT, mAlgOrderedPropDemonic,
+    AllOutputs, support]
+
+/-- Installing support semantics explicitly on the transformer instead makes
+its empty support satisfy every postcondition vacuously. -/
+example :
+    letI := mAlgOrderedPropDemonic (m := OptionT Id)
+    MAlgOrdered.wp noResult (fun _ => True) := by
+  rw [wp_iff_allOutputs]
+  exact fun _ _ => trivial
+
+end AlgebraSelection

--- a/PolyFunTest/Control/MonadAttach.lean
+++ b/PolyFunTest/Control/MonadAttach.lean
@@ -1,0 +1,141 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+module
+
+public import PolyFun.PFunctor.Free.Support
+
+/-!
+# Examples for exact monadic support and the always/never judgments
+
+These examples pin the definitional-transfer contract of the support layer: the satisfaction
+judgments must stay `Iff.rfl`-convertible both to their bounded-quantifier spellings and to
+`MonadAttach.CanReturn`, so downstream support-based statements transfer without rewriting.
+They also exercise the scoped `⊨ₐ` / `⊨ₛ` / `⊭` notation, the structural recursion of the
+judgments over free-monad trees, and `MonadAttach.pbind`.
+
+The `StateT` section is the executable justification for `StateT σ m` having a `MonadAttach`
+instance but *not* an `ExactMonadAttach` one: both introduction rules genuinely fail there.
+-/
+
+@[expose] public section
+
+universe u v uA uB
+
+open MonadAttach
+open scoped MonadAttach
+
+section DefinitionalTransfer
+
+variable {m : Type u → Type v} [MonadAttach m] {α : Type u} (p : α → Prop) (x : m α)
+
+/-- `AllOutputs` is definitionally the bounded universal quantifier. -/
+example : (x ⊨ₐ p) ↔ ∀ a ∈ support x, p a := Iff.rfl
+
+/-- `SomeOutput` is definitionally the bounded existential quantifier. -/
+example : (x ⊨ₛ p) ↔ ∃ a ∈ support x, p a := Iff.rfl
+
+/-- `NoOutput` is definitionally the negated bounded quantifier. -/
+example : (x ⊭ p) ↔ ∀ a ∈ support x, ¬ p a := Iff.rfl
+
+/-- Membership in the support is `CanReturn`, definitionally. -/
+example (a : α) : a ∈ support x ↔ CanReturn x a := Iff.rfl
+
+/-- The "always" judgment is definitionally a quantifier over `CanReturn`. -/
+example : (x ⊨ₐ p) ↔ ∀ a, CanReturn x a → p a := Iff.rfl
+
+end DefinitionalTransfer
+
+section Judgments
+
+/-- A two-direction query interface: one position, boolean responses. -/
+abbrev coinP : PFunctor.{0, 0} := ⟨PUnit, fun _ => Bool⟩
+
+open PFunctor in
+/-- Flip one coin and return it. -/
+def flipCoin : FreeM coinP Bool := FreeM.lift (P := coinP) PUnit.unit
+
+open PFunctor in
+/-- Flip two coins and return their conjunction. -/
+def flipTwo : FreeM coinP Bool := do
+  let a ← flipCoin
+  let b ← flipCoin
+  pure (a && b)
+
+/-- Every outcome of a coin flip is a boolean tautology's witness. -/
+example : flipCoin ⊨ₐ fun b => b = true ∨ b = false := by
+  intro b _
+  cases b <;> simp
+
+/-- Some outcome of `flipTwo` is `true`, witnessed by two `true` flips. -/
+example : flipTwo ⊨ₛ fun b => b = true := by
+  rw [someOutput_iff_exists_support]
+  refine ⟨true, ?_, rfl⟩
+  rw [show flipTwo = flipCoin >>= (fun a => flipCoin >>= fun b => pure (a && b)) from rfl,
+    mem_support_bind]
+  have hcoin : (true : Bool) ∈ support flipCoin := by
+    rw [flipCoin, PFunctor.FreeM.support_lift]
+    exact Set.mem_univ true
+  refine ⟨true, hcoin, ?_⟩
+  rw [mem_support_bind]
+  exact ⟨true, hcoin, by simp⟩
+
+/-- No outcome of `flipTwo` lies outside `Bool`'s two values. -/
+example : flipTwo ⊭ fun b => b ≠ true ∧ b ≠ false := by
+  intro b _ hb
+  cases b <;> simp_all
+
+/-- `attach` is computable on free programs, so `pbind` can carry reachability proofs into
+the continuation. -/
+example : PFunctor.FreeM coinP {b : Bool // CanReturn flipCoin b} :=
+  MonadAttach.attach flipCoin
+
+/-- `pbind` gives the continuation a proof that its input was reachable. -/
+example : PFunctor.FreeM coinP Bool :=
+  MonadAttach.pbind flipCoin fun b (_ : CanReturn flipCoin b) => pure (!b)
+
+end Judgments
+
+section StatefulCounterexamples
+
+/-! `StateT σ m` has a canonical `MonadAttach` instance — the union over initial states — so
+`support` is defined and the elimination theory applies. It is not `ExactMonadAttach`: both
+introduction rules fail, as the two examples below witness. Reason per run instead. -/
+
+/-- Possible outputs do *not* compose along `bind` for `StateT`: the continuation may
+observe a state the prefix never produced. -/
+example : ¬ (∀ {α β : Type} {x : StateT Bool Id α} {f : α → StateT Bool Id β} {a : α}
+      {b : β}, CanReturn x a → CanReturn (f a) b → CanReturn (x >>= f) b) := by
+  intro h
+  have hx : CanReturn (m := StateT Bool Id) (fun _ => ((), true)) () := ⟨false, true, rfl⟩
+  have hf : CanReturn (m := StateT Bool Id) (fun s => (s, s)) false := ⟨false, false, rfl⟩
+  obtain ⟨s, s', hs⟩ := h (x := fun _ => ((), true)) (f := fun _ => fun s => (s, s)) hx hf
+  simp only [CanReturn, Id.run] at hs
+  exact Bool.noConfusion (congrArg Prod.fst hs)
+
+/-- Even the `pure` introduction rule fails when the state type is empty: there is no
+initial state to run from. -/
+example (a : Nat) : ¬ CanReturn (m := StateT Empty Id) (pure a) a := by
+  rintro ⟨s, -, -⟩
+  exact s.elim
+
+/-- The usable form: state facts about a `StateT` computation per run. -/
+example {m : Type → Type v} [Monad m] [MonadAttach m] {σ α : Type} (x : StateT σ m α)
+    (a : α) : a ∈ support x ↔ ∃ s s', (a, s') ∈ support (x.run s) :=
+  mem_support_stateT_iff
+
+end StatefulCounterexamples
+
+section TrivialTriple
+
+variable {m : Type → Type v} [Monad m] [LawfulMonad m] [MonadAttach m] [ExactMonadAttach m]
+variable {α : Type}
+
+/-- The "always" judgment is the trivial-precondition `Prop`-valued triple. -/
+example (x : m α) (p : α → Prop) :
+    MAlgOrdered.Triple (l := Prop) ⊤ x p ↔ (x ⊨ₐ p) :=
+  triple_top_iff_allOutputs x p
+
+end TrivialTriple

--- a/PolyFunTest/Control/MonadAttach.lean
+++ b/PolyFunTest/Control/MonadAttach.lean
@@ -96,7 +96,78 @@ example : PFunctor.FreeM coinP {b : Bool // CanReturn flipCoin b} :=
 example : PFunctor.FreeM coinP Bool :=
   MonadAttach.pbind flipCoin fun b (_ : CanReturn flipCoin b) => pure (!b)
 
+/-- Both responses of the Boolean query are reachable; this rejects support
+implementations that silently select one branch. -/
+example : true ∈ support flipCoin ∧ false ∈ support flipCoin := by
+  constructor <;> rw [flipCoin, PFunctor.FreeM.support_lift] <;> trivial
+
+/-- A false output of the answer-dependent two-query continuation is
+reachable (for example, choose `true` and then `false`). -/
+example : false ∈ support flipTwo := by
+  rw [show flipTwo = flipCoin >>= (fun a => flipCoin >>= fun b => pure (a && b)) from rfl,
+    mem_support_bind]
+  refine ⟨true, ?_, ?_⟩
+  · rw [flipCoin, PFunctor.FreeM.support_lift]
+    trivial
+  · rw [mem_support_bind]
+    refine ⟨false, ?_, by simp⟩
+    rw [flipCoin, PFunctor.FreeM.support_lift]
+    trivial
+
+/-- `attachSupp` preserves a branch-dependent tree after erasing the attached
+reachability proofs. -/
+example : Subtype.val <$> PFunctor.FreeM.attachSupp flipTwo = flipTwo :=
+  PFunctor.FreeM.map_attachSupp flipTwo
+
 end Judgments
+
+section BaseSupports
+
+/-- Failed optional computations have empty support. -/
+example : support (none : Option Bool) = ∅ := by
+  ext b
+  simp [support, CanReturn]
+
+/-- Exceptions likewise have empty support. -/
+example : support (.error () : Except Unit Bool) = ∅ := by
+  ext b
+  simp [support, CanReturn]
+
+/-- `SetM` support preserves every member rather than selecting one. -/
+def bothBools : SetM Bool := fun _ => True
+
+example : support bothBools = Set.univ :=
+  rfl
+
+/-- `OptionT` success and failure bind paths retain their intended supports. -/
+def optionSuccess : OptionT Id Bool := some true
+def optionFailure : OptionT Id Bool := none
+
+example : support (optionSuccess >>= fun b => pure (!b)) = {false} := by
+  change {b | some false = some b} = {false}
+  ext b
+  simp
+
+example : support (optionFailure >>= fun b => pure (!b)) = ∅ := by
+  change {b | (none : Option Bool) = some b} = ∅
+  ext b
+  simp
+
+/-- `ExceptT` success and failure bind paths retain their intended supports. -/
+def exceptSuccess : ExceptT Unit Id Bool := .ok true
+def exceptFailure : ExceptT Unit Id Bool := .error ()
+
+example : support (exceptSuccess >>= fun b => pure (!b)) = {false} := by
+  change {b | Except.ok false = Except.ok b} = {false}
+  ext b
+  simp
+
+example : support (exceptFailure >>= fun b => pure (!b)) = ∅ := by
+  change {b | (Except.error () : Except Unit Bool) = Except.ok b} = ∅
+  ext b
+  simp
+
+end BaseSupports
 
 section StatefulCounterexamples
 
@@ -145,15 +216,25 @@ section AlgebraSelection
 
 /-- A computation used to distinguish transformer failure semantics from
 support-based partial-correctness semantics. -/
-def noResult : OptionT Id Nat := ⟨none⟩
+def noResult : OptionT Id Nat := none
+
+section TransformerDefault
+
+local instance : MAlgOrdered Id Prop := mAlgOrderedPropDemonic
 
 /-- Installing the support algebra only on the base monad leaves PolyFun's
 existing `OptionT` algebra in charge, so `none` is failure (`⊥`). -/
-example :
-    letI := mAlgOrderedPropDemonic (m := Id)
-    ¬ MAlgOrdered.wp noResult (fun _ => True) := by
-  simp [MAlgOrdered.wp, noResult, MAlgOrdered.instOptionT, mAlgOrderedPropDemonic,
-    AllOutputs, support]
+example : ¬ MAlgOrdered.wp noResult (fun _ => True) := by
+  change ¬ MAlgOrdered.wpOpt noResult (fun _ => True) False
+  intro hw
+  have hEq :=
+    MAlgOrdered.wpOpt_fail (m := Id) (l := Prop) (α := Nat) (fun _ => True) False
+  have hw' : MAlgOrdered.wpOpt (OptionT.mk (pure none) : OptionT Id Nat)
+      (fun _ => True) False := by
+    exact hw
+  exact hEq.mp hw'
+
+end TransformerDefault
 
 /-- Installing support semantics explicitly on the transformer instead makes
 its empty support satisfy every postcondition vacuously. -/

--- a/docs/wiki/repo-map.md
+++ b/docs/wiki/repo-map.md
@@ -25,7 +25,8 @@ PolyFun/
   Realizability/     step classes and realizability of free programs by
                      machines whose transition functions are admissible
   Control/           monad/comonad and LTS infrastructure (Coalgebra,
-                     Comonad, Lawful, Free, Iter, Bisimulation, LTS/Trace)
+                     Comonad, Lawful, Free, Iter, Bisimulation, LTS/Trace),
+                     including exact monadic support (Monad/Support)
   Logic/             small logic helpers (HEq)
 
 docs/wiki/           agent-facing notes (this directory)
@@ -93,6 +94,7 @@ PFunctor/Lens/{Basic, Cartesian, State}
 
 PFunctor/Lens/Basic -> PFunctor/SubstMonoid
 PFunctor/{Free/Path, SubstMonoid} -> PFunctor/Free/Polynomial
+PFunctor/Free/Path + Control/Monad/Support -> PFunctor/Free/Support
 PFunctor/Comonoid -> PFunctor/Comonoid/Category
 PFunctor/{Comonoid, Lens/Duoidal} -> PFunctor/Comonoid/Tensor
 PFunctor/{SubstMonoid, Comonoid, InternalHom, Lens/Duoidal}


### PR DESCRIPTION
## Summary

Builds PolyFun's support layer on Lean core's `MonadAttach` (shipped since v4.28) rather than on a bespoke class.

- fix an import leak in `Control/Monad/Hom.lean`: drop the unused public `Mathlib.Probability.ProbabilityMassFunction.Monad` (a scope violation per gotcha #3) and `Mathlib.CategoryTheory.Monad.Types`; test files and `Realizability/Instances.lean` that had been receiving `norm_num` and `Fintype` instances through that transitive closure now import what they use
- add `ExactMonadAttach`: the two *introduction* rules for `MonadAttach.CanReturn` that core omits
- add `MonadAttach.support : m α → Set α`, definitionally `CanReturn`, so `a ∈ support x ↔ CanReturn x a` is `Iff.rfl`
- add the judgments `AllOutputs` / `SomeOutput` / `NoOutput` with scoped notation `x ⊨ₐ p` / `x ⊨ₛ p` / `x ⊭ p`, and the demonic `MAlgOrdered m Prop` instance identifying "always" with the trivial-precondition triple
- add `MonadAttach`/`ExactMonadAttach` for `FreeM P` with a computable, axiom-free `attach`, plus `Except` and `SetM` instances (core has neither)

## Why not a bespoke class

Core proves only the *elimination* half of the support theory (`canReturn_bind_imp'`, `eq_of_canReturn_pure`, `canReturn_map_imp'`), which bounds the support from above. That does not pin it down — `fun _ => PUnit` with `CanReturn := False` satisfies `LawfulMonadAttach` vacuously, since every core law is an implication *out of* `CanReturn`. `ExactMonadAttach` supplies the missing introduction rules, so each of core's implications becomes the equivalence support reasoning rewrites with; extending `LawfulMonadAttach` rather than the weak class simultaneously excludes `MonadAttach.trivial` (`CanReturn := True`, i.e. `support = univ`).

The payoff beyond deleting ~120 lines of boilerplate: core supplies the `Id`, `Option`, `OptionT`, and `ExceptT` instances; `FreeM`'s structural equations hold by `rfl`; its value universe is no longer pinned to the direction universe; `MonadAttach.pbind` becomes available for well-founded recursion over free programs; and (in the stacked PR) `WPSound` converts `mvcgen` proofs into support facts.

## Notes

- Core's `MonadAttach (ExceptT ε m)` is declared at `max`-joined universes and cannot be synthesized in a polymorphic context; a single-universe alias works around it and should be deleted once upstream is repaired.
- `StateT`/`ReaderT` keep core's canonical support (the union over initial states), so the elimination theory applies, but they are correctly *not* `ExactMonadAttach` — the tests now *prove* both introduction rules fail there, where the previous design only asserted it in prose.

## Validation

`lake build`, `lake lint`, `lake test`, `./scripts/validate.sh --axioms` (zero-debt baseline preserved). `PolyFunTest/Control/MonadAttach.lean` pins the `Iff.rfl` transfer contract, the `StateT` counterexamples, and `pbind`.

Part 1 of 2; the free-monad wp layer and the `Std.Do`/`mvcgen` bridge build on this in the follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
