### PR TITLE
feat(pfunctor): free-monad weakest preconditions, Std.Do quarantine, and WPSound adequacy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -259,7 +259,7 @@ too specific or too changeable to keep at the repo root.
 - [`docs/wiki/interaction.md`](docs/wiki/interaction.md): generic interaction
   framework (`TypeTree`, two-party, multiparty, concurrent, UC).
 - [`docs/wiki/program-logic.md`](docs/wiki/program-logic.md): the
-  program-logic kernel (ordered monad algebras, `MonadSupport`, free-monad
+  program-logic kernel (ordered monad algebras, exact monadic support, free-monad
   wp, `Std.Do` quarantine).
 - [`docs/wiki/realizability.md`](docs/wiki/realizability.md): step classes and
   realizability of free programs by admissible state machines.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,9 +95,11 @@ and depend on this library.
   and concrete complexity classes live downstream.
 - `PolyFun/Control/`: monad and comonad infrastructure transitively
   required by the above (coalgebra, comonad, free / freecont monad
-  algebra, monad iter / hom, lawful re-exports), plus exact monadic
-  support over core's `MonadAttach` and the always/some/never judgments
-  (`Monad/Support`).
+  algebra, monad iter / hom, lawful re-exports), plus the program-logic
+  kernel: ordered monad algebras (`Monad/Algebra`, unary and relational),
+  exact monadic support over core's `MonadAttach` with the
+  always/some/never judgments (`Monad/Support`), and the core-`Std.Do`
+  quarantine root (`Do/Basic`).
 - `PolyFun/Control/LTS/Trace.lean`: generic finite visible traces over the
   silent/visible `Control.LTS` layer and preservation by weak simulation.
 - `PolyFun/Logic/`: small logic helpers (`HEq`).
@@ -196,6 +198,11 @@ Structures use UpperCamelCase: `PFunctor`, `TypeTree`, `Decoration`,
    `./scripts/update-lib.sh`.
 7. **Do not introduce `sorry` or `admit` in finished work.** Use `stop`
    only when explicitly preserving partial proof work during a refactor.
+8. **`Std.Tactic.Do` imports are quarantined.** Only
+   `PolyFun/Control/Do/Basic.lean`, `PolyFun/PFunctor/Free/Do.lean`, and
+   `PolyFunTest/Do/` may import core `Std.Do` / `mvcgen`, and they export
+   constructions (`def`s and `scoped` instances), never global `WP`
+   instances. See `docs/wiki/program-logic.md`.
 
 ## Building
 
@@ -251,6 +258,9 @@ too specific or too changeable to keep at the repo root.
 - [`docs/wiki/itree.md`](docs/wiki/itree.md): interaction trees layer.
 - [`docs/wiki/interaction.md`](docs/wiki/interaction.md): generic interaction
   framework (`TypeTree`, two-party, multiparty, concurrent, UC).
+- [`docs/wiki/program-logic.md`](docs/wiki/program-logic.md): the
+  program-logic kernel (ordered monad algebras, `MonadSupport`, free-monad
+  wp, `Std.Do` quarantine).
 - [`docs/wiki/realizability.md`](docs/wiki/realizability.md): step classes and
   realizability of free programs by admissible state machines.
 - [`docs/wiki/uc.md`](docs/wiki/uc.md): UC semantic contract, paper-to-code

--- a/PolyFun.lean
+++ b/PolyFun.lean
@@ -7,6 +7,7 @@ public import PolyFun.Control.Comonad.Instances
 public import PolyFun.Control.LTS.Trace
 public import PolyFun.Control.Lawful.Basic
 public import PolyFun.Control.Monad.Algebra
+public import PolyFun.Control.Monad.Algebra.Relational
 public import PolyFun.Control.Monad.Free
 public import PolyFun.Control.Monad.FreeCont
 public import PolyFun.Control.Monad.Hom

--- a/PolyFun.lean
+++ b/PolyFun.lean
@@ -4,6 +4,7 @@ public import PolyFun.Control.Bisimulation
 public import PolyFun.Control.Coalgebra
 public import PolyFun.Control.Comonad.Basic
 public import PolyFun.Control.Comonad.Instances
+public import PolyFun.Control.Do.Basic
 public import PolyFun.Control.LTS.Trace
 public import PolyFun.Control.Lawful.Basic
 public import PolyFun.Control.Monad.Algebra
@@ -190,6 +191,7 @@ public import PolyFun.PFunctor.Free.Displayed.Append
 public import PolyFun.PFunctor.Free.Displayed.Cursor
 public import PolyFun.PFunctor.Free.Displayed.Decoration
 public import PolyFun.PFunctor.Free.Displayed.StateChain
+public import PolyFun.PFunctor.Free.Do
 public import PolyFun.PFunctor.Free.Parallel
 public import PolyFun.PFunctor.Free.Path
 public import PolyFun.PFunctor.Free.Path.Execution
@@ -198,6 +200,7 @@ public import PolyFun.PFunctor.Free.Replicate
 public import PolyFun.PFunctor.Free.Resumption
 public import PolyFun.PFunctor.Free.Support
 public import PolyFun.PFunctor.Free.Universal
+public import PolyFun.PFunctor.Free.WP
 public import PolyFun.PFunctor.Handler
 public import PolyFun.PFunctor.Handler.Free
 public import PolyFun.PFunctor.Handler.Instrumentation

--- a/PolyFun/Control/Do/Basic.lean
+++ b/PolyFun/Control/Do/Basic.lean
@@ -6,6 +6,7 @@ Authors: Devon Tuma
 module
 
 public import Std.Tactic.Do
+public import PolyFun.Control.Monad.Hom
 public import PolyFun.Control.Monad.Support
 
 /-!
@@ -22,13 +23,26 @@ It provides constructions — deliberately not instances — that transport core
 * `MonadHom.transportWP` / `MonadHom.transportWPMonad` pull a `WP`/`WPMonad`
   structure back along a monad morphism `F : m →ᵐ n`, so a monad that interprets
   into an `mvcgen`-ready stack inherits its predicate-transformer semantics.
-* `MonadSupport.toWP` / `MonadSupport.toWPMonad` give any supported monad the
-  demonic (almost-sure) interpretation at the `.pure` post shape: `wp x Q` holds
-  when every possible output of `x` satisfies `Q`.
+* `MonadAttach.toWP` / `MonadAttach.toWPMonad` give any monad with exact support
+  the demonic (almost-sure) interpretation at the `.pure` post shape: `wp x Q`
+  holds when every possible output of `x` satisfies `Q`. `MonadAttach.toWPSound`
+  proves that interpretation sound in core's sense, with `attach` supplying the
+  `Ensures` witness.
+* `MonadAttach.support_subset_of_wp` / `allOutputs_of_wp` go the other way: *any*
+  `WPSound` predicate-transformer semantics bounds the support, so an
+  `mvcgen`-discharged triple becomes a support fact in one step. These need only
+  `LawfulMonadAttach`, so they also apply to `StateT`/`ReaderT`/`EStateM`, where
+  `ExactMonadAttach` is unavailable.
 
 Downstream libraries choose where to register these (scoped or local); a global
 instance here would clash with registrations on reducible unfoldings of the same
 monads downstream.
+
+This file depends on `Std.Do.Internal.Ensures` only through `WPSound`'s own field
+type. Reasoning here goes through `WPSound.of_wp_canReturn`, which lives in the
+stable `Std.Do` namespace; core's `Internal.MayReturn.canReturn_eq` (which proves
+`CanReturn` *is* the intrinsic strongest postcondition) is cited but not depended
+upon.
 -/
 
 @[expose] public section
@@ -66,10 +80,14 @@ def transportWPMonad (F : m →ᵐ n) [LawfulMonad m] [WPMonad n ps] : WPMonad m
 
 end MonadHom
 
-namespace MonadSupport
+namespace MonadAttach
 
-variable {m : Type u → Type v} [Monad m] [MonadSupport m]
+section Demonic
 
+variable {m : Type u → Type v} [Monad m] [LawfulMonad m] [MonadAttach m]
+  [ExactMonadAttach m]
+
+omit [Monad m] [LawfulMonad m] [ExactMonadAttach m] in
 theorem allOutputs_postCond_and {α : Type u} (x : m α)
     (Q₁ Q₂ : PostCond α .pure) :
     AllOutputs (fun a => ((Q₁.and Q₂).1 a).down) x ↔
@@ -87,12 +105,12 @@ def toWP : WP m .pure where
       conjunctiveRaw := fun Q₁ Q₂ =>
         SPred.pure_congr (allOutputs_postCond_and x Q₁ Q₂) }
 
-/-- The demonic interpretation is a `WPMonad` for any lawful supported monad.
+/-- The demonic interpretation is a `WPMonad` whenever the support is exact.
 Not an instance. -/
 @[instance_reducible]
-def toWPMonad [LawfulMonad m] : WPMonad m .pure where
+def toWPMonad : WPMonad m .pure where
   toLawfulMonad := inferInstance
-  toWP := MonadSupport.toWP
+  toWP := MonadAttach.toWP
   wp_pure a := by
     ext Q
     exact allOutputs_pure _ a
@@ -100,4 +118,52 @@ def toWPMonad [LawfulMonad m] : WPMonad m .pure where
     ext Q
     exact allOutputs_bind _ x f
 
-end MonadSupport
+/-! ### Soundness in core's sense
+
+`attach` is exactly the witness `Std.Do`'s `Ensures` asks for: decorate the
+computation's results with their reachability proofs, then re-tag those proofs
+with the postcondition, which the "always" judgment supplies pointwise. -/
+
+omit [MonadAttach m] [ExactMonadAttach m] in
+theorem erasesTo_of_map_eq {α : Type u} {P : α → Prop} {y : m (Subtype P)} {x : m α}
+    (h : Subtype.val <$> y = x) : Std.Do.Internal.ErasesTo y x :=
+  ⟨fun {_} k => by rw [← h, bind_map_left]⟩
+
+/-- An "always" judgment yields the `Ensures` witness core's soundness class wants. -/
+theorem ensures_of_allOutputs {α : Type u} {x : m α} {P : α → Prop}
+    (h : AllOutputs P x) : Std.Do.Internal.Ensures P x :=
+  ⟨⟨(fun z : Subtype (CanReturn x) => (⟨z.1, h z.1 z.2⟩ : Subtype P)) <$> MonadAttach.attach x,
+    erasesTo_of_map_eq (by rw [Functor.map_map]; exact WeaklyLawfulMonadAttach.map_attach)⟩⟩
+
+/-- The demonic interpretation is sound in core's sense. Not an instance. -/
+theorem toWPSound : letI := toWP (m := m); WPSound m .pure :=
+  letI := toWP (m := m)
+  { ensures_of_wp := fun {_ _ _} hwp => ensures_of_allOutputs (hwp True.intro) }
+
+end Demonic
+
+/-! ### From weakest preconditions back to supports
+
+The converse direction needs no exactness — only that `CanReturn` is the strongest
+postcondition — so it applies to every monad core equips, including the stateful
+ones where `ExactMonadAttach` fails. -/
+
+section OfWP
+
+variable {m : Type u → Type v} [Monad m] [LawfulMonad m] [MonadAttach m]
+  [LawfulMonadAttach m] {ps : PostShape.{u}} [WP m ps] [WPSound m ps]
+
+/-- Any `WPSound` predicate-transformer semantics bounds the support. -/
+theorem support_subset_of_wp {α : Type u} {x : m α} {P : α → Prop}
+    (h : ⊢ₛ wp⟦x⟧ (⇓?a => ⌜P a⌝)) : support x ⊆ {a | P a} :=
+  fun _ hcan => WPSound.of_wp_canReturn (P := P) hcan h
+
+/-- The "always" phrasing of `support_subset_of_wp`: a weakest-precondition proof
+discharges the almost-sure judgment. -/
+theorem allOutputs_of_wp {α : Type u} {x : m α} {P : α → Prop}
+    (h : ⊢ₛ wp⟦x⟧ (⇓?a => ⌜P a⌝)) : AllOutputs P x :=
+  fun _ hcan => WPSound.of_wp_canReturn (P := P) hcan h
+
+end OfWP
+
+end MonadAttach

--- a/PolyFun/Control/Do/Basic.lean
+++ b/PolyFun/Control/Do/Basic.lean
@@ -1,0 +1,103 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+module
+
+public import Std.Tactic.Do
+public import PolyFun.Control.Monad.Support
+
+/-!
+# Core `Std.Do` Enablement
+
+This file is the *only* PolyFun root importing `Std.Tactic.Do`; every other use of
+the core `Std.Do` weakest-precondition framework and the `mvcgen` tactic must go
+through it (or through `PolyFun.PFunctor.Free.Do`), keeping the dependency on the
+evolving upstream API quarantined.
+
+It provides constructions — deliberately not instances — that transport core
+`Std.Do` structure onto PolyFun's monads:
+
+* `MonadHom.transportWP` / `MonadHom.transportWPMonad` pull a `WP`/`WPMonad`
+  structure back along a monad morphism `F : m →ᵐ n`, so a monad that interprets
+  into an `mvcgen`-ready stack inherits its predicate-transformer semantics.
+* `MonadSupport.toWP` / `MonadSupport.toWPMonad` give any supported monad the
+  demonic (almost-sure) interpretation at the `.pure` post shape: `wp x Q` holds
+  when every possible output of `x` satisfies `Q`.
+
+Downstream libraries choose where to register these (scoped or local); a global
+instance here would clash with registrations on reducible unfoldings of the same
+monads downstream.
+-/
+
+@[expose] public section
+
+universe u v w
+
+open Std.Do
+
+namespace MonadHom
+
+variable {m : Type u → Type v} {n : Type u → Type w} [Monad m] [Monad n]
+  {ps : PostShape.{u}}
+
+/-- Transport a core `Std.Do.WP` structure along a monad morphism: interpret
+`x : m α` by the predicate transformer of its image `F x`. Not an instance —
+downstream registers it at chosen carriers. -/
+@[instance_reducible]
+def transportWP (F : m →ᵐ n) [WP n ps] : WP m ps where
+  wp x := WP.wp (F x)
+
+/-- The transported structure is a `WPMonad` whenever the target is and the
+source is a lawful monad. Not an instance. -/
+@[instance_reducible]
+def transportWPMonad (F : m →ᵐ n) [LawfulMonad m] [WPMonad n ps] : WPMonad m ps where
+  toLawfulMonad := inferInstance
+  toWP := F.transportWP
+  wp_pure a := by
+    change WP.wp (F (pure a)) = _
+    rw [F.mmap_pure]
+    exact WPMonad.wp_pure a
+  wp_bind x f := by
+    change WP.wp (F (x >>= f)) = _
+    rw [F.mmap_bind]
+    exact WPMonad.wp_bind (F x) fun a => F (f a)
+
+end MonadHom
+
+namespace MonadSupport
+
+variable {m : Type u → Type v} [Monad m] [MonadSupport m]
+
+theorem allOutputs_postCond_and {α : Type u} (x : m α)
+    (Q₁ Q₂ : PostCond α .pure) :
+    AllOutputs (fun a => ((Q₁.and Q₂).1 a).down) x ↔
+      AllOutputs (fun a => (Q₁.1 a).down) x ∧ AllOutputs (fun a => (Q₂.1 a).down) x := by
+  rw [← allOutputs_and]
+  exact Iff.of_eq (congrArg (AllOutputs · x) (funext fun a => rfl))
+
+/-- The demonic (almost-sure) `Std.Do.WP` structure of a supported monad at the
+`.pure` post shape: `wp x Q` asserts that every possible output of `x` satisfies
+the success postcondition. Not an instance. -/
+@[instance_reducible]
+def toWP : WP m .pure where
+  wp x :=
+    { trans := fun Q => ⌜AllOutputs (fun a => (Q.1 a).down) x⌝
+      conjunctiveRaw := fun Q₁ Q₂ =>
+        SPred.pure_congr (allOutputs_postCond_and x Q₁ Q₂) }
+
+/-- The demonic interpretation is a `WPMonad` for any lawful supported monad.
+Not an instance. -/
+@[instance_reducible]
+def toWPMonad [LawfulMonad m] : WPMonad m .pure where
+  toLawfulMonad := inferInstance
+  toWP := MonadSupport.toWP
+  wp_pure a := by
+    ext Q
+    exact allOutputs_pure _ a
+  wp_bind x f := by
+    ext Q
+    exact allOutputs_bind _ x f
+
+end MonadSupport

--- a/PolyFun/Control/Monad/Algebra/Relational.lean
+++ b/PolyFun/Control/Monad/Algebra/Relational.lean
@@ -18,16 +18,17 @@ This file introduces a two-monad relational analogue of `MAlgOrdered`:
 * Asynchronous (one-sided) bind rules `relWP_bind_left_le` / `relWP_bind_right_le`
   and their `Triple` forms, recovering Maillard et al.'s asynchronous shapes.
 * Structural pure rules for `if`, `dite`, `Option.elim`, `Sum.elim`.
-* Side-lifting instances for heterogeneous stacks (`StateT`, `OptionT`, `ExceptT`).
+* Named side lifts for heterogeneous stacks (`StateT`, `OptionT`, `ExceptT`).
 * `StrictBind` subclass capturing strict relational effect observations
   (in the sense of Maillard et al.) together with `StateT` lifts that preserve it.
 
 The framework is the predicate-transformer specialization of Maillard et al.'s
 *simple framework* (POPL 2020, §2): the relational specification monad is fixed
 to `(α → β → l) → l` and the relational effect observation is inlined as the
-`rwp` field. Everything here is stated against abstract lawful monads and an
-abstract ordered carrier; concrete instantiations (for example coupling-based
-probabilistic carriers) live in downstream libraries.
+`rwp` field. Everything here is stated against abstract monads, adding
+lawfulness only to rules that use monad equalities, and an abstract ordered
+carrier; concrete instantiations (for example coupling-based probabilistic
+carriers) live in downstream libraries.
 
 Attribution:
 - Loom repository: https://github.com/verse-lab/loom
@@ -264,8 +265,13 @@ variable {m₁ : Type u → Type v₁} {m₂ : Type u → Type v₂} {l : Type u
 variable [Monad m₁] [Monad m₂] [LawfulMonad m₁] [LawfulMonad m₂] [Preorder l]
 variable [MAlgRelOrdered m₁ m₂ l]
 
-/-- Left `StateT` lift for heterogeneous relational algebras. -/
-noncomputable instance instStateTLeft (σ : Type u) :
+/-- Left `StateT` lift for heterogeneous relational algebras.
+
+This is a named definition rather than a global instance: registering both
+left and right lifts creates inequivalent instance paths when both sides use
+the same transformer. -/
+@[instance_reducible]
+noncomputable def stateTLeft (σ : Type u) :
     MAlgRelOrdered (StateT σ m₁) m₂ (σ → l) where
   rwp x y post := fun s =>
     MAlgRelOrdered.rwp (x.run s) y (fun xs b => post xs.1 b xs.2)
@@ -283,8 +289,10 @@ noncomputable instance instStateTLeft (σ : Type u) :
         (f := fun xs => (f xs.1).run xs.2) (g := g)
         (post := fun zs d => post zs.1 d zs.2))
 
-/-- Right `StateT` lift for heterogeneous relational algebras. -/
-noncomputable instance instStateTRight (σ : Type u) :
+/-- Right `StateT` lift for heterogeneous relational algebras. See
+`stateTLeft` for why transformer-side choices are explicit. -/
+@[instance_reducible]
+noncomputable def stateTRight (σ : Type u) :
     MAlgRelOrdered m₁ (StateT σ m₂) (σ → l) where
   rwp x y post := fun s =>
     MAlgRelOrdered.rwp x (y.run s) (fun a ys => post a ys.1 ys.2)
@@ -302,9 +310,11 @@ noncomputable instance instStateTRight (σ : Type u) :
         (f := f) (g := fun ys => (g ys.1).run ys.2)
         (post := fun c td => post c td.1 td.2))
 
-/-- Two-sided `StateT` instance: both sides carry their own state.
-The postcondition takes both output values and both final states. -/
-noncomputable instance instStateTBoth (σ₁ σ₂ : Type u) :
+/-- Two-sided `StateT` lift: both sides carry their own state.
+The postcondition takes both output values and both final states. This named
+definition fixes their order explicitly. -/
+@[instance_reducible]
+noncomputable def stateTBoth (σ₁ σ₂ : Type u) :
     MAlgRelOrdered (StateT σ₁ m₁) (StateT σ₂ m₂) (σ₁ → σ₂ → l) where
   rwp x y post := fun s₁ s₂ =>
     MAlgRelOrdered.rwp (x.run s₁) (y.run s₂)
@@ -332,8 +342,10 @@ variable {m₁ : Type u → Type v₁} {m₂ : Type u → Type v₂} {l : Type u
 variable [Monad m₁] [Monad m₂] [LawfulMonad m₁] [LawfulMonad m₂] [Preorder l] [OrderBot l]
 variable [MAlgRelOrdered m₁ m₂ l]
 
-/-- Right `OptionT` lift (interpreting `none` as `⊥`). -/
-noncomputable instance instOptionTRight :
+/-- Right `OptionT` lift (interpreting `none` as `⊥`). Explicit rather than
+global to avoid left/right transformer diamonds. -/
+@[instance_reducible]
+noncomputable def optionTRight :
     MAlgRelOrdered m₁ (OptionT m₂) l where
   rwp x y post :=
     MAlgRelOrdered.rwp x y.run (fun a ob =>
@@ -376,8 +388,10 @@ noncomputable instance instOptionTRight :
           (MAlgRelOrdered.rwp_bind_le (m₁ := m₁) (m₂ := m₂) (l := l)
             x y.run f gRun collapse)
 
-/-- Left `OptionT` lift (interpreting `none` as `⊥`). -/
-noncomputable instance instOptionTLeft :
+/-- Left `OptionT` lift (interpreting `none` as `⊥`). Explicit rather than
+global to avoid left/right transformer diamonds. -/
+@[instance_reducible]
+noncomputable def optionTLeft :
     MAlgRelOrdered (OptionT m₁) m₂ l where
   rwp x y post :=
     MAlgRelOrdered.rwp x.run y (fun oa b =>
@@ -430,8 +444,10 @@ noncomputable instance instOptionTLeft :
           (MAlgRelOrdered.rwp_bind_le (m₁ := m₁) (m₂ := m₂) (l := l)
             x.run y fRun g collapse)
 
-/-- Right `ExceptT` lift (interpreting exceptions as `⊥`). -/
-noncomputable instance instExceptTRight (ε : Type u) :
+/-- Right `ExceptT` lift (interpreting exceptions as `⊥`). Explicit rather
+than global to avoid left/right transformer diamonds. -/
+@[instance_reducible]
+noncomputable def exceptTRight (ε : Type u) :
     MAlgRelOrdered m₁ (ExceptT ε m₂) l where
   rwp x y post :=
     MAlgRelOrdered.rwp x y.run (fun a eb =>
@@ -477,8 +493,10 @@ noncomputable instance instExceptTRight (ε : Type u) :
           x y.run f gRun collapse using 1
         all_goals rfl
 
-/-- Left `ExceptT` lift (interpreting exceptions as `⊥`). -/
-noncomputable instance instExceptTLeft (ε : Type u) :
+/-- Left `ExceptT` lift (interpreting exceptions as `⊥`). Explicit rather
+than global to avoid left/right transformer diamonds. -/
+@[instance_reducible]
+noncomputable def exceptTLeft (ε : Type u) :
     MAlgRelOrdered (ExceptT ε m₁) m₂ l where
   rwp x y post :=
     MAlgRelOrdered.rwp x.run y (fun ea b =>
@@ -576,36 +594,57 @@ variable {m₁ : Type u → Type v₁} {m₂ : Type u → Type v₂} {l : Type u
 variable [Monad m₁] [Monad m₂] [LawfulMonad m₁] [LawfulMonad m₂] [Preorder l]
 variable [MAlgRelOrdered m₁ m₂ l]
 
-/-- Strictness lifts through the left `StateT` instance. -/
-instance instStrictBindStateTLeft [StrictBind m₁ m₂ l] (σ : Type u) :
-    StrictBind (StateT σ m₁) m₂ (σ → l) where
-  rwp_bind {_ _ _ _} x y f g post := by
-    funext s
-    have h := StrictBind.rwp_bind (m₁ := m₁) (m₂ := m₂) (l := l)
-      (x := x.run s) (y := y) (f := fun xs => (f xs.1).run xs.2) (g := g)
-      (post := fun zs d => post zs.1 d zs.2)
-    convert h using 1 <;> rfl
+/-! The strictness witnesses below are definitions, rather than theorems, so
+callers can install the matching named algebra/witness pair as local instances. -/
 
-/-- Strictness lifts through the right `StateT` instance. -/
-instance instStrictBindStateTRight [StrictBind m₁ m₂ l] (σ : Type u) :
-    StrictBind m₁ (StateT σ m₂) (σ → l) where
-  rwp_bind {_ _ _ _} x y f g post := by
-    funext s
-    have h := StrictBind.rwp_bind (m₁ := m₁) (m₂ := m₂) (l := l)
-      (x := x) (y := y.run s) (f := f) (g := fun ys => (g ys.1).run ys.2)
-      (post := fun c td => post c td.1 td.2)
-    convert h using 1 <;> rfl
+set_option linter.defProp false in
+set_option linter.style.haveILetI false in
+/-- Strictness lifts through the named left `StateT` algebra. -/
+@[instance_reducible]
+noncomputable def strictBindStateTLeft [StrictBind m₁ m₂ l] (σ : Type u) :
+    letI := stateTLeft (m₁ := m₁) (m₂ := m₂) (l := l) σ
+    StrictBind (StateT σ m₁) m₂ (σ → l) := by
+  letI := stateTLeft (m₁ := m₁) (m₂ := m₂) (l := l) σ
+  refine { rwp_bind := ?_ }
+  intro α β γ δ x y f g post
+  funext s
+  have h := StrictBind.rwp_bind (m₁ := m₁) (m₂ := m₂) (l := l)
+    (x := x.run s) (y := y) (f := fun xs => (f xs.1).run xs.2) (g := g)
+    (post := fun zs d => post zs.1 d zs.2)
+  convert h using 1 <;> rfl
 
-/-- Strictness lifts through the two-sided `StateT` instance. -/
-instance instStrictBindStateTBoth [StrictBind m₁ m₂ l] (σ₁ σ₂ : Type u) :
-    StrictBind (StateT σ₁ m₁) (StateT σ₂ m₂) (σ₁ → σ₂ → l) where
-  rwp_bind {_ _ _ _} x y f g post := by
-    funext s₁ s₂
-    have h := StrictBind.rwp_bind (m₁ := m₁) (m₂ := m₂) (l := l)
-      (x := x.run s₁) (y := y.run s₂)
-      (f := fun p₁ => (f p₁.1).run p₁.2) (g := fun p₂ => (g p₂.1).run p₂.2)
-      (post := fun p₁ p₂ => post p₁.1 p₂.1 p₁.2 p₂.2)
-    convert h using 1 <;> rfl
+set_option linter.defProp false in
+set_option linter.style.haveILetI false in
+/-- Strictness lifts through the named right `StateT` algebra. -/
+@[instance_reducible]
+noncomputable def strictBindStateTRight [StrictBind m₁ m₂ l] (σ : Type u) :
+    letI := stateTRight (m₁ := m₁) (m₂ := m₂) (l := l) σ
+    StrictBind m₁ (StateT σ m₂) (σ → l) := by
+  letI := stateTRight (m₁ := m₁) (m₂ := m₂) (l := l) σ
+  refine { rwp_bind := ?_ }
+  intro α β γ δ x y f g post
+  funext s
+  have h := StrictBind.rwp_bind (m₁ := m₁) (m₂ := m₂) (l := l)
+    (x := x) (y := y.run s) (f := f) (g := fun ys => (g ys.1).run ys.2)
+    (post := fun c td => post c td.1 td.2)
+  convert h using 1 <;> rfl
+
+set_option linter.defProp false in
+set_option linter.style.haveILetI false in
+/-- Strictness lifts through the named two-sided `StateT` algebra. -/
+@[instance_reducible]
+noncomputable def strictBindStateTBoth [StrictBind m₁ m₂ l] (σ₁ σ₂ : Type u) :
+    letI := stateTBoth (m₁ := m₁) (m₂ := m₂) (l := l) σ₁ σ₂
+    StrictBind (StateT σ₁ m₁) (StateT σ₂ m₂) (σ₁ → σ₂ → l) := by
+  letI := stateTBoth (m₁ := m₁) (m₂ := m₂) (l := l) σ₁ σ₂
+  refine { rwp_bind := ?_ }
+  intro α β γ δ x y f g post
+  funext s₁ s₂
+  have h := StrictBind.rwp_bind (m₁ := m₁) (m₂ := m₂) (l := l)
+    (x := x.run s₁) (y := y.run s₂)
+    (f := fun p₁ => (f p₁.1).run p₁.2) (g := fun p₂ => (g p₂.1).run p₂.2)
+    (post := fun p₁ p₂ => post p₁.1 p₂.1 p₁.2 p₂.2)
+  convert h using 1 <;> rfl
 
 end StrictBindInstances
 
@@ -622,7 +661,7 @@ freeze the relational `rwp` to the underlying unary `wp` at one of the two corne
 recovering Maillard et al.'s "two unary triples + a relational triple" pattern from
 [*The Next 700 Relational Program Logics*, POPL 2020] without committing to the full
 relative-monad machinery. They are precisely the ingredient missing from the lossy
-exception lifts (see `instExceptTLeft` / `instExceptTRight` above): once anchored, one
+exception lifts (see `exceptTLeft` / `exceptTRight` above): once anchored, one
 can derive *honest exception* combinators `wpExc` (unary) and `rwpExc` (relational)
 that track success and failure separately rather than collapsing failures to `⊥`.
 

--- a/PolyFun/Control/Monad/Algebra/Relational.lean
+++ b/PolyFun/Control/Monad/Algebra/Relational.lean
@@ -1,0 +1,672 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+module
+
+public import Mathlib.Order.CompleteLattice.Basic
+public import PolyFun.Control.Monad.Algebra
+
+/-!
+# Relational monad algebras
+
+This file introduces a two-monad relational analogue of `MAlgOrdered`:
+
+* `MAlgRelOrdered m₁ m₂ l` with a relational weakest-precondition operator `rwp`.
+* Generic relational triple rules (`pure`, `consequence`, `bind`, `map`).
+* Asynchronous (one-sided) bind rules `relWP_bind_left_le` / `relWP_bind_right_le`
+  and their `Triple` forms, recovering Maillard et al.'s asynchronous shapes.
+* Structural pure rules for `if`, `dite`, `Option.elim`, `Sum.elim`.
+* Side-lifting instances for heterogeneous stacks (`StateT`, `OptionT`, `ExceptT`).
+* `StrictBind` subclass capturing strict relational effect observations
+  (in the sense of Maillard et al.) together with `StateT` lifts that preserve it.
+
+The framework is the predicate-transformer specialization of Maillard et al.'s
+*simple framework* (POPL 2020, §2): the relational specification monad is fixed
+to `(α → β → l) → l` and the relational effect observation is inlined as the
+`rwp` field. Everything here is stated against abstract lawful monads and an
+abstract ordered carrier; concrete instantiations (for example coupling-based
+probabilistic carriers) live in downstream libraries.
+
+Attribution:
+- Loom repository: https://github.com/verse-lab/loom
+- POPL 2026 paper: *Foundational Multi-Modal Program Verifiers*,
+  Vladimir Gladshtein, George Pîrlea, Qiyuan Zhao, Vitaly Kurin, Ilya Sergey.
+  DOI: https://doi.org/10.1145/3776719
+- POPL 2020 paper: *The Next 700 Relational Program Logics*,
+  Kenji Maillard, Catalin Hritcu, Exequiel Rivas, Antoine Van Muylder.
+  DOI: https://doi.org/10.1145/3371072
+-/
+
+@[expose] public section
+
+universe u v₁ v₂ v₃ v₄
+
+/-- Ordered relational monad algebra between two monads. -/
+class MAlgRelOrdered (m₁ : Type u → Type v₁) (m₂ : Type u → Type v₂) (l : Type u)
+    [Monad m₁] [Monad m₂] [Preorder l] where
+  /-- Relational weakest precondition. -/
+  rwp : {α β : Type u} → m₁ α → m₂ β → (α → β → l) → l
+  /-- Pure rule for the relational weakest precondition. -/
+  rwp_pure {α β : Type u} (a : α) (b : β) (post : α → β → l) :
+      rwp (pure a) (pure b) post = post a b
+  /-- Monotonicity in the relational postcondition. -/
+  rwp_mono {α β : Type u} {x : m₁ α} {y : m₂ β} {post post' : α → β → l}
+      (hpost : ∀ a b, post a b ≤ post' a b) :
+      rwp x y post ≤ rwp x y post'
+  /-- Sequential composition rule for relational WPs. -/
+  rwp_bind_le {α β γ δ : Type u}
+      (x : m₁ α) (y : m₂ β) (f : α → m₁ γ) (g : β → m₂ δ) (post : γ → δ → l) :
+      rwp x y (fun a b => rwp (f a) (g b) post) ≤ rwp (x >>= f) (y >>= g) post
+
+namespace MAlgRelOrdered
+
+variable {m₁ : Type u → Type v₁} {m₂ : Type u → Type v₂} {l : Type u}
+variable [Monad m₁] [Monad m₂] [Preorder l] [MAlgRelOrdered m₁ m₂ l]
+variable {α β γ δ : Type u}
+
+/-- Relational weakest precondition induced by `MAlgRelOrdered`. -/
+abbrev RelWP (x : m₁ α) (y : m₂ β) (post : α → β → l) : l :=
+  MAlgRelOrdered.rwp x y post
+
+/-- Relational Hoare-style triple. -/
+def Triple (pre : l) (x : m₁ α) (y : m₂ β) (post : α → β → l) : Prop :=
+  pre ≤ RelWP x y post
+
+@[simp]
+theorem relWP_pure (a : α) (b : β) (post : α → β → l) :
+    RelWP (pure a : m₁ α) (pure b : m₂ β) post = post a b :=
+  MAlgRelOrdered.rwp_pure a b post
+
+theorem relWP_mono (x : m₁ α) (y : m₂ β) {post post' : α → β → l}
+    (hpost : ∀ a b, post a b ≤ post' a b) :
+    RelWP x y post ≤ RelWP x y post' :=
+  MAlgRelOrdered.rwp_mono hpost
+
+theorem relWP_bind_le (x : m₁ α) (y : m₂ β) (f : α → m₁ γ) (g : β → m₂ δ)
+    (post : γ → δ → l) :
+    RelWP x y (fun a b => RelWP (f a) (g b) post) ≤ RelWP (x >>= f) (y >>= g) post :=
+  MAlgRelOrdered.rwp_bind_le x y f g post
+
+theorem triple_conseq {pre pre' : l} {x : m₁ α} {y : m₂ β} {post post' : α → β → l}
+    (hpre : pre' ≤ pre) (hpost : ∀ a b, post a b ≤ post' a b) :
+    Triple pre x y post → Triple pre' x y post' := by
+  intro hxy
+  exact le_trans hpre (le_trans hxy (relWP_mono x y hpost))
+
+theorem triple_pure
+    {pre : l} {a : α} {b : β} {post : α → β → l}
+    (hpre : pre ≤ post a b) :
+    Triple pre (pure a : m₁ α) (pure b : m₂ β) post := by
+  simpa [Triple, relWP_pure] using hpre
+
+theorem triple_bind {pre : l} {x : m₁ α} {y : m₂ β}
+    {f : α → m₁ γ} {g : β → m₂ δ}
+    {cut : α → β → l} {post : γ → δ → l}
+    (hxy : Triple pre x y cut)
+    (hfg : ∀ a b, Triple (cut a b) (f a) (g b) post) :
+    Triple pre (x >>= f) (y >>= g) post := by
+  have hcut : pre ≤ RelWP x y (fun a b => RelWP (f a) (g b) post) :=
+    le_trans hxy (relWP_mono x y hfg)
+  exact le_trans hcut (relWP_bind_le x y f g post)
+
+/-- Mapping on the left program is monotone for relational WP. -/
+theorem relWP_map_left [LawfulMonad m₁] [LawfulMonad m₂]
+    (f : α → γ) (x : m₁ α) (y : m₂ β) (post : γ → β → l) :
+    RelWP x y (fun a b => post (f a) b) ≤ RelWP (f <$> x) y post := by
+  have hbind := relWP_bind_le x y (fun a => pure (f a)) (fun b => pure b) post
+  simpa [Functor.map, bind_pure_comp, relWP_pure] using hbind
+
+/-- Mapping on the right program is monotone for relational WP. -/
+theorem relWP_map_right [LawfulMonad m₁] [LawfulMonad m₂]
+    (g : β → δ) (x : m₁ α) (y : m₂ β) (post : α → δ → l) :
+    RelWP x y (fun a b => post a (g b)) ≤ RelWP x (g <$> y) post := by
+  have hbind := relWP_bind_le x y (fun a => pure a) (fun b => pure (g b)) post
+  simpa [Functor.map, bind_pure_comp, relWP_pure] using hbind
+
+/-- `Triple` form of `relWP_map_left`. -/
+theorem triple_map_left [LawfulMonad m₁] [LawfulMonad m₂]
+    (f : α → γ) {pre : l} {x : m₁ α} {y : m₂ β} {post : γ → β → l}
+    (h : Triple pre x y (fun a b => post (f a) b)) :
+    Triple pre (f <$> x) y post :=
+  le_trans h (relWP_map_left f x y post)
+
+/-- `Triple` form of `relWP_map_right`. -/
+theorem triple_map_right [LawfulMonad m₁] [LawfulMonad m₂]
+    (g : β → δ) {pre : l} {x : m₁ α} {y : m₂ β} {post : α → δ → l}
+    (h : Triple pre x y (fun a b => post a (g b))) :
+    Triple pre x (g <$> y) post :=
+  le_trans h (relWP_map_right g x y post)
+
+/-! ### Asynchronous (one-sided) bind rules
+
+These are the relational counterparts of SSProve's `apply_left` /
+`apply_right` (`theories/Relational/GenericRulesSimple.v`) and Maillard
+et al.'s asynchronous bind shapes (Eqs. 5–6 of *The Next 700 Relational
+Program Logics*). They let one side bind without forcing the other side
+to bind in lockstep, by absorbing the inactive side as a `pure`. Both are
+direct consequences of `relWP_bind_le` and lawful right-unit.
+-/
+
+/-- Asynchronous bind on the left: the right side performs no bind step. -/
+theorem relWP_bind_left_le [LawfulMonad m₂]
+    (x : m₁ α) (f : α → m₁ γ) (y : m₂ β) (post : γ → β → l) :
+    RelWP x y (fun a b => RelWP (f a) (pure b : m₂ β) post) ≤ RelWP (x >>= f) y post := by
+  have h := relWP_bind_le (γ := γ) (δ := β) x y f (fun b : β => (pure b : m₂ β)) post
+  simpa [bind_pure] using h
+
+/-- Asynchronous bind on the right: the left side performs no bind step. -/
+theorem relWP_bind_right_le [LawfulMonad m₁]
+    (x : m₁ α) (y : m₂ β) (g : β → m₂ δ) (post : α → δ → l) :
+    RelWP x y (fun a b => RelWP (pure a : m₁ α) (g b) post) ≤ RelWP x (y >>= g) post := by
+  have h := relWP_bind_le (γ := α) (δ := δ) x y (fun a : α => (pure a : m₁ α)) g post
+  simpa [bind_pure] using h
+
+/-- `Triple` form of `relWP_bind_left_le`: chain a left-side `bind` against
+a right-side that stays inert. -/
+theorem triple_bind_left [LawfulMonad m₂]
+    {pre : l} {x : m₁ α} {y : m₂ β} {f : α → m₁ γ}
+    {cut : α → β → l} {post : γ → β → l}
+    (hxy : Triple pre x y cut)
+    (hf : ∀ a b, Triple (cut a b) (f a) (pure b : m₂ β) post) :
+    Triple pre (x >>= f) y post := by
+  have hcut : pre ≤ RelWP x y (fun a b => RelWP (f a) (pure b : m₂ β) post) :=
+    le_trans hxy (relWP_mono x y hf)
+  exact le_trans hcut (relWP_bind_left_le x f y post)
+
+/-- `Triple` form of `relWP_bind_right_le`: chain a right-side `bind` against
+a left-side that stays inert. -/
+theorem triple_bind_right [LawfulMonad m₁]
+    {pre : l} {x : m₁ α} {y : m₂ β} {g : β → m₂ δ}
+    {cut : α → β → l} {post : α → δ → l}
+    (hxy : Triple pre x y cut)
+    (hg : ∀ a b, Triple (cut a b) (pure a : m₁ α) (g b) post) :
+    Triple pre x (y >>= g) post := by
+  have hcut : pre ≤ RelWP x y (fun a b => RelWP (pure a : m₁ α) (g b) post) :=
+    le_trans hxy (relWP_mono x y hg)
+  exact le_trans hcut (relWP_bind_right_le x y g post)
+
+/-! ### Structural pure rules
+
+Generic case-split rules that let `vcgen`/`rvcgen`-style proofs peel
+boolean, decidable-propositional, dependent-`if`, `Option`, and `Sum`
+case splits without unfolding `rwp`. These are the relational analogues
+of SSProve's `if_rule` / `nat_rect_rule`
+(`theories/Relational/GenericRulesSimple.v`) and Maillard et al.'s R1
+rules. The `nat_rect` analogue is intentionally omitted: Lean's
+`induction n` is the idiomatic substitute.
+-/
+
+/-- Boolean if-then-else with the same scrutinee on both sides. -/
+theorem triple_ite (b : Bool) {pre : l} {x x' : m₁ α} {y y' : m₂ β}
+    {post : α → β → l}
+    (h_t : b = true → Triple pre x y post)
+    (h_f : b = false → Triple pre x' y' post) :
+    Triple pre (if b then x else x') (if b then y else y') post := by
+  cases hb : b
+  · simpa [hb] using h_f hb
+  · simpa [hb] using h_t hb
+
+/-- Decidable propositional if-then-else with the same scrutinee on both sides. -/
+theorem triple_ite_prop {p : Prop} [Decidable p]
+    {pre : l} {x x' : m₁ α} {y y' : m₂ β} {post : α → β → l}
+    (h_t : p → Triple pre x y post)
+    (h_f : ¬ p → Triple pre x' y' post) :
+    Triple pre (if p then x else x') (if p then y else y') post := by
+  by_cases hp : p
+  · simpa [hp] using h_t hp
+  · simpa [hp] using h_f hp
+
+/-- Dependent if-then-else with the same scrutinee on both sides. -/
+theorem triple_dite {p : Prop} [Decidable p] {pre : l}
+    {x : p → m₁ α} {x' : ¬ p → m₁ α}
+    {y : p → m₂ β} {y' : ¬ p → m₂ β}
+    {post : α → β → l}
+    (h_t : ∀ hp : p, Triple pre (x hp) (y hp) post)
+    (h_f : ∀ hnp : ¬ p, Triple pre (x' hnp) (y' hnp) post) :
+    Triple pre (if h : p then x h else x' h) (if h : p then y h else y' h) post := by
+  by_cases hp : p
+  · simpa [hp] using h_t hp
+  · simpa [hp] using h_f hp
+
+/-- `Option.elim` with the same scrutinee on both sides. -/
+theorem triple_option_elim {α' : Type u} (oa : Option α') {pre : l}
+    {x : m₁ α} {x' : α' → m₁ α}
+    {y : m₂ β} {y' : α' → m₂ β}
+    {post : α → β → l}
+    (h_none : oa = none → Triple pre x y post)
+    (h_some : ∀ a, oa = some a → Triple pre (x' a) (y' a) post) :
+    Triple pre (oa.elim x x') (oa.elim y y') post := by
+  cases oa with
+  | none => simpa using h_none rfl
+  | some a => simpa using h_some a rfl
+
+/-- `Sum.elim` with the same scrutinee on both sides. -/
+theorem triple_sum_elim {α' β' : Type u} (s : α' ⊕ β') {pre : l}
+    {x : α' → m₁ α} {x' : β' → m₁ α}
+    {y : α' → m₂ β} {y' : β' → m₂ β}
+    {post : α → β → l}
+    (h_inl : ∀ a, s = .inl a → Triple pre (x a) (y a) post)
+    (h_inr : ∀ b, s = .inr b → Triple pre (x' b) (y' b) post) :
+    Triple pre (s.elim x x') (s.elim y y') post := by
+  cases s with
+  | inl a => simpa using h_inl a rfl
+  | inr b => simpa using h_inr b rfl
+
+end MAlgRelOrdered
+
+namespace MAlgRelOrdered
+
+section Instances
+
+variable {m₁ : Type u → Type v₁} {m₂ : Type u → Type v₂} {l : Type u}
+variable [Monad m₁] [Monad m₂] [LawfulMonad m₁] [LawfulMonad m₂] [Preorder l]
+variable [MAlgRelOrdered m₁ m₂ l]
+
+/-- Left `StateT` lift for heterogeneous relational algebras. -/
+noncomputable instance instStateTLeft (σ : Type u) :
+    MAlgRelOrdered (StateT σ m₁) m₂ (σ → l) where
+  rwp x y post := fun s =>
+    MAlgRelOrdered.rwp (x.run s) y (fun xs b => post xs.1 b xs.2)
+  rwp_pure a b post := by
+    funext s
+    simp [StateT.run_pure]
+  rwp_mono hpost := by
+    intro s
+    exact MAlgRelOrdered.rwp_mono (m₁ := m₁) (m₂ := m₂) (l := l) (fun xs b => hpost xs.1 b xs.2)
+  rwp_bind_le x y f g post := by
+    intro s
+    simpa [StateT.run_bind] using
+      (MAlgRelOrdered.rwp_bind_le (m₁ := m₁) (m₂ := m₂) (l := l)
+        (x := x.run s) (y := y)
+        (f := fun xs => (f xs.1).run xs.2) (g := g)
+        (post := fun zs d => post zs.1 d zs.2))
+
+/-- Right `StateT` lift for heterogeneous relational algebras. -/
+noncomputable instance instStateTRight (σ : Type u) :
+    MAlgRelOrdered m₁ (StateT σ m₂) (σ → l) where
+  rwp x y post := fun s =>
+    MAlgRelOrdered.rwp x (y.run s) (fun a ys => post a ys.1 ys.2)
+  rwp_pure a b post := by
+    funext s
+    simp [StateT.run_pure]
+  rwp_mono hpost := by
+    intro s
+    exact MAlgRelOrdered.rwp_mono (m₁ := m₁) (m₂ := m₂) (l := l) (fun a ys => hpost a ys.1 ys.2)
+  rwp_bind_le x y f g post := by
+    intro s
+    simpa [StateT.run_bind] using
+      (MAlgRelOrdered.rwp_bind_le (m₁ := m₁) (m₂ := m₂) (l := l)
+        (x := x) (y := y.run s)
+        (f := f) (g := fun ys => (g ys.1).run ys.2)
+        (post := fun c td => post c td.1 td.2))
+
+/-- Two-sided `StateT` instance: both sides carry their own state.
+The postcondition takes both output values and both final states. -/
+noncomputable instance instStateTBoth (σ₁ σ₂ : Type u) :
+    MAlgRelOrdered (StateT σ₁ m₁) (StateT σ₂ m₂) (σ₁ → σ₂ → l) where
+  rwp x y post := fun s₁ s₂ =>
+    MAlgRelOrdered.rwp (x.run s₁) (y.run s₂)
+      (fun p₁ p₂ => post p₁.1 p₂.1 p₁.2 p₂.2)
+  rwp_pure a b post := by
+    funext s₁ s₂
+    simp [StateT.run_pure]
+  rwp_mono hpost := by
+    intro s₁ s₂
+    exact MAlgRelOrdered.rwp_mono (m₁ := m₁) (m₂ := m₂) (l := l)
+      (fun p₁ p₂ => hpost p₁.1 p₂.1 p₁.2 p₂.2)
+  rwp_bind_le x y f g post := by
+    intro s₁ s₂
+    simpa [StateT.run_bind] using
+      (MAlgRelOrdered.rwp_bind_le (m₁ := m₁) (m₂ := m₂) (l := l)
+        (x := x.run s₁) (y := y.run s₂)
+        (f := fun p₁ => (f p₁.1).run p₁.2) (g := fun p₂ => (g p₂.1).run p₂.2)
+        (post := fun p₁ p₂ => post p₁.1 p₂.1 p₁.2 p₂.2))
+
+end Instances
+
+section FailureInstances
+
+variable {m₁ : Type u → Type v₁} {m₂ : Type u → Type v₂} {l : Type u}
+variable [Monad m₁] [Monad m₂] [LawfulMonad m₁] [LawfulMonad m₂] [Preorder l] [OrderBot l]
+variable [MAlgRelOrdered m₁ m₂ l]
+
+/-- Right `OptionT` lift (interpreting `none` as `⊥`). -/
+noncomputable instance instOptionTRight :
+    MAlgRelOrdered m₁ (OptionT m₂) l where
+  rwp x y post :=
+    MAlgRelOrdered.rwp x y.run (fun a ob =>
+      match ob with
+      | none => ⊥
+      | some b => post a b)
+  rwp_pure a b post := by
+    simp
+  rwp_mono hpost :=
+    MAlgRelOrdered.rwp_mono (m₁ := m₁) (m₂ := m₂) (l := l) (fun a ob => by
+      cases ob with
+      | none => exact le_rfl
+      | some b => simpa using hpost a b)
+  rwp_bind_le {α β γ δ} x y f g post := by
+    let collapse : γ → Option δ → l := fun c od =>
+      match od with
+      | none => ⊥
+      | some d => post c d
+    let gRun : Option β → m₂ (Option δ) := fun ob =>
+      Option.elim ob (pure none) (fun b => (g b).run)
+    have hmono :
+        MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (l := l) x y.run
+          (fun a ob =>
+            match ob with
+            | none => ⊥
+            | some b => MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (l := l) (f a) (g b).run collapse)
+        ≤
+        MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (l := l) x y.run (fun a ob =>
+          MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (l := l) (f a) (gRun ob) collapse) := by
+      apply MAlgRelOrdered.rwp_mono (m₁ := m₁) (m₂ := m₂) (l := l)
+      intro a ob
+      cases ob with
+      | none =>
+          simp [gRun, collapse]
+      | some b =>
+          simp [gRun]
+    exact le_trans hmono <|
+      by
+        simpa [OptionT.run_bind, Option.elimM, gRun, collapse] using
+          (MAlgRelOrdered.rwp_bind_le (m₁ := m₁) (m₂ := m₂) (l := l)
+            x y.run f gRun collapse)
+
+/-- Left `OptionT` lift (interpreting `none` as `⊥`). -/
+noncomputable instance instOptionTLeft :
+    MAlgRelOrdered (OptionT m₁) m₂ l where
+  rwp x y post :=
+    MAlgRelOrdered.rwp x.run y (fun oa b =>
+      match oa with
+      | none => ⊥
+      | some a => post a b)
+  rwp_pure a b post := by
+    simp
+  rwp_mono hpost :=
+    MAlgRelOrdered.rwp_mono (m₁ := m₁) (m₂ := m₂) (l := l) (fun oa b => by
+      cases oa with
+      | none => exact le_rfl
+      | some a => simpa using hpost a b)
+  rwp_bind_le {α β γ δ} x y f g post := by
+    let collapse : Option γ → δ → l := fun oa b =>
+      match oa with
+      | none => ⊥
+      | some a => post a b
+    let fRun : Option α → m₁ (Option γ) := fun oa =>
+      Option.elim oa (pure none) (fun a => (f a).run)
+    have hmono :
+        MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (l := l) x.run y
+          (fun oa b =>
+            match oa with
+            | none => ⊥
+            | some a => MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (l := l) (f a).run (g b) collapse)
+        ≤
+        MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (l := l) x.run y (fun oa b =>
+          MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (l := l) (fRun oa) (g b) collapse) := by
+      apply MAlgRelOrdered.rwp_mono (m₁ := m₁) (m₂ := m₂) (l := l)
+      intro oa b
+      cases oa with
+      | none =>
+          simp [fRun, collapse]
+      | some a =>
+          simp [fRun]
+    have hmono' :
+        MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (l := l) x.run y
+          (fun oa b =>
+            match oa with
+            | none => ⊥
+            | some a => MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (l := l) (f a).run (g b) collapse)
+        ≤
+        MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (l := l) x.run y (fun oa b =>
+          MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (l := l) (fRun oa) (g b) collapse) := by
+      simpa [collapse] using hmono
+    exact le_trans hmono' <|
+      by
+        simpa [OptionT.run_bind, Option.elimM, fRun, collapse] using
+          (MAlgRelOrdered.rwp_bind_le (m₁ := m₁) (m₂ := m₂) (l := l)
+            x.run y fRun g collapse)
+
+/-- Right `ExceptT` lift (interpreting exceptions as `⊥`). -/
+noncomputable instance instExceptTRight (ε : Type u) :
+    MAlgRelOrdered m₁ (ExceptT ε m₂) l where
+  rwp x y post :=
+    MAlgRelOrdered.rwp x y.run (fun a eb =>
+      match eb with
+      | Except.error _ => ⊥
+      | Except.ok b => post a b)
+  rwp_pure a b post := by
+    simp
+  rwp_mono hpost :=
+    MAlgRelOrdered.rwp_mono (m₁ := m₁) (m₂ := m₂) (l := l) (fun a eb => by
+      cases eb with
+      | error e => exact le_rfl
+      | ok b => simpa using hpost a b)
+  rwp_bind_le {α β γ δ} x y f g post := by
+    let collapse : γ → Except ε δ → l := fun c ed =>
+      match ed with
+      | Except.error _ => ⊥
+      | Except.ok d => post c d
+    let gRun : Except ε β → m₂ (Except ε δ) := fun eb =>
+      match eb with
+      | Except.ok b => (g b).run
+      | Except.error e => pure (Except.error e)
+    have hmono :
+        MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (l := l) x y.run
+          (fun a eb =>
+            match eb with
+            | Except.error _ => ⊥
+            | Except.ok b =>
+                MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (l := l) (f a) (g b).run collapse)
+        ≤
+        MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (l := l) x y.run (fun a eb =>
+          MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (l := l) (f a) (gRun eb) collapse) := by
+      apply MAlgRelOrdered.rwp_mono (m₁ := m₁) (m₂ := m₂) (l := l)
+      intro a eb
+      cases eb with
+      | error e =>
+          simp [gRun, collapse]
+      | ok b =>
+          simp [gRun]
+    exact le_trans hmono <|
+      by
+        convert MAlgRelOrdered.rwp_bind_le (m₁ := m₁) (m₂ := m₂) (l := l)
+          x y.run f gRun collapse using 1
+        all_goals rfl
+
+/-- Left `ExceptT` lift (interpreting exceptions as `⊥`). -/
+noncomputable instance instExceptTLeft (ε : Type u) :
+    MAlgRelOrdered (ExceptT ε m₁) m₂ l where
+  rwp x y post :=
+    MAlgRelOrdered.rwp x.run y (fun ea b =>
+      match ea with
+      | Except.error _ => ⊥
+      | Except.ok a => post a b)
+  rwp_pure a b post := by
+    simp
+  rwp_mono hpost :=
+    MAlgRelOrdered.rwp_mono (m₁ := m₁) (m₂ := m₂) (l := l) (fun ea b => by
+      cases ea with
+      | error e => exact le_rfl
+      | ok a => simpa using hpost a b)
+  rwp_bind_le {α β γ δ} x y f g post := by
+    let collapse : Except ε γ → δ → l := fun ec d =>
+      match ec with
+      | Except.error _ => ⊥
+      | Except.ok c => post c d
+    let fRun : Except ε α → m₁ (Except ε γ) := fun ea =>
+      match ea with
+      | Except.ok a => (f a).run
+      | Except.error e => pure (Except.error e)
+    have hmono :
+        MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (l := l) x.run y
+          (fun ea b =>
+            match ea with
+            | Except.error _ => ⊥
+            | Except.ok a =>
+                MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (l := l) (f a).run (g b) collapse)
+        ≤
+        MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (l := l) x.run y (fun ea b =>
+          MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (l := l) (fRun ea) (g b) collapse) := by
+      apply MAlgRelOrdered.rwp_mono (m₁ := m₁) (m₂ := m₂) (l := l)
+      intro ea b
+      cases ea with
+      | error e =>
+          simp [fRun, collapse]
+      | ok a =>
+          simp [fRun]
+    exact le_trans hmono <|
+      by
+        convert MAlgRelOrdered.rwp_bind_le (m₁ := m₁) (m₂ := m₂) (l := l)
+          x.run y fRun g collapse using 1
+        all_goals rfl
+
+end FailureInstances
+
+/-! ## Strict bind subclass
+
+Maillard et al.'s "simple framework" distinguishes *lax* relational
+effect observations (the bind law is an inequality) from *strict* ones
+(the bind law is an equality). The default `MAlgRelOrdered` class
+records only the lax form via `rwp_bind_le`; the strict subclass
+`StrictBind` adds the equality. Strictness holds when the underlying
+relational specification monad is deterministic in both arguments
+(Reader-, Writer-, plain-State-style without sampling), and is
+preserved by every `StateT` lift in this file. Coupling-based
+probabilistic carriers are intrinsically lax because the optimal
+coupling for a composite computation can be more precise than the
+sequential composition of optimal couplings.
+-/
+
+/-- A `MAlgRelOrdered` instance whose `rwp` bind law is an equality, not just an
+inequality. This is the strict relational effect observation in the sense of
+Maillard et al. (Def. 2 of *The Next 700 Relational Program Logics*). -/
+class StrictBind (m₁ : Type u → Type v₁) (m₂ : Type u → Type v₂) (l : Type u)
+    [Monad m₁] [Monad m₂] [Preorder l] [MAlgRelOrdered m₁ m₂ l] : Prop where
+  /-- Strict bind law: relational WP of a sequenced computation equals the
+  iterated relational WP. -/
+  rwp_bind {α β γ δ : Type u} (x : m₁ α) (y : m₂ β) (f : α → m₁ γ) (g : β → m₂ δ)
+      (post : γ → δ → l) :
+    MAlgRelOrdered.rwp x y (fun a b => MAlgRelOrdered.rwp (f a) (g b) post) =
+      MAlgRelOrdered.rwp (x >>= f) (y >>= g) post
+
+namespace StrictBind
+
+variable {m₁ : Type u → Type v₁} {m₂ : Type u → Type v₂} {l : Type u}
+variable [Monad m₁] [Monad m₂] [Preorder l]
+variable [MAlgRelOrdered m₁ m₂ l]
+variable {α β γ δ : Type u}
+
+/-- Strict version of `relWP_bind_le`: under `StrictBind` the bind law is an
+equality, so the relational WP of a sequenced computation can be rewritten in
+either direction. -/
+theorem relWP_bind [StrictBind m₁ m₂ l]
+    (x : m₁ α) (y : m₂ β) (f : α → m₁ γ) (g : β → m₂ δ) (post : γ → δ → l) :
+    RelWP x y (fun a b => RelWP (f a) (g b) post) = RelWP (x >>= f) (y >>= g) post :=
+  StrictBind.rwp_bind x y f g post
+
+end StrictBind
+
+section StrictBindInstances
+
+variable {m₁ : Type u → Type v₁} {m₂ : Type u → Type v₂} {l : Type u}
+variable [Monad m₁] [Monad m₂] [LawfulMonad m₁] [LawfulMonad m₂] [Preorder l]
+variable [MAlgRelOrdered m₁ m₂ l]
+
+/-- Strictness lifts through the left `StateT` instance. -/
+instance instStrictBindStateTLeft [StrictBind m₁ m₂ l] (σ : Type u) :
+    StrictBind (StateT σ m₁) m₂ (σ → l) where
+  rwp_bind {_ _ _ _} x y f g post := by
+    funext s
+    have h := StrictBind.rwp_bind (m₁ := m₁) (m₂ := m₂) (l := l)
+      (x := x.run s) (y := y) (f := fun xs => (f xs.1).run xs.2) (g := g)
+      (post := fun zs d => post zs.1 d zs.2)
+    convert h using 1 <;> rfl
+
+/-- Strictness lifts through the right `StateT` instance. -/
+instance instStrictBindStateTRight [StrictBind m₁ m₂ l] (σ : Type u) :
+    StrictBind m₁ (StateT σ m₂) (σ → l) where
+  rwp_bind {_ _ _ _} x y f g post := by
+    funext s
+    have h := StrictBind.rwp_bind (m₁ := m₁) (m₂ := m₂) (l := l)
+      (x := x) (y := y.run s) (f := f) (g := fun ys => (g ys.1).run ys.2)
+      (post := fun c td => post c td.1 td.2)
+    convert h using 1 <;> rfl
+
+/-- Strictness lifts through the two-sided `StateT` instance. -/
+instance instStrictBindStateTBoth [StrictBind m₁ m₂ l] (σ₁ σ₂ : Type u) :
+    StrictBind (StateT σ₁ m₁) (StateT σ₂ m₂) (σ₁ → σ₂ → l) where
+  rwp_bind {_ _ _ _} x y f g post := by
+    funext s₁ s₂
+    have h := StrictBind.rwp_bind (m₁ := m₁) (m₂ := m₂) (l := l)
+      (x := x.run s₁) (y := y.run s₂)
+      (f := fun p₁ => (f p₁.1).run p₁.2) (g := fun p₂ => (g p₂.1).run p₂.2)
+      (post := fun p₁ p₂ => post p₁.1 p₂.1 p₁.2 p₂.2)
+    convert h using 1 <;> rfl
+
+end StrictBindInstances
+
+/-! ## Anchored subclass
+
+A relational logic is *anchored* (with respect to a unary algebra on each side) when
+relational reasoning collapses to unary reasoning whenever one of the two computations
+is a `pure` value. The two coherence axioms
+
+* `rwp_pure_left a y post = wp y (post a)`
+* `rwp_pure_right x b post = wp x (fun a => post a b)`
+
+freeze the relational `rwp` to the underlying unary `wp` at one of the two corners,
+recovering Maillard et al.'s "two unary triples + a relational triple" pattern from
+[*The Next 700 Relational Program Logics*, POPL 2020] without committing to the full
+relative-monad machinery. They are precisely the ingredient missing from the lossy
+exception lifts (see `instExceptTLeft` / `instExceptTRight` above): once anchored, one
+can derive *honest exception* combinators `wpExc` (unary) and `rwpExc` (relational)
+that track success and failure separately rather than collapsing failures to `⊥`.
+
+Anchoring is independent of `StrictBind`. A coupling-based probabilistic carrier is
+anchored (Dirac couplings are unique) but is not strict, while a deterministic
+specification monad is strict and anchored.
+-/
+
+/-- A `MAlgRelOrdered` instance that *anchors* the relational WP to the unary WPs of
+the two sides at `pure`. The two axioms are the relational analogues of the coupling
+identities `IsCoupling c (pure a) q ↔ c = (a, ·) <$> q` (and symmetrically on the
+right): once one side is a Dirac, the relational WP collapses to the unary WP of the
+other side, specialized at the Dirac point. -/
+class Anchored (m₁ : Type u → Type v₁) (m₂ : Type u → Type v₂) (l : Type u)
+    [Monad m₁] [Monad m₂] [CompleteLattice l]
+    [MAlgOrdered m₁ l] [MAlgOrdered m₂ l] [MAlgRelOrdered m₁ m₂ l] : Prop where
+  /-- Left anchoring: when the left computation is `pure a`, the relational WP equals
+  the unary WP of the right computation evaluated at the postcondition specialized at
+  `a`. -/
+  rwp_pure_left {α β : Type u} (a : α) (y : m₂ β) (post : α → β → l) :
+    MAlgRelOrdered.rwp (pure a : m₁ α) y post = MAlgOrdered.wp y (post a)
+  /-- Right anchoring: when the right computation is `pure b`, the relational WP equals
+  the unary WP of the left computation evaluated at the postcondition specialized at
+  `b`. -/
+  rwp_pure_right {α β : Type u} (x : m₁ α) (b : β) (post : α → β → l) :
+    MAlgRelOrdered.rwp x (pure b : m₂ β) post = MAlgOrdered.wp x (fun a => post a b)
+
+namespace Anchored
+
+variable {m₁ : Type u → Type v₁} {m₂ : Type u → Type v₂} {l : Type u}
+variable [Monad m₁] [Monad m₂] [CompleteLattice l]
+variable [MAlgOrdered m₁ l] [MAlgOrdered m₂ l] [MAlgRelOrdered m₁ m₂ l]
+variable {α β : Type u}
+
+/-- `RelWP`-flavoured restatement of the left anchoring axiom. -/
+theorem relWP_pure_left [Anchored m₁ m₂ l] (a : α) (y : m₂ β) (post : α → β → l) :
+    RelWP (pure a : m₁ α) y post = MAlgOrdered.wp y (post a) :=
+  Anchored.rwp_pure_left a y post
+
+/-- `RelWP`-flavoured restatement of the right anchoring axiom. -/
+theorem relWP_pure_right [Anchored m₁ m₂ l] (x : m₁ α) (b : β) (post : α → β → l) :
+    RelWP x (pure b : m₂ β) post = MAlgOrdered.wp x (fun a => post a b) :=
+  Anchored.rwp_pure_right x b post
+
+end Anchored
+
+end MAlgRelOrdered

--- a/PolyFun/PFunctor/Free/Do.lean
+++ b/PolyFun/PFunctor/Free/Do.lean
@@ -20,7 +20,7 @@ semantics in two ways:
   `MonadHom.transportWPMonad`. Registration is left to the caller.
 * **Demonically, with operations uninterpreted**: the *scoped* instances
   `instWPAll` / `instWPMonadAll` interpret `wp⟦x⟧ Q` as "every possible output of
-  `x` satisfies `Q`" (the `MonadSupport.toWP` structure at the `.pure` post
+  `x` satisfies `Q`" (the `MonadAttach.toWP` structure at the `.pure` post
   shape). Under `open scoped PFunctor.FreeM.DemonicWP`, the `mvcgen` tactic
   decomposes `do`-programs over `FreeM P`, with `Spec.lift` providing the
   verification condition for an uninterpreted operation: all of its responses
@@ -50,14 +50,21 @@ def wpMonadOfHandler {n : Type uB → Type w} {ps : PostShape.{uB}} [Monad n]
 
 namespace DemonicWP
 
+open MonadAttach
+
 /-- Demonic (all-outputs) predicate-transformer semantics for free programs with
 uninterpreted operations, at the `.pure` post shape. -/
 scoped instance instWPAll : WP (FreeM P) .pure :=
-  MonadSupport.toWP
+  MonadAttach.toWP
 
 /-- The demonic semantics respects the monad structure. -/
 scoped instance instWPMonadAll : WPMonad (FreeM P) .pure :=
-  MonadSupport.toWPMonad
+  MonadAttach.toWPMonad
+
+/-- The demonic semantics is sound in core's sense, so an `mvcgen`-discharged
+triple converts to a support fact via `WPSound.of_wp_canReturn`. -/
+scoped instance instWPSoundAll : WPSound (FreeM P) .pure :=
+  MonadAttach.toWPSound
 
 variable {α : Type uB}
 

--- a/PolyFun/PFunctor/Free/Do.lean
+++ b/PolyFun/PFunctor/Free/Do.lean
@@ -1,0 +1,94 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+module
+
+public import PolyFun.Control.Do.Basic
+public import PolyFun.PFunctor.Free.WP
+
+/-!
+# Core `Std.Do` Structure for the Free Monad
+
+Together with `PolyFun.Control.Do.Basic`, this file quarantines PolyFun's use of
+the core `Std.Do` framework. It equips `FreeM P` with predicate-transformer
+semantics in two ways:
+
+* **Through a handler**: `FreeM.wpMonadOfHandler s` interprets programs by
+  `FreeM.liftM s` into any monad already carrying a `WPMonad` structure, via
+  `MonadHom.transportWPMonad`. Registration is left to the caller.
+* **Demonically, with operations uninterpreted**: the *scoped* instances
+  `instWPAll` / `instWPMonadAll` interpret `wp⟦x⟧ Q` as "every possible output of
+  `x` satisfies `Q`" (the `MonadSupport.toWP` structure at the `.pure` post
+  shape). Under `open scoped PFunctor.FreeM.DemonicWP`, the `mvcgen` tactic
+  decomposes `do`-programs over `FreeM P`, with `Spec.lift` providing the
+  verification condition for an uninterpreted operation: all of its responses
+  must satisfy the continuation.
+
+The instances are scoped because downstream libraries register their own
+`Std.Do.WP` structures on reducible unfoldings of `FreeM` (for example on oracle
+computations); a global instance here would race those registrations.
+-/
+
+@[expose] public section
+
+universe uA uB v w
+
+open Std.Do
+
+namespace PFunctor.FreeM
+
+variable {P : PFunctor.{uA, uB}}
+
+/-- Interpret free programs through a handler into a monad with a `WPMonad`
+structure. Not an instance — register it scoped or local downstream. -/
+@[instance_reducible]
+def wpMonadOfHandler {n : Type uB → Type w} {ps : PostShape.{uB}} [Monad n]
+    [WPMonad n ps] (s : Handler n P) : WPMonad (FreeM P) ps :=
+  (FreeM.liftMHom s).transportWPMonad
+
+namespace DemonicWP
+
+/-- Demonic (all-outputs) predicate-transformer semantics for free programs with
+uninterpreted operations, at the `.pure` post shape. -/
+scoped instance instWPAll : WP (FreeM P) .pure :=
+  MonadSupport.toWP
+
+/-- The demonic semantics respects the monad structure. -/
+scoped instance instWPMonadAll : WPMonad (FreeM P) .pure :=
+  MonadSupport.toWPMonad
+
+variable {α : Type uB}
+
+/-- The demonic `wp⟦x⟧` is the "always" judgment on the success postcondition. -/
+theorem wp_apply_eq (x : FreeM P α) (Q : PostCond α .pure) :
+    wp⟦x⟧ Q = ⌜AllOutputs (fun a => (Q.1 a).down) x⌝ :=
+  rfl
+
+/-- The demonic triple with trivial precondition is the "always" judgment. -/
+theorem triple_iff_allOutputs (x : FreeM P α) (Q : PostCond α .pure) :
+    Triple x ⌜True⌝ Q ↔ AllOutputs (fun a => (Q.1 a).down) x := by
+  constructor
+  · intro h
+    exact h trivial
+  · intro h
+    exact SPred.pure_mono fun _ => h
+
+end DemonicWP
+
+namespace Spec
+
+open DemonicWP
+
+/-- Schematic specification for an uninterpreted operation under the demonic
+semantics: the weakest precondition of `FreeM.lift a` demands the postcondition
+of *every* response. Registered for `mvcgen`. -/
+@[spec]
+theorem lift (a : P.A) {Q : PostCond (P.B a) .pure} :
+    Triple (FreeM.lift (P := P) a) (⌜∀ b, (Q.1 b).down⌝) Q :=
+  SPred.pure_mono fun h b _ => h b
+
+end Spec
+
+end PFunctor.FreeM

--- a/PolyFun/PFunctor/Free/WP.lean
+++ b/PolyFun/PFunctor/Free/WP.lean
@@ -1,0 +1,241 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+module
+
+public import PolyFun.PFunctor.Free.Support
+public import PolyFun.PFunctor.Handler
+
+/-!
+# Weakest Preconditions Over the Free Monad
+
+This file provides the extrinsic verification-condition substrate for `FreeM P`,
+in two coupled layers:
+
+* **Syntactic wp.** An `OpSpec P l` assigns each operation `a : P.A` a predicate
+  transformer `(P.B a → l) → l` over an ordered carrier `l`, saying what one call
+  to `a` guarantees. `FreeM.wpFold Φ` folds these per-operation specs over a free
+  tree, leaving the operations uninterpreted. Every monotone spec induces an
+  ordered monad algebra `OpSpec.toMAlgOrdered`, so the whole `MAlgOrdered.wp` /
+  `Triple` rule set applies; `wp_toMAlgOrdered` identifies the induced `wp` with
+  `wpFold`.
+
+* **Semantic wp.** `FreeM.wpVia s` is the weakest precondition of the program
+  *interpreted* through a handler `s : Handler m P` into a monad carrying an
+  ordered algebra. The soundness theorems `wpFold_le_wpVia` / `wpFold_eq_wpVia`
+  say that per-operation specs that (under-)approximate the handler's wp give
+  syntactic wps that (under-)approximate the semantic wp — the generic engine
+  behind handler-specification reasoning.
+
+The canonical `Prop`-carrier specs `OpSpec.demonic` ("every response") and
+`OpSpec.angelic` ("some response") recover the support-based judgments of
+`PolyFun.PFunctor.Free.Support`: `wpFold_demonic_iff_allOutputs` and
+`wpFold_angelic_iff_someOutput` identify their folds with `AllOutputs` and
+`SomeOutput`, so trivial-precondition ("always" / "never") triples and the
+syntactic wp theory agree.
+-/
+
+@[expose] public section
+
+universe uA uB v w
+
+namespace PFunctor
+
+/-! ## Per-operation specifications -/
+
+/-- A per-operation predicate-transformer specification for the interface `P` over
+an ordered carrier `l`: at each position `a`, transform a postcondition on the
+directions of `a` into a precondition. -/
+def OpSpec (P : PFunctor.{uA, uB}) (l : Type w) : Type max uA uB w :=
+  (a : P.A) → (P.B a → l) → l
+
+namespace OpSpec
+
+variable {P : PFunctor.{uA, uB}} {l : Type w}
+
+/-- Monotonicity of a per-operation spec in its continuation. -/
+def Mono [Preorder l] (Φ : OpSpec P l) : Prop :=
+  ∀ (a : P.A) ⦃k k' : P.B a → l⦄, (∀ b, k b ≤ k' b) → Φ a k ≤ Φ a k'
+
+/-- The demonic ("all responses") spec on the `Prop` carrier: a call to `a`
+guarantees only that *every* response satisfies the continuation. -/
+def demonic (P : PFunctor.{uA, uB}) : OpSpec P Prop :=
+  fun _ k => ∀ b, k b
+
+/-- The angelic ("some response") spec on the `Prop` carrier: a call to `a`
+guarantees that *some* response satisfies the continuation. -/
+def angelic (P : PFunctor.{uA, uB}) : OpSpec P Prop :=
+  fun _ k => ∃ b, k b
+
+theorem demonic_mono : (demonic P).Mono :=
+  fun _ _ _ h hk b => h b (hk b)
+
+theorem angelic_mono : (angelic P).Mono :=
+  fun _ _ _ h => fun ⟨b, hb⟩ => ⟨b, h b hb⟩
+
+end OpSpec
+
+namespace FreeM
+
+variable {P : PFunctor.{uA, uB}} {l : Type w} {α β : Type v}
+
+/-! ## Syntactic weakest precondition -/
+
+/-- Fold a per-operation spec over a free tree: the syntactic weakest
+precondition of `x` for postcondition `post`, with operations uninterpreted. -/
+def wpFold (Φ : OpSpec P l) : FreeM P α → (α → l) → l
+  | .pure x, post => post x
+  | .liftBind a r, post => Φ a fun b => (r b).wpFold Φ post
+
+@[simp, freeM_unfold]
+theorem wpFold_pure (Φ : OpSpec P l) (x : α) (post : α → l) :
+    wpFold Φ (pure x : FreeM P α) post = post x :=
+  rfl
+
+@[freeM_unfold]
+theorem wpFold_liftBind (Φ : OpSpec P l) (a : P.A) (r : P.B a → FreeM P α)
+    (post : α → l) :
+    wpFold Φ (FreeM.liftBind a r) post = Φ a fun b => wpFold Φ (r b) post :=
+  rfl
+
+@[simp]
+theorem wpFold_lift (Φ : OpSpec P l) (a : P.A) (post : P.B a → l) :
+    wpFold Φ (FreeM.lift (P := P) a) post = Φ a post :=
+  rfl
+
+theorem wpFold_bind (Φ : OpSpec P l) (x : FreeM P α) (f : α → FreeM P β)
+    (post : β → l) :
+    wpFold Φ (x >>= f) post = wpFold Φ x fun a => wpFold Φ (f a) post := by
+  induction x with
+  | pure x => rfl
+  | lift_bind a r ih => exact congrArg (Φ a) (funext fun b => ih b)
+
+theorem wpFold_mono [Preorder l] {Φ : OpSpec P l} (hΦ : Φ.Mono) (x : FreeM P α)
+    {post post' : α → l} (h : ∀ a, post a ≤ post' a) :
+    wpFold Φ x post ≤ wpFold Φ x post' := by
+  induction x with
+  | pure x => exact h x
+  | lift_bind a r ih => exact hΦ a fun b => ih b
+
+/-! ## The induced ordered monad algebra -/
+
+/-- Every monotone per-operation spec over a complete lattice induces an ordered
+monad algebra on `FreeM P`, giving the full `MAlgOrdered.wp`/`Triple` rule set
+for free. -/
+@[instance_reducible]
+def _root_.PFunctor.OpSpec.toMAlgOrdered {l : Type v} [CompleteLattice l]
+    (Φ : OpSpec P l) (hΦ : Φ.Mono) : MAlgOrdered (FreeM P) l where
+  μ x := wpFold Φ x id
+  μ_pure _ := rfl
+  μ_bind_mono f g hfg x := by
+    rw [wpFold_bind, wpFold_bind]
+    exact wpFold_mono hΦ x hfg
+
+/-- The `MAlgOrdered.wp` induced by a per-operation spec is its syntactic fold. -/
+theorem wp_toMAlgOrdered {l : Type v} [CompleteLattice l]
+    (Φ : OpSpec P l) (hΦ : Φ.Mono) (x : FreeM P α) (post : α → l) :
+    letI := Φ.toMAlgOrdered hΦ
+    MAlgOrdered.wp x post = wpFold Φ x post := by
+  change wpFold Φ (x >>= fun a => pure (post a)) id = _
+  rw [wpFold_bind]
+  rfl
+
+/-! ## Semantic weakest precondition through a handler -/
+
+section wpVia
+
+variable {m : Type uB → Type w} [Monad m] [LawfulMonad m]
+  {l : Type uB} [CompleteLattice l] [MAlgOrdered m l] {α β : Type uB}
+
+/-- The semantic weakest precondition of a free program interpreted through a
+handler into a monad carrying an ordered algebra. -/
+def wpVia (s : Handler m P) (x : FreeM P α) (post : α → l) : l :=
+  MAlgOrdered.wp (x.liftM s) post
+
+@[simp]
+theorem wpVia_pure (s : Handler m P) (x : α) (post : α → l) :
+    wpVia s (pure x : FreeM P α) post = post x := by
+  rw [wpVia, FreeM.liftM_pure, MAlgOrdered.wp_pure]
+
+theorem wpVia_bind (s : Handler m P) (x : FreeM P α) (f : α → FreeM P β)
+    (post : β → l) :
+    wpVia s (x >>= f) post = wpVia s x fun a => wpVia s (f a) post := by
+  rw [wpVia, FreeM.liftM_bind, MAlgOrdered.wp_bind]
+  rfl
+
+theorem wpVia_liftBind (s : Handler m P) (a : P.A) (r : P.B a → FreeM P α)
+    (post : α → l) :
+    wpVia s (FreeM.liftBind a r) post =
+      MAlgOrdered.wp (s a) fun b => wpVia s (r b) post := by
+  rw [wpVia, show (FreeM.liftBind a r : FreeM P α) = FreeM.lift a >>= r from rfl,
+    FreeM.liftM_bind, FreeM.liftM_lift, MAlgOrdered.wp_bind]
+  rfl
+
+/-- **Soundness of per-operation specs against a handler**: specs that lower-bound
+the handler's wp at every operation give a syntactic wp lower-bounding the
+semantic wp of the interpreted program. -/
+theorem wpFold_le_wpVia {Φ : OpSpec P l} (s : Handler m P)
+    (h : ∀ (a : P.A) (k : P.B a → l), Φ a k ≤ MAlgOrdered.wp (s a) k)
+    (x : FreeM P α) (post : α → l) :
+    wpFold Φ x post ≤ wpVia s x post := by
+  induction x with
+  | pure x => rw [wpFold_pure, wpVia_pure]
+  | lift_bind a r ih =>
+      calc Φ a (fun b => wpFold Φ (r b) post)
+          ≤ MAlgOrdered.wp (s a) fun b => wpFold Φ (r b) post := h a _
+        _ ≤ MAlgOrdered.wp (s a) fun b => wpVia s (r b) post :=
+            MAlgOrdered.wp_mono _ fun b => ih b
+        _ = wpVia s (FreeM.liftBind a r) post := (wpVia_liftBind s a r post).symm
+
+/-- Exact per-operation specs give the semantic wp exactly. -/
+theorem wpFold_eq_wpVia {Φ : OpSpec P l} (s : Handler m P)
+    (h : ∀ (a : P.A) (k : P.B a → l), Φ a k = MAlgOrdered.wp (s a) k)
+    (x : FreeM P α) (post : α → l) :
+    wpFold Φ x post = wpVia s x post := by
+  induction x with
+  | pure x => rw [wpFold_pure, wpVia_pure]
+  | lift_bind a r ih =>
+      rw [show ((FreeM.lift a).bind r : FreeM P α) = FreeM.liftBind a r from rfl,
+        wpFold_liftBind, wpVia_liftBind, h a]
+      exact congrArg _ (funext fun b => ih b)
+
+end wpVia
+
+/-! ## Coherence with the canonical support -/
+
+section Support
+
+variable {α : Type uB}
+
+/-- The demonic fold is the "always" judgment over the canonical support. -/
+theorem wpFold_demonic_iff_allOutputs (x : FreeM P α) (post : α → Prop) :
+    wpFold (OpSpec.demonic P) x post ↔ AllOutputs post x := by
+  induction x with
+  | pure x => simp
+  | lift_bind a r ih =>
+      rw [show ((FreeM.lift a).bind r : FreeM P α) = FreeM.liftBind a r from rfl,
+        wpFold_liftBind, allOutputs_liftBind]
+      exact forall_congr' fun b => ih b
+
+/-- The angelic fold is the "some output" judgment over the canonical support. -/
+theorem wpFold_angelic_iff_someOutput (x : FreeM P α) (post : α → Prop) :
+    wpFold (OpSpec.angelic P) x post ↔ SomeOutput post x := by
+  induction x with
+  | pure x => simp
+  | lift_bind a r ih =>
+      rw [show ((FreeM.lift a).bind r : FreeM P α) = FreeM.liftBind a r from rfl,
+        wpFold_liftBind, someOutput_liftBind]
+      exact exists_congr fun b => ih b
+
+/-- The demonic fold of a negated postcondition is the "never" judgment. -/
+theorem wpFold_demonic_not_iff_noOutput (x : FreeM P α) (post : α → Prop) :
+    wpFold (OpSpec.demonic P) x (fun a => ¬ post a) ↔ NoOutput post x :=
+  wpFold_demonic_iff_allOutputs x fun a => ¬ post a
+
+end Support
+
+end FreeM
+
+end PFunctor

--- a/PolyFun/PFunctor/Free/WP.lean
+++ b/PolyFun/PFunctor/Free/WP.lean
@@ -207,6 +207,8 @@ end wpVia
 
 section Support
 
+open MonadAttach
+
 variable {α : Type uB}
 
 /-- The demonic fold is the "always" judgment over the canonical support. -/

--- a/PolyFunTest/Control/MonadAlgebraRelational.lean
+++ b/PolyFunTest/Control/MonadAlgebraRelational.lean
@@ -1,0 +1,249 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+module
+
+public import PolyFun.Control.Monad.Algebra.Relational
+
+/-!
+# Relational monad-algebra canaries
+
+Concrete identity-algebra examples pin the core relational WP laws and the
+transformer side lifts. These tests are intentionally independent of any
+downstream probability or cryptography instance.
+-/
+
+@[expose] public section
+
+namespace PolyFunTest.MonadAlgebraRelational
+
+open MAlgRelOrdered
+
+noncomputable local instance instIdRel : MAlgRelOrdered Id Id Prop where
+  rwp x y post := post x y
+  rwp_pure _ _ _ := rfl
+  rwp_mono hpost := hpost _ _
+  rwp_bind_le _ _ _ _ _ := le_rfl
+
+noncomputable local instance instIdOrdered : MAlgOrdered Id Prop where
+  μ x := x
+  μ_pure _ := rfl
+  μ_bind_mono _ _ h x := h x
+
+local instance instStrictId : StrictBind Id Id Prop where
+  rwp_bind _ _ _ _ _ := rfl
+
+local instance instAnchoredId : Anchored Id Id Prop where
+  rwp_pure_left _ _ _ := rfl
+  rwp_pure_right _ _ _ := rfl
+
+/-- The identity relational algebra evaluates its postcondition directly. -/
+example : RelWP (m₁ := Id) (m₂ := Id) (2 : Nat) (3 : Nat)
+    (fun a b => a + 1 = b) := by
+  change 2 + 1 = 3
+  decide
+
+/-- The generic bind rule composes concrete identity computations. -/
+example : Triple (m₁ := Id) (m₂ := Id) True (2 : Nat) (3 : Nat)
+    (fun a b => a + 1 = b) := by
+  apply triple_pure
+  change True → 2 + 1 = 3
+  intro
+  decide
+
+/-- Strict bind specializes to definitional equality for the identity model. -/
+example (x y : Nat) (f g : Nat → Nat) (post : Nat → Nat → Prop) :
+    RelWP (m₁ := Id) (m₂ := Id) x y
+        (fun a b => RelWP (m₁ := Id) (m₂ := Id) (f a) (g b) post) =
+      RelWP (m₁ := Id) (m₂ := Id) (x >>= f) (y >>= g) post :=
+  StrictBind.relWP_bind (m₁ := Id) (m₂ := Id) (l := Prop) x y f g post
+
+/-- Anchoring recovers the unary WP when the left computation is pure. -/
+example (a : Nat) (y : Id Nat) (post : Nat → Nat → Prop) :
+    RelWP (m₁ := Id) (m₂ := Id) (pure a) y post = MAlgOrdered.wp y (post a) :=
+  Anchored.relWP_pure_left a y post
+
+/-- The one-sided bind rules have the advertised orientation on concrete,
+non-equal values. -/
+example :
+    RelWP (m₁ := Id) (m₂ := Id) (1 : Nat) (4 : Nat)
+        (fun a b => RelWP (m₁ := Id) (m₂ := Id) (a + 2) (pure b)
+          (fun left right => left + 1 = right)) ≤
+      RelWP (m₁ := Id) (m₂ := Id) ((1 : Id Nat) >>= fun a => pure (a + 2)) 4
+        (fun left right => left + 1 = right) :=
+  relWP_bind_left_le (m₁ := Id) (m₂ := Id) (l := Prop)
+    1 (fun a => pure (a + 2)) 4 (fun left right => left + 1 = right)
+
+example :
+    RelWP (m₁ := Id) (m₂ := Id) (1 : Nat) (2 : Nat)
+        (fun a b => RelWP (m₁ := Id) (m₂ := Id) (pure a) (b + 2)
+          (fun left right => left + 3 = right)) ≤
+      RelWP (m₁ := Id) (m₂ := Id) 1 ((2 : Id Nat) >>= fun b => pure (b + 2))
+        (fun left right => left + 3 = right) :=
+  relWP_bind_right_le (m₁ := Id) (m₂ := Id) (l := Prop)
+    1 2 (fun b => pure (b + 2)) (fun left right => left + 3 = right)
+
+/-! ## Transformer selection and execution -/
+
+section LeftState
+
+noncomputable local instance instLeftState :
+    MAlgRelOrdered (StateT Nat Id) Id (Nat → Prop) :=
+  stateTLeft Nat
+
+noncomputable local instance instStrictLeftState :
+    StrictBind (StateT Nat Id) Id (Nat → Prop) :=
+  strictBindStateTLeft Nat
+
+#synth MAlgRelOrdered (StateT Nat Id) Id (Nat → Prop)
+#synth StrictBind (StateT Nat Id) Id (Nat → Prop)
+
+/-- A left-state lift threads the final state into the postcondition. -/
+def bump : StateT Nat Id Nat :=
+  fun state => (state, state + 1)
+
+example : RelWP (m₁ := StateT Nat Id) (m₂ := Id) bump (2 : Nat)
+    (fun value right finalState => value = 1 ∧ right = 2 ∧ finalState = 2) 1 := by
+  change 1 = 1 ∧ 2 = 2 ∧ 2 = 2
+  decide
+
+end LeftState
+
+section RightState
+
+noncomputable local instance instRightState :
+    MAlgRelOrdered Id (StateT Bool Id) (Bool → Prop) :=
+  stateTRight Bool
+
+noncomputable local instance instStrictRightState :
+    StrictBind Id (StateT Bool Id) (Bool → Prop) :=
+  strictBindStateTRight Bool
+
+#synth MAlgRelOrdered Id (StateT Bool Id) (Bool → Prop)
+#synth StrictBind Id (StateT Bool Id) (Bool → Prop)
+
+example : (RelWP (m₁ := Id) (m₂ := StateT Bool Id) (l := Bool → Prop)
+    (7 : Nat) (fun state => (if state then 8 else 6, !state))
+    (fun left right finalState => left + 1 = right ∧ finalState = false)) true := by
+  change 7 + 1 = 8 ∧ false = false
+  decide
+
+end RightState
+
+section BothStates
+
+noncomputable local instance instBothStates :
+    MAlgRelOrdered (StateT Bool Id) (StateT Nat Id) (Bool → Nat → Prop) :=
+  stateTBoth Bool Nat
+
+noncomputable local instance instStrictBothStates :
+    StrictBind (StateT Bool Id) (StateT Nat Id) (Bool → Nat → Prop) :=
+  strictBindStateTBoth Bool Nat
+
+#synth MAlgRelOrdered (StateT Bool Id) (StateT Nat Id) (Bool → Nat → Prop)
+#synth StrictBind (StateT Bool Id) (StateT Nat Id) (Bool → Nat → Prop)
+
+/-- The two-sided lift keeps left output, right output, left final state, and
+right final state in that order. Distinct types and values make every swap
+observable. -/
+example : (RelWP (m₁ := StateT Bool Id) (m₂ := StateT Nat Id)
+    (l := Bool → Nat → Prop)
+    (fun left => (if left then 7 else 5, !left))
+    (fun right => (right + 10, right + 1))
+    (fun leftOut rightOut leftFinal rightFinal =>
+      leftOut = 7 ∧ rightOut = 13 ∧ leftFinal = false ∧ rightFinal = 4))
+    true 3 := by
+  change 7 = 7 ∧ 13 = 13 ∧ false = false ∧ 4 = 4
+  decide
+
+end BothStates
+
+section RightOption
+
+noncomputable local instance instRightOption :
+    MAlgRelOrdered Id (OptionT Id) Prop :=
+  optionTRight
+
+#synth MAlgRelOrdered Id (OptionT Id) Prop
+
+/-- The lossy `OptionT` side lift interprets `none` as `⊥`. -/
+def noRightResult : OptionT Id Nat := none
+
+example : ¬ RelWP (m₁ := Id) (m₂ := OptionT Id) (1 : Nat) noRightResult
+    (fun _ _ => True) := by
+  change ¬ False
+  exact not_false
+
+example : RelWP (m₁ := Id) (m₂ := OptionT Id) (1 : Nat) (pure 2)
+    (fun left right => left + 1 = right) := by
+  change 1 + 1 = 2
+  decide
+
+end RightOption
+
+section LeftOption
+
+noncomputable local instance instLeftOption :
+    MAlgRelOrdered (OptionT Id) Id Prop :=
+  optionTLeft
+
+#synth MAlgRelOrdered (OptionT Id) Id Prop
+
+example : ¬ RelWP (m₁ := OptionT Id) (m₂ := Id) (none : OptionT Id Nat) (1 : Nat)
+    (fun _ _ => True) := by
+  change ¬ False
+  exact not_false
+
+example : RelWP (m₁ := OptionT Id) (m₂ := Id) (pure 2) (3 : Nat)
+    (fun left right => left + 1 = right) := by
+  change 2 + 1 = 3
+  decide
+
+end LeftOption
+
+section LeftExcept
+
+noncomputable local instance instLeftExcept :
+    MAlgRelOrdered (ExceptT Unit Id) Id Prop :=
+  exceptTLeft Unit
+
+#synth MAlgRelOrdered (ExceptT Unit Id) Id Prop
+
+/-- The lossy `ExceptT` side lift likewise interprets an error as `⊥`. -/
+def leftError : ExceptT Unit Id Nat := .error ()
+
+example : ¬ RelWP (m₁ := ExceptT Unit Id) (m₂ := Id) leftError (1 : Nat)
+    (fun _ _ => True) := by
+  change ¬ False
+  exact not_false
+
+example : RelWP (m₁ := ExceptT Unit Id) (m₂ := Id) (pure 2) (3 : Nat)
+    (fun left right => left + 1 = right) := by
+  change 2 + 1 = 3
+  decide
+
+end LeftExcept
+
+section RightExcept
+
+noncomputable local instance instRightExcept :
+    MAlgRelOrdered Id (ExceptT Unit Id) Prop :=
+  exceptTRight Unit
+
+#synth MAlgRelOrdered Id (ExceptT Unit Id) Prop
+
+example : ¬ RelWP (m₁ := Id) (m₂ := ExceptT Unit Id) (1 : Nat)
+    (.error () : ExceptT Unit Id Nat) (fun _ _ => True) := by
+  change ¬ False
+  exact not_false
+
+example : RelWP (m₁ := Id) (m₂ := ExceptT Unit Id) (2 : Nat) (pure 3)
+    (fun left right => left + 1 = right) := by
+  change 2 + 1 = 3
+  decide
+
+end RightExcept
+
+end PolyFunTest.MonadAlgebraRelational

--- a/PolyFunTest/Do/FreeM.lean
+++ b/PolyFunTest/Do/FreeM.lean
@@ -52,3 +52,23 @@ example : ⦃⌜True⌝⦄ flipNot ⦃⇓ r => ⌜r = true ∨ r = false⌝⦄ :
   mvcgen [flipNot]
   intro a
   cases a <;> simp
+
+/-! ## From weakest preconditions back to supports
+
+`WPSound` closes the loop: a triple discharged by `mvcgen` becomes a fact about
+the program's possible outputs, with no further reasoning about the tree. -/
+
+/-- An `mvcgen`-discharged triple converts into a support fact. -/
+example (a : Bool) (h : MonadAttach.CanReturn flipTwo a) : a = true ∨ a = false := by
+  refine WPSound.of_wp_canReturn (m := PFunctor.FreeM coinP)
+    (P := fun b => b = true ∨ b = false) h ?_
+  mvcgen [flipTwo]
+  intro x y
+  cases x && y <;> simp
+
+/-- The same, phrased as the "always" judgment over the support. -/
+example : MonadAttach.AllOutputs (fun b => b = true ∨ b = false) flipTwo := by
+  refine MonadAttach.allOutputs_of_wp ?_
+  mvcgen [flipTwo]
+  intro x y
+  cases x && y <;> simp

--- a/PolyFunTest/Do/FreeM.lean
+++ b/PolyFunTest/Do/FreeM.lean
@@ -1,0 +1,54 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+module
+
+public import PolyFun.PFunctor.Free.Do
+
+/-!
+# `mvcgen` smoke tests over the free monad
+
+These examples demonstrate that core `Std.Do`'s `mvcgen` decomposes `do`-programs
+over `FreeM P` with uninterpreted operations, under the scoped demonic
+weakest-precondition instances of `PolyFun.PFunctor.Free.Do`. Each query is
+discharged through the registered `Spec.lift` specification: an uninterpreted
+operation guarantees its postcondition for every possible response.
+-/
+
+@[expose] public section
+
+set_option mvcgen.warning false
+
+open Std.Do
+open scoped PFunctor.FreeM.DemonicWP
+
+/-- A single-position query interface with boolean responses. -/
+abbrev coinP : PFunctor.{0, 0} := ⟨PUnit, fun _ => Bool⟩
+
+open PFunctor in
+/-- Two coin flips, combined with `&&`. -/
+def flipTwo : FreeM coinP Bool := do
+  let a ← FreeM.lift (P := coinP) PUnit.unit
+  let b ← FreeM.lift (P := coinP) PUnit.unit
+  pure (a && b)
+
+/-- `mvcgen` decomposes a two-query bind chain; the leaf VCs quantify over each
+uninterpreted response. -/
+example : ⦃⌜True⌝⦄ flipTwo ⦃⇓ r => ⌜r = true ∨ r = false⌝⦄ := by
+  mvcgen [flipTwo]
+  intro a b
+  cases a && b <;> simp
+
+open PFunctor in
+/-- A query whose result is post-processed deterministically. -/
+def flipNot : FreeM coinP Bool := do
+  let a ← FreeM.lift (P := coinP) PUnit.unit
+  pure (!a)
+
+/-- The postcondition can depend on the (universally quantified) response. -/
+example : ⦃⌜True⌝⦄ flipNot ⦃⇓ r => ⌜r = true ∨ r = false⌝⦄ := by
+  mvcgen [flipNot]
+  intro a
+  cases a <;> simp

--- a/PolyFunTest/Do/FreeM.lean
+++ b/PolyFunTest/Do/FreeM.lean
@@ -72,3 +72,19 @@ example : MonadAttach.AllOutputs (fun b => b = true ∨ b = false) flipTwo := by
   mvcgen [flipTwo]
   intro x y
   cases x && y <;> simp
+
+open PFunctor in
+/-- A query whose result is forced to `false`, giving a program-specific
+postcondition rather than a tautology over `Bool`. -/
+def maskFalse : FreeM coinP Bool := do
+  let a ← FreeM.lift (P := coinP) PUnit.unit
+  pure (a && false)
+
+/-- `WPSound` transports a nontrivial verification condition to every
+reachable result. -/
+example (a : Bool) (h : MonadAttach.CanReturn maskFalse a) : a = false := by
+  refine WPSound.of_wp_canReturn (m := PFunctor.FreeM coinP)
+    (P := fun b => b = false) h ?_
+  mvcgen [maskFalse]
+  intro response
+  cases response <;> simp

--- a/PolyFunTest/Do/Transport.lean
+++ b/PolyFunTest/Do/Transport.lean
@@ -1,0 +1,46 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+module
+
+public import PolyFun.PFunctor.Free.Do
+
+/-!
+# Nonidentity `Std.Do` transport canary
+
+This test installs handler-transported weakest-precondition semantics without
+opening the demonic scope. It ensures that transport follows the handler rather
+than silently selecting the free monad's all-responses interpretation.
+-/
+
+@[expose] public section
+
+namespace PolyFunTest.DoTransport
+
+open Std.Do
+open PFunctor
+
+abbrev coinP : PFunctor.{0, 0} := ⟨PUnit, fun _ => Bool⟩
+
+def flipTwo : FreeM coinP Bool := do
+  let a ← FreeM.lift (P := coinP) PUnit.unit
+  let b ← FreeM.lift (P := coinP) PUnit.unit
+  pure (a && b)
+
+/-- A nonidentity monad morphism: interpret every free query as `true` in `Id`. -/
+def chooseTrue : Handler Id coinP :=
+  fun _ => true
+
+local instance instHandlerWP : WPMonad (FreeM coinP) .pure :=
+  FreeM.wpMonadOfHandler chooseTrue
+
+/-- The transported WP proves a handler-specific fact that the demonic
+all-responses semantics cannot prove. -/
+example : ⦃⌜True⌝⦄ flipTwo ⦃⇓ result => ⌜result = true⌝⦄ := by
+  change True → true && true = true
+  intro
+  rfl
+
+end PolyFunTest.DoTransport

--- a/PolyFunTest/PFunctor/FreeWP.lean
+++ b/PolyFunTest/PFunctor/FreeWP.lean
@@ -1,0 +1,113 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+module
+
+public import PolyFun.PFunctor.Free.WP
+
+/-!
+# Free-monad weakest-precondition canaries
+
+These examples distinguish demonic and angelic operation specifications, pin
+answer-dependent continuations, and exercise syntactic-to-semantic transport
+through a nontrivial handler.
+-/
+
+@[expose] public section
+
+namespace PolyFunTest.FreeWP
+
+open PFunctor
+open PFunctor.FreeM
+open MonadAttach
+
+/-- A single query with two observably different responses. -/
+abbrev coinP : PFunctor.{0, 0} := ⟨PUnit, fun _ => Bool⟩
+
+/-- Two responses are combined, so the second continuation depends on the
+first response. -/
+def flipTwo : FreeM coinP Bool := do
+  let a ← FreeM.lift (P := coinP) PUnit.unit
+  let b ← FreeM.lift (P := coinP) PUnit.unit
+  pure (a && b)
+
+/-- Demonic semantics rejects a postcondition falsified by one response path. -/
+example : ¬ wpFold (OpSpec.demonic coinP) flipTwo (fun out => out = true) := by
+  change ¬ ∀ a b : Bool, (a && b) = true
+  intro h
+  exact Bool.noConfusion (h false false)
+
+/-- Angelic semantics accepts the same postcondition by choosing `true` twice. -/
+example : wpFold (OpSpec.angelic coinP) flipTwo (fun out => out = true) := by
+  change ∃ a b : Bool, (a && b) = true
+  exact ⟨true, true, rfl⟩
+
+/-- A deterministic operation spec that always answers `true`. -/
+def chooseTrueSpec : OpSpec coinP Prop :=
+  fun _ continuation => continuation true
+
+theorem chooseTrueSpec_mono : chooseTrueSpec.Mono :=
+  fun _ _ _ h => h true
+
+/-- `wpFold` preserves the answer-dependent continuation of both queries. -/
+example : wpFold chooseTrueSpec flipTwo (fun out => out = true) := by
+  change true && true = true
+  rfl
+
+/-- The induced ordered algebra computes the same nontrivial fold. -/
+example :
+    letI := chooseTrueSpec.toMAlgOrdered chooseTrueSpec_mono
+    MAlgOrdered.wp flipTwo (fun out => out = true) := by
+  rw [wp_toMAlgOrdered]
+  change true && true = true
+  rfl
+
+/-! ## Handler semantics -/
+
+/-- Interpret every query as the concrete answer `true`. -/
+def chooseTrueHandler : Handler Id coinP :=
+  fun _ => true
+
+noncomputable local instance instIdOrdered : MAlgOrdered Id Prop where
+  μ x := x
+  μ_pure _ := rfl
+  μ_bind_mono _ _ h x := h x
+
+/-- The semantic WP observes the handler rather than quantifying over every
+syntactic response. -/
+example : wpVia chooseTrueHandler flipTwo (fun out => out = true) := by
+  change true && true = true
+  rfl
+
+/-- The deterministic operation spec agrees exactly with the handler WP. -/
+example : wpFold chooseTrueSpec flipTwo (fun out => out = true) =
+    wpVia chooseTrueHandler flipTwo (fun out => out = true) := by
+  apply wpFold_eq_wpVia
+  intro _ continuation
+  rfl
+
+/-- Demonic syntax safely under-approximates the deterministic handler even
+when the postcondition is not tautological. -/
+example : wpFold (OpSpec.demonic coinP) flipTwo (fun out => out = true) ≤
+    wpVia chooseTrueHandler flipTwo (fun out => out = true) := by
+  apply wpFold_le_wpVia
+  intro _ continuation hall
+  exact hall true
+
+/-! ## Coherence with support -/
+
+/-- The demonic fold exposes a genuine negative support fact. -/
+example : ¬ AllOutputs (fun out => out = true) flipTwo := by
+  rw [← wpFold_demonic_iff_allOutputs]
+  exact show ¬ (∀ a b : Bool, (a && b) = true) by
+    intro h
+    exact Bool.noConfusion (h false false)
+
+/-- The angelic fold exposes a concrete reachable output. -/
+example : SomeOutput (fun out => out = true) flipTwo := by
+  rw [← wpFold_angelic_iff_someOutput]
+  exact ⟨true, true, rfl⟩
+
+end PolyFunTest.FreeWP

--- a/docs/reading/program-logic-landscape.md
+++ b/docs/reading/program-logic-landscape.md
@@ -1,0 +1,113 @@
+# Program-Logic Landscape and PolyFun's Core
+
+Status: design memo for the program-logic core (2026-08). Companion wiki page:
+[`docs/wiki/program-logic.md`](../wiki/program-logic.md).
+
+## The problem
+
+VCVio carries a mature (18k-line, sorry-free) program logic over `OracleComp`
+— unary and relational, with its own `vcgen`/`rvcgen` tactic family — but its
+foundations are split across three competing assertion substrates, and PolyFun,
+the layer everything sits on, historically contributed only
+`Control/Monad/Algebra.lean`. This memo records the landscape, the architecture
+decision, and the resulting PolyFun core.
+
+## The three substrates
+
+| Substrate | Assertions | Status | Consumers |
+|---|---|---|---|
+| Core `Std.Do` / `mvcgen` (Lean ≥ 4.22) | `SPred`/`PostShape` (Prop-based), `WP m ps`, `@[spec]`, `mvcgen`; `mvcgen'` (SymM) in development | Upstream, moving fast | VCVio via a narrow bridge (`StdDoBridge`, `HandlerSpecs`, `WriterTBridge`), almost-sure view only |
+| Loom2 `Std.Do'` (fork of verse-lab/loom, POPL 2026, DOI 10.1145/3776719) | Lattice-generic `WP m Pred EPred`, any `CompleteLattice`, `EPost`, relational APIs, own `mvcgen'` | Fork pinned by SHA, VCVio-maintained | VCVio's main ProgramLogic: ℝ≥0∞ / Prop / Prob carriers, pRHL + eRHL |
+| Iris/BI (Bluebell, POPL 2025, DOI 10.1145/3704894) | `HyperAssertion` over indexed probability-space × permission resources, `BIBase`, joint-conditioning modality | Branch-only in VCVio (`Ferinko/measureMySpace` line, Lean 4.24) and the org's iris-lean fork | Nethermind's Bluebell mechanization effort |
+
+Downstream of VCVio, ArkLib is a *greenfield* consumer: it uses none of the
+program logic today (its pin predates the layer), but its security definitions
+are literally quantitative Hoare triples over `OptionT (OracleComp …)`, its
+highest-leverage open gap is the additive-error sequencing rule for sequential
+composition, and its completeness proofs want a grind-friendly support /
+never-fails calculus.
+
+## The unifying observation
+
+`MAlgOrdered` — ordered monad algebras over a complete lattice — is the common
+semantic kernel: core `Std.Do`'s `PredTrans` is the Prop/SPred special case,
+Loom2's `Std.Do'.WP` is the lattice-generic version VCVio consumes (its
+quantitative carrier bridges to `MAlgOrdered` by `rfl`), and Bluebell's `wp` is
+a BI-valued sibling. PolyFun therefore owns the *handler/algebra-parameterized*
+theory over the polynomial substrate, and each downstream picks its carrier.
+PolyFun takes no Loom2 or Iris dependency and does not pick between the
+substrates; core `Std.Do` is used only behind a two-file quarantine.
+
+## The core (implemented)
+
+- `Control/Monad/Algebra.lean` — the pre-existing kernel: `MAlgOrdered`,
+  `wp`/`Triple`, transformer lifts, honest `wpExc`/`wpOpt`.
+- `Control/Monad/Algebra/Relational.lean` — `MAlgRelOrdered` (relational
+  `rwp`/`RelWP`/`Triple`, asynchronous bind rules, `StrictBind`, `Anchored`),
+  upstreamed from VCVio's `ToMathlib/Control/Monad/RelationalAlgebra.lean`
+  (near-verbatim; three unused `LawfulMonad` binders dropped).
+- `Control/Monad/Support.lean` — `MonadSupport`: a monad with a canonical
+  set-valued support, bundled as a monad morphism `supportHom : m →ᵐ SetM` into
+  Mathlib's powerset monad (there is **no** upstream abstraction for this; the
+  ad-hoc idiom is `[MonadLiftT m SetM]`, with documented diamond pitfalls).
+  `supportM`, the `AllOutputs`/`SomeOutput`/`NoOutput` judgments with scoped
+  `⊨ₐ`/`⊨ₛ`/`⊭` notation, the demonic `MAlgOrdered m Prop` instance, and
+  failure-transformer instances. `StateT`/`ReaderT` deliberately have no
+  instance (union over initial states is not a monad morphism).
+- `PFunctor/Free/Support.lean` — the canonical `MonadSupport (FreeM P)`:
+  fold every operation to `Set.univ`; coherence with `Free/Path.lean`
+  (`supportM_eq_range_output`).
+- `PFunctor/Free/WP.lean` — `OpSpec` per-operation predicate-transformer
+  specs; the syntactic fold `FreeM.wpFold` with `demonic`/`angelic` `Prop`
+  specs; `OpSpec.toMAlgOrdered`; the semantic `FreeM.wpVia` through a
+  `Handler`; soundness `wpFold_le_wpVia` / `wpFold_eq_wpVia` (the generic
+  engine behind VCVio's `HandlerSpecs` pattern); coherence of demonic/angelic
+  folds with `AllOutputs`/`SomeOutput`.
+- `Control/Do/Basic.lean` + `PFunctor/Free/Do.lean` — the core-`Std.Do`
+  quarantine: `MonadHom.transportWP(Monad)`, `MonadSupport.toWP(Monad)`,
+  scoped demonic `WP (FreeM P) .pure` instances, and the `Spec.lift` `@[spec]`
+  lemma; `mvcgen` decomposes `do`-programs over `FreeM` with uninterpreted
+  operations (`PolyFunTest/Do/FreeM.lean` proves this in CI). Only these two
+  files (plus tests) may import `Std.Tactic.Do`.
+
+## Deliberately not in PolyFun
+
+Anything importing loom2/`Std.Do'`; all probability (`evalDist`/SPMF,
+ℝ≥0∞/Prob carriers, couplings, pRHL/eRHL); concrete handler specs
+(caching/logging/seeded oracles); the `vcgen`/`@[vcspec]` tactic family;
+Bluebell/iris-lean/BI; global `WP` instances for `FreeM` (they would race
+downstream registrations on reducible unfoldings such as `OracleComp`).
+
+## Downstream migration sketch (VCVio, at its next PolyFun bump)
+
+1. Replace `ToMathlib/Control/Monad/RelationalAlgebra.lean` with the PolyFun
+   import.
+2. Re-derive `support` from `MonadSupport` (its `instMonadLiftTSetM` becomes
+   `MonadSupport.toMonadLiftT`; `allOutputsSatisfy`/`someOutputSatisfies`
+   become deprecated aliases of `AllOutputs`/`SomeOutput` during migration),
+   and `HoarePropTriple.instMAlgOrdered` from the generic demonic instance.
+3. Re-derive `instWPOracleComp` from `MonadSupport.toWP` and
+   `simulateQ_triple_preserves_invariant`-style facts from
+   `wpFold_le_wpVia`; keep `wpProp_iff_forall_support` as the only
+   probability-touching step, and `wp_eq_mAlgOrdered_wp` as the rfl regression
+   test for the quantitative carrier.
+
+Acceptance targets: VCVio's support instances become one-liners; ArkLib (once
+its pin catches up) can delete `ToVCVio/DistEq.lean`, derive its Merkle
+`NeverFail` calculus from `supportM_bind`-shaped rules, and state
+`append_completeness` against a future generic approximate-triple algebra
+(`pre ≤ wp x post + ε` over a lattice-with-addition carrier — sketched, not yet
+implemented).
+
+## Open follow-ups
+
+- Relational free-monad layer: a two-tree `rwpFold` giving
+  `MAlgRelOrdered (FreeM P) (FreeM Q) l` from a relational op-spec.
+- `Display`/wp adequacy: `Display.ofPredicates` sections versus `wpFold` of
+  the induced spec — the intrinsic/extrinsic bridge (roadmap track D5).
+- ITree: no `WP` instance planned while `iter` is lawful only up to weak
+  bisimulation; the honest deliverables are wp-congruence under `WeakBisim`
+  and an invariant rule for the `ITree/Do.lean` `ForIn` loop.
+- The ε-additive approximate-triple algebra (ArkLib's sequencing blocker).
+- Optional `MonadFinSupport` (Finset-valued support, generalizing VCVio's
+  `HasEvalFinset`).

--- a/docs/reading/program-logic-landscape.md
+++ b/docs/reading/program-logic-landscape.md
@@ -53,7 +53,7 @@ substrates; core `Std.Do` is used only behind a two-file quarantine.
   so PolyFun contributes `ExactMonadAttach`, the two introduction rules, plus
   `MonadAttach.support` (the `Set`-valued view), the
   `AllOutputs`/`SomeOutput`/`NoOutput` judgments with scoped `⊨ₐ`/`⊨ₛ`/`⊭`
-  notation, and the demonic `MAlgOrdered m Prop` instance. Core supplies the
+  notation, and the named demonic `MAlgOrdered m Prop` choice. Core supplies the
   `Id`/`Option`/`OptionT`/`ExceptT`/`StateT`/`ReaderT` instances; PolyFun adds
   `Except` and `SetM` (absent upstream) and a universe alias working around
   core's `max`-joined `ExceptT` declaration. `StateT`/`ReaderT` keep core's
@@ -97,7 +97,8 @@ downstream registrations on reducible unfoldings such as `OracleComp`).
    `PMF.bindOnSupport`, which is exactly `pbind`), `SPMF`, and `FinRatPMF.Raw`
    need real work, all probability-side. `allOutputsSatisfy`/`someOutputSatisfies`
    become deprecated aliases of `AllOutputs`/`SomeOutput` during migration, and
-   `HoarePropTriple.instMAlgOrdered` follows from the generic demonic instance.
+   `HoarePropTriple.instMAlgOrdered` can select the generic demonic definition
+   explicitly.
    Guards: core's `StateT`/`ReaderT` instances make `support` typecheck on stacks
    where `CellRef.lean`/`WriterCost.lean` mean the per-run support, and
    `MonadAttach.trivial` must never be let in.

--- a/docs/reading/program-logic-landscape.md
+++ b/docs/reading/program-logic-landscape.md
@@ -46,17 +46,23 @@ substrates; core `Std.Do` is used only behind a two-file quarantine.
   `rwp`/`RelWP`/`Triple`, asynchronous bind rules, `StrictBind`, `Anchored`),
   upstreamed from VCVio's `ToMathlib/Control/Monad/RelationalAlgebra.lean`
   (near-verbatim; three unused `LawfulMonad` binders dropped).
-- `Control/Monad/Support.lean` — `MonadSupport`: a monad with a canonical
-  set-valued support, bundled as a monad morphism `supportHom : m →ᵐ SetM` into
-  Mathlib's powerset monad (there is **no** upstream abstraction for this; the
-  ad-hoc idiom is `[MonadLiftT m SetM]`, with documented diamond pitfalls).
-  `supportM`, the `AllOutputs`/`SomeOutput`/`NoOutput` judgments with scoped
-  `⊨ₐ`/`⊨ₛ`/`⊭` notation, the demonic `MAlgOrdered m Prop` instance, and
-  failure-transformer instances. `StateT`/`ReaderT` deliberately have no
-  instance (union over initial states is not a monad morphism).
-- `PFunctor/Free/Support.lean` — the canonical `MonadSupport (FreeM P)`:
-  fold every operation to `Set.univ`; coherence with `Free/Path.lean`
-  (`supportM_eq_range_output`).
+- `Control/Monad/Support.lean` — the support layer, built on Lean core's
+  `MonadAttach` (shipped since v4.28; `CanReturn` *is* the support predicate).
+  Core proves only the elimination half of the theory, and provably cannot prove
+  the rest — a monad with `CanReturn := False` satisfies `LawfulMonadAttach` —
+  so PolyFun contributes `ExactMonadAttach`, the two introduction rules, plus
+  `MonadAttach.support` (the `Set`-valued view), the
+  `AllOutputs`/`SomeOutput`/`NoOutput` judgments with scoped `⊨ₐ`/`⊨ₛ`/`⊭`
+  notation, and the demonic `MAlgOrdered m Prop` instance. Core supplies the
+  `Id`/`Option`/`OptionT`/`ExceptT`/`StateT`/`ReaderT` instances; PolyFun adds
+  `Except` and `SetM` (absent upstream) and a universe alias working around
+  core's `max`-joined `ExceptT` declaration. `StateT`/`ReaderT` keep core's
+  canonical support but are correctly not `ExactMonadAttach`.
+- `PFunctor/Free/Support.lean` — `MonadAttach`/`ExactMonadAttach` for `FreeM P`
+  with a computable, axiom-free `attach` (so `MonadAttach.pbind` is available for
+  well-founded recursion); structural equations hold by `rfl`; coherence with
+  `Free/Path.lean` (`support_eq_range_output`) and with the powerset fold
+  (`support_eq_liftM_univ`).
 - `PFunctor/Free/WP.lean` — `OpSpec` per-operation predicate-transformer
   specs; the syntactic fold `FreeM.wpFold` with `demonic`/`angelic` `Prop`
   specs; `OpSpec.toMAlgOrdered`; the semantic `FreeM.wpVia` through a
@@ -64,7 +70,9 @@ substrates; core `Std.Do` is used only behind a two-file quarantine.
   engine behind VCVio's `HandlerSpecs` pattern); coherence of demonic/angelic
   folds with `AllOutputs`/`SomeOutput`.
 - `Control/Do/Basic.lean` + `PFunctor/Free/Do.lean` — the core-`Std.Do`
-  quarantine: `MonadHom.transportWP(Monad)`, `MonadSupport.toWP(Monad)`,
+  quarantine: `MonadHom.transportWP(Monad)`, `MonadAttach.toWP(Monad)`,
+  `toWPSound` plus `support_subset_of_wp`/`allOutputs_of_wp` (any `WPSound`
+  triple becomes a support fact),
   scoped demonic `WP (FreeM P) .pure` instances, and the `Spec.lift` `@[spec]`
   lemma; `mvcgen` decomposes `do`-programs over `FreeM` with uninterpreted
   operations (`PolyFunTest/Do/FreeM.lean` proves this in CI). Only these two
@@ -82,11 +90,18 @@ downstream registrations on reducible unfoldings such as `OracleComp`).
 
 1. Replace `ToMathlib/Control/Monad/RelationalAlgebra.lean` with the PolyFun
    import.
-2. Re-derive `support` from `MonadSupport` (its `instMonadLiftTSetM` becomes
-   `MonadSupport.toMonadLiftT`; `allOutputsSatisfy`/`someOutputSatisfies`
-   become deprecated aliases of `AllOutputs`/`SomeOutput` during migration),
-   and `HoarePropTriple.instMAlgOrdered` from the generic demonic instance.
-3. Re-derive `instWPOracleComp` from `MonadSupport.toWP` and
+2. Re-derive `support` as `export MonadAttach (support)` — that single line keeps
+   all 1403 `support` occurrences and 212 `support_*` lemma names. `OracleComp`
+   (= `OptionT (FreeM …)`) gets `MonadAttach`/`ExactMonadAttach` by pure instance
+   composition, needing *no* VCVio-side instance; only `PMF` (via
+   `PMF.bindOnSupport`, which is exactly `pbind`), `SPMF`, and `FinRatPMF.Raw`
+   need real work, all probability-side. `allOutputsSatisfy`/`someOutputSatisfies`
+   become deprecated aliases of `AllOutputs`/`SomeOutput` during migration, and
+   `HoarePropTriple.instMAlgOrdered` follows from the generic demonic instance.
+   Guards: core's `StateT`/`ReaderT` instances make `support` typecheck on stacks
+   where `CellRef.lean`/`WriterCost.lean` mean the per-run support, and
+   `MonadAttach.trivial` must never be let in.
+3. Re-derive `instWPOracleComp` from `MonadAttach.toWP` and
    `simulateQ_triple_preserves_invariant`-style facts from
    `wpFold_le_wpVia`; keep `wpProp_iff_forall_support` as the only
    probability-touching step, and `wp_eq_mAlgOrdered_wp` as the rfl regression
@@ -94,7 +109,7 @@ downstream registrations on reducible unfoldings such as `OracleComp`).
 
 Acceptance targets: VCVio's support instances become one-liners; ArkLib (once
 its pin catches up) can delete `ToVCVio/DistEq.lean`, derive its Merkle
-`NeverFail` calculus from `supportM_bind`-shaped rules, and state
+`NeverFail` calculus from `support_bind`-shaped rules, and state
 `append_completeness` against a future generic approximate-triple algebra
 (`pre ≤ wp x post + ε` over a lattice-with-addition carrier — sketched, not yet
 implemented).

--- a/docs/reading/roadmap.md
+++ b/docs/reading/roadmap.md
@@ -346,7 +346,9 @@ canonical `FreeM` interpretation.
     specification language for them. The bet: VCVio's Loom-style
     `wp`/`Triple` layer (`Control/Monad/Algebra`) is a fragment of that
     internal logic. Highest-value research track; natural paper-3
-    companion.
+    companion. The implemented program-logic kernel this would interpret
+    is surveyed in
+    [`program-logic-landscape.md`](program-logic-landscape.md).
   - *Q5 — ⊗-monoids in Cat♯*: grounded by Prop 8.77 in the current
     edition (Prop 8.79 in earlier-edition notes; ⊗ on Cat♯ =
     products of categories, built from the duoidal lens). ⊗-monoids =

--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -60,7 +60,7 @@ See the *Wiki Maintenance Contract* section in
   behavioural-equivalence notions (strong / delay / weak), the generic
   `Control.LTS` framework, and how the ITree, dynamical, and UC layers relate.
 - [`program-logic.md`](program-logic.md): the program-logic kernel
-  (`MAlgOrdered`, relational algebras, `MonadSupport` and the always/never
+  (`MAlgOrdered`, relational algebras, exact monadic support and the always/never
   judgments, free-monad wp, and the core-`Std.Do` quarantine).
 - [`notation.md`](notation.md): notation reference. Currently scoped to UC
   composition (`∥`, `⊞`, `⊠`), boundary tensor / swap, and the scoped

--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -59,8 +59,12 @@ See the *Wiki Maintenance Contract* section in
 - [`bisimulation.md`](bisimulation.md): glossary of the bisimulation and
   behavioural-equivalence notions (strong / delay / weak), the generic
   `Control.LTS` framework, and how the ITree, dynamical, and UC layers relate.
+- [`program-logic.md`](program-logic.md): the program-logic kernel
+  (`MAlgOrdered`, relational algebras, `MonadSupport` and the always/never
+  judgments, free-monad wp, and the core-`Std.Do` quarantine).
 - [`notation.md`](notation.md): notation reference. Currently scoped to UC
-  composition (`∥`, `⊞`, `⊠`) and boundary tensor / swap.
+  composition (`∥`, `⊞`, `⊠`), boundary tensor / swap, and the scoped
+  satisfaction judgments (`⊨`, `⊨ₐ`, `⊨ₛ`, `⊭`).
 - [`gotchas.md`](gotchas.md): recurring Lean traps and PolyFun-specific
   pitfalls.
 

--- a/docs/wiki/gotchas.md
+++ b/docs/wiki/gotchas.md
@@ -287,3 +287,14 @@ path. Foundational citations live in
 [`REFERENCES.md`](../../REFERENCES.md); module docstrings reference
 those keys (`Hancock-Setzer`, `Spivak-Niu`, etc.) rather than copying
 prose.
+
+### 12. `Std.Tactic.Do` imports are quarantined
+
+Only `PolyFun/Control/Do/Basic.lean`, `PolyFun/PFunctor/Free/Do.lean`, and
+`PolyFunTest/Do/` may import `Std.Tactic.Do` (core `Std.Do` / `mvcgen`). The
+upstream API is evolving quickly (an `mvcgen'` rewrite is in progress), so the
+dependency stays confined to those files, and everything they export is a
+construction (`def`), never a global instance: a global `Std.Do.WP` instance on
+`FreeM P` would race downstream registrations on reducible unfoldings such as
+oracle-computation types. Register the provided structures `scoped` or `local`
+downstream. See [`program-logic.md`](program-logic.md).

--- a/docs/wiki/notation.md
+++ b/docs/wiki/notation.md
@@ -69,6 +69,13 @@ than via custom notation, to keep elaboration predictable. Specifically:
   abbreviates `DynComputation.Implements M program`. It is opt-in via
   `open scoped PFunctor.DynComputation`; the symbol deliberately says nothing
   about resource bounds.
+- Support satisfaction judgments, opt-in via `open scoped MonadSupport` for
+  any monad with a `MonadSupport` instance: `x ⊨ₐ p` (`AllOutputs p x`, every
+  possible output satisfies `p`), `x ⊨ₛ p` (`SomeOutput p x`, some possible
+  output satisfies `p`), and `x ⊭ p` (`NoOutput p x`, no possible output
+  satisfies `p`; input `\nvDash`, U+22AD). All three are definitionally the
+  corresponding bounded quantifier over `supportM x`; see
+  [`program-logic.md`](program-logic.md).
 
 If you find yourself wishing for new notation in PolyFun, consider
 whether the underlying name suffices first: this library leans toward

--- a/docs/wiki/notation.md
+++ b/docs/wiki/notation.md
@@ -69,12 +69,13 @@ than via custom notation, to keep elaboration predictable. Specifically:
   abbreviates `DynComputation.Implements M program`. It is opt-in via
   `open scoped PFunctor.DynComputation`; the symbol deliberately says nothing
   about resource bounds.
-- Support satisfaction judgments, opt-in via `open scoped MonadSupport` for
-  any monad with a `MonadSupport` instance: `x ⊨ₐ p` (`AllOutputs p x`, every
+- Support satisfaction judgments, opt-in via `open scoped MonadAttach` for any
+  monad with a core `MonadAttach` instance: `x ⊨ₐ p` (`AllOutputs p x`, every
   possible output satisfies `p`), `x ⊨ₛ p` (`SomeOutput p x`, some possible
   output satisfies `p`), and `x ⊭ p` (`NoOutput p x`, no possible output
   satisfies `p`; input `\nvDash`, U+22AD). All three are definitionally the
-  corresponding bounded quantifier over `supportM x`; see
+  corresponding bounded quantifier over `MonadAttach.support x`, itself the
+  `Set`-valued view of core's `CanReturn`; see
   [`program-logic.md`](program-logic.md).
 
 If you find yourself wishing for new notation in PolyFun, consider

--- a/docs/wiki/program-logic.md
+++ b/docs/wiki/program-logic.md
@@ -1,0 +1,60 @@
+# Program-Logic Core
+
+PolyFun's program-logic layer is the probability-free kernel shared by the
+downstream verification stacks (VCVio's Loom2-based logic, core `Std.Do` /
+`mvcgen`, and the Bluebell/Iris line). Design rationale and the downstream
+migration sketch live in
+[`docs/reading/program-logic-landscape.md`](../reading/program-logic-landscape.md).
+
+## Layers
+
+| Module | Content |
+|---|---|
+| `PolyFun/Control/Monad/Algebra.lean` | `MAlgOrdered m l`: ordered monad algebras over a complete lattice, with `wp`, `Triple`, the structural rule set, `StateT`/`ReaderT`/`ExceptT`/`OptionT` lifts, and the honest two-postcondition `wpExc`/`wpOpt` |
+| `PolyFun/Control/Monad/Algebra/Relational.lean` | `MAlgRelOrdered m₁ m₂ l`: relational `rwp`/`RelWP`/`Triple`, asynchronous one-sided bind rules, structural pure rules, side-lifts, and the `StrictBind` / `Anchored` subclasses (Maillard et al. POPL 2020 shapes) |
+| `PolyFun/Control/Monad/Support.lean` | `MonadSupport m`: a canonical set-valued support as a monad morphism `supportHom : m →ᵐ SetM`; `supportM`; the `AllOutputs`/`SomeOutput`/`NoOutput` judgments and scoped `⊨ₐ`/`⊨ₛ`/`⊭` notation; the demonic `MAlgOrdered m Prop` instance |
+| `PolyFun/PFunctor/Free/Support.lean` | The canonical `MonadSupport (FreeM P)` (every response possible) and its coherence with `Free/Path.lean` (`supportM_eq_range_output`) |
+| `PolyFun/PFunctor/Free/WP.lean` | `OpSpec P l` per-operation specs; syntactic `FreeM.wpFold` (with `demonic`/`angelic`); `OpSpec.toMAlgOrdered`; semantic `FreeM.wpVia` through a `Handler`; soundness `wpFold_le_wpVia`/`wpFold_eq_wpVia` |
+| `PolyFun/Control/Do/Basic.lean` | Core-`Std.Do` transports: `MonadHom.transportWP(Monad)` along a monad morphism, `MonadSupport.toWP(Monad)` demonically at `.pure` |
+| `PolyFun/PFunctor/Free/Do.lean` | Scoped demonic `WP (FreeM P) .pure` instances (`open scoped PFunctor.FreeM.DemonicWP`), `wpMonadOfHandler`, and the `Spec.lift` `@[spec]` lemma enabling `mvcgen` on free programs with uninterpreted operations |
+
+Worked examples: `PolyFunTest/Control/MonadSupport.lean` (judgments, notation,
+`Iff.rfl` transfer contract) and `PolyFunTest/Do/FreeM.lean` (`mvcgen` smoke
+tests).
+
+## Always / never judgments
+
+For `[MonadSupport m]` and `x : m α` (`open scoped MonadSupport`):
+
+- `x ⊨ₐ p` (`AllOutputs p x`): every possible output satisfies `p` —
+  definitionally `∀ a ∈ supportM x, p a`.
+- `x ⊨ₛ p` (`SomeOutput p x`): some possible output satisfies `p`.
+- `x ⊭ p` (`NoOutput p x`): no possible output satisfies `p`.
+
+These stay `Iff.rfl`-convertible to their bounded-quantifier spellings — a
+contract pinned by tests — so downstream support-based statements transfer
+without rewriting. `triple_top_iff_allOutputs` identifies `x ⊨ₐ p` with the
+trivial-precondition `Prop`-carrier triple, and on `FreeM` the judgments
+recurse structurally (`allOutputs_liftBind` and friends) and agree with the
+demonic/angelic `wpFold` (`wpFold_demonic_iff_allOutputs`).
+
+`StateT` and `ReaderT` have no `MonadSupport` instance on purpose: the union
+over initial states is not a monad morphism. State such facts per run,
+`supportM (x.run s)`.
+
+## The `Std.Do` quarantine
+
+Only `PolyFun/Control/Do/Basic.lean` and `PolyFun/PFunctor/Free/Do.lean` (and
+`PolyFunTest/Do/`) may import `Std.Tactic.Do`. The quarantine keeps the
+dependency on the fast-moving upstream `mvcgen` API confined to two files, and
+everything they provide is a construction (`def`), not a global instance —
+global `WP` instances on `FreeM` would race downstream registrations on
+reducible unfoldings such as VCVio's `OracleComp`. The demonic instances are
+`scoped` under `PFunctor.FreeM.DemonicWP`.
+
+## What stays downstream
+
+Probability carriers (`evalDist`, SPMF, ℝ≥0∞/`Prob`), couplings and
+pRHL/eRHL, concrete handler specifications, verification tactics
+(`vcgen`/`mvcgen'` and attribute machinery), and any Loom2 or Iris/Bluebell
+dependency. PolyFun ships definitions, rule lemmas, and simp sets only.

--- a/docs/wiki/program-logic.md
+++ b/docs/wiki/program-logic.md
@@ -12,35 +12,65 @@ migration sketch live in
 |---|---|
 | `PolyFun/Control/Monad/Algebra.lean` | `MAlgOrdered m l`: ordered monad algebras over a complete lattice, with `wp`, `Triple`, the structural rule set, `StateT`/`ReaderT`/`ExceptT`/`OptionT` lifts, and the honest two-postcondition `wpExc`/`wpOpt` |
 | `PolyFun/Control/Monad/Algebra/Relational.lean` | `MAlgRelOrdered m₁ m₂ l`: relational `rwp`/`RelWP`/`Triple`, asynchronous one-sided bind rules, structural pure rules, side-lifts, and the `StrictBind` / `Anchored` subclasses (Maillard et al. POPL 2020 shapes) |
-| `PolyFun/Control/Monad/Support.lean` | `MonadSupport m`: a canonical set-valued support as a monad morphism `supportHom : m →ᵐ SetM`; `supportM`; the `AllOutputs`/`SomeOutput`/`NoOutput` judgments and scoped `⊨ₐ`/`⊨ₛ`/`⊭` notation; the demonic `MAlgOrdered m Prop` instance |
-| `PolyFun/PFunctor/Free/Support.lean` | The canonical `MonadSupport (FreeM P)` (every response possible) and its coherence with `Free/Path.lean` (`supportM_eq_range_output`) |
+| `PolyFun/Control/Monad/Support.lean` | `ExactMonadAttach m`: the introduction rules core omits for `MonadAttach.CanReturn`; `MonadAttach.support`; the `AllOutputs`/`SomeOutput`/`NoOutput` judgments and scoped `⊨ₐ`/`⊨ₛ`/`⊭` notation; the demonic `MAlgOrdered m Prop` instance; instances for `Except`/`SetM` (absent upstream) and the `ExceptT` universe alias |
+| `PolyFun/PFunctor/Free/Support.lean` | `MonadAttach`/`ExactMonadAttach` for `FreeM P` with a computable, axiom-free `attach`; structural equations by `rfl`; coherence with `Free/Path.lean` (`support_eq_range_output`) and with the powerset fold (`support_eq_liftM_univ`) |
 | `PolyFun/PFunctor/Free/WP.lean` | `OpSpec P l` per-operation specs; syntactic `FreeM.wpFold` (with `demonic`/`angelic`); `OpSpec.toMAlgOrdered`; semantic `FreeM.wpVia` through a `Handler`; soundness `wpFold_le_wpVia`/`wpFold_eq_wpVia` |
-| `PolyFun/Control/Do/Basic.lean` | Core-`Std.Do` transports: `MonadHom.transportWP(Monad)` along a monad morphism, `MonadSupport.toWP(Monad)` demonically at `.pure` |
+| `PolyFun/Control/Do/Basic.lean` | Core-`Std.Do` transports: `MonadHom.transportWP(Monad)` along a monad morphism, `MonadAttach.toWP(Monad)` demonically at `.pure`, `toWPSound` for core-sense soundness, and `support_subset_of_wp`/`allOutputs_of_wp` turning any `WPSound` triple into a support fact |
 | `PolyFun/PFunctor/Free/Do.lean` | Scoped demonic `WP (FreeM P) .pure` instances (`open scoped PFunctor.FreeM.DemonicWP`), `wpMonadOfHandler`, and the `Spec.lift` `@[spec]` lemma enabling `mvcgen` on free programs with uninterpreted operations |
 
-Worked examples: `PolyFunTest/Control/MonadSupport.lean` (judgments, notation,
+Worked examples: `PolyFunTest/Control/MonadAttach.lean` (judgments, notation,
 `Iff.rfl` transfer contract) and `PolyFunTest/Do/FreeM.lean` (`mvcgen` smoke
 tests).
 
+## Relation to core `MonadAttach`
+
+The support layer is a three-way split:
+
+- **Core owns the data and canonicity.** `MonadAttach.CanReturn x a` is "`a` is a
+  possible output of `x`", `attach` decorates results with proofs of it, and
+  `LawfulMonadAttach` pins it down as the strongest postcondition.
+- **PolyFun owns the introduction rules.** Core proves only elimination lemmas,
+  which bound the support from above; they do not pin it down, since a monad with
+  `CanReturn := fun _ _ => False` satisfies `LawfulMonadAttach` vacuously.
+  `ExactMonadAttach` adds `canReturn_pure` and `canReturn_bind`, turning each of
+  core's implications into the equivalence support reasoning rewrites with.
+  Extending `LawfulMonadAttach` rather than the weak class simultaneously excludes
+  `MonadAttach.trivial` (`CanReturn := True`, i.e. `support = univ`).
+- **`WPSound` is the bridge.** `MonadAttach.toWPSound` proves PolyFun's demonic
+  interpretation sound in core's sense, and `support_subset_of_wp` /
+  `allOutputs_of_wp` convert any `WPSound` weakest-precondition proof — including
+  an `mvcgen`-discharged one — into a support fact.
+
+Core supplies the instances for `Id`, `Option`, `OptionT`, `ExceptT`, `StateT`,
+and `ReaderT`; PolyFun adds `Except` and `SetM` (which core lacks), a
+single-universe alias for core's `ExceptT` instance (which is declared at
+`max`-joined universes and cannot otherwise be synthesized polymorphically), and
+the `FreeM P` instance.
+
 ## Always / never judgments
 
-For `[MonadSupport m]` and `x : m α` (`open scoped MonadSupport`):
+For `[MonadAttach m]` and `x : m α` (`open scoped MonadAttach`):
 
 - `x ⊨ₐ p` (`AllOutputs p x`): every possible output satisfies `p` —
-  definitionally `∀ a ∈ supportM x, p a`.
+  definitionally `∀ a ∈ support x, p a`.
 - `x ⊨ₛ p` (`SomeOutput p x`): some possible output satisfies `p`.
 - `x ⊭ p` (`NoOutput p x`): no possible output satisfies `p`.
 
-These stay `Iff.rfl`-convertible to their bounded-quantifier spellings — a
-contract pinned by tests — so downstream support-based statements transfer
-without rewriting. `triple_top_iff_allOutputs` identifies `x ⊨ₐ p` with the
-trivial-precondition `Prop`-carrier triple, and on `FreeM` the judgments
-recurse structurally (`allOutputs_liftBind` and friends) and agree with the
-demonic/angelic `wpFold` (`wpFold_demonic_iff_allOutputs`).
+These stay `Iff.rfl`-convertible both to their bounded-quantifier spellings and
+to `CanReturn` — a contract pinned by tests — so downstream support-based
+statements transfer without rewriting. `triple_top_iff_allOutputs` identifies
+`x ⊨ₐ p` with the trivial-precondition `Prop`-carrier triple, and on `FreeM` the
+judgments recurse structurally (`allOutputs_liftBind` and friends) and agree with
+the demonic/angelic `wpFold` (`wpFold_demonic_iff_allOutputs`).
 
-`StateT` and `ReaderT` have no `MonadSupport` instance on purpose: the union
-over initial states is not a monad morphism. State such facts per run,
-`supportM (x.run s)`.
+`StateT` and `ReaderT` do carry core's canonical support — the union over initial
+states — so the elimination theory applies to them, but they are deliberately
+*not* `ExactMonadAttach`: possible outputs do not compose along `bind` when the
+continuation may observe a state the prefix never produced. The test suite proves
+both introduction rules fail there. Reason per run instead, via
+`mem_support_stateT_iff`. Oracle- and state-relative supports belong at the
+specification layer (`PFunctor/Free/WP.lean`), which indexes the notion by a
+per-operation answer assignment.
 
 ## The `Std.Do` quarantine
 

--- a/docs/wiki/program-logic.md
+++ b/docs/wiki/program-logic.md
@@ -11,8 +11,8 @@ migration sketch live in
 | Module | Content |
 |---|---|
 | `PolyFun/Control/Monad/Algebra.lean` | `MAlgOrdered m l`: ordered monad algebras over a complete lattice, with `wp`, `Triple`, the structural rule set, `StateT`/`ReaderT`/`ExceptT`/`OptionT` lifts, and the honest two-postcondition `wpExc`/`wpOpt` |
-| `PolyFun/Control/Monad/Algebra/Relational.lean` | `MAlgRelOrdered m₁ m₂ l`: relational `rwp`/`RelWP`/`Triple`, asynchronous one-sided bind rules, structural pure rules, side-lifts, and the `StrictBind` / `Anchored` subclasses (Maillard et al. POPL 2020 shapes) |
-| `PolyFun/Control/Monad/Support.lean` | `ExactMonadAttach m`: the introduction rules core omits for `MonadAttach.CanReturn`; `MonadAttach.support`; the `AllOutputs`/`SomeOutput`/`NoOutput` judgments and scoped `⊨ₐ`/`⊨ₛ`/`⊭` notation; the demonic `MAlgOrdered m Prop` instance; instances for `Except`/`SetM` (absent upstream) and the `ExceptT` universe alias |
+| `PolyFun/Control/Monad/Algebra/Relational.lean` | `MAlgRelOrdered m₁ m₂ l`: relational `rwp`/`RelWP`/`Triple`, asynchronous one-sided bind rules, structural pure rules, explicit named side lifts, and the `StrictBind` / `Anchored` subclasses (Maillard et al. POPL 2020 shapes) |
+| `PolyFun/Control/Monad/Support.lean` | `ExactMonadAttach m`: the introduction rules core omits for `MonadAttach.CanReturn`; `MonadAttach.support`; the `AllOutputs`/`SomeOutput`/`NoOutput` judgments and scoped `⊨ₐ`/`⊨ₛ`/`⊭` notation; the named demonic `MAlgOrdered m Prop` choice; instances for `Except`/`SetM` (absent upstream) and the `ExceptT` universe alias |
 | `PolyFun/PFunctor/Free/Support.lean` | `MonadAttach`/`ExactMonadAttach` for `FreeM P` with a computable, axiom-free `attach`; structural equations by `rfl`; coherence with `Free/Path.lean` (`support_eq_range_output`) and with the powerset fold (`support_eq_liftM_univ`) |
 | `PolyFun/PFunctor/Free/WP.lean` | `OpSpec P l` per-operation specs; syntactic `FreeM.wpFold` (with `demonic`/`angelic`); `OpSpec.toMAlgOrdered`; semantic `FreeM.wpVia` through a `Handler`; soundness `wpFold_le_wpVia`/`wpFold_eq_wpVia` |
 | `PolyFun/Control/Do/Basic.lean` | Core-`Std.Do` transports: `MonadHom.transportWP(Monad)` along a monad morphism, `MonadAttach.toWP(Monad)` demonically at `.pure`, `toWPSound` for core-sense soundness, and `support_subset_of_wp`/`allOutputs_of_wp` turning any `WPSound` triple into a support fact |
@@ -71,6 +71,13 @@ both introduction rules fail there. Reason per run instead, via
 `mem_support_stateT_iff`. Oracle- and state-relative supports belong at the
 specification layer (`PFunctor/Free/WP.lean`), which indexes the notion by a
 per-operation answer assignment.
+
+The support-based `MAlgOrdered m Prop` and relational transformer lifts are
+explicit named definitions, not unrestricted global instances. This keeps
+support partial correctness distinct from the existing failure-as-`⊥`
+`OptionT`/`ExceptT` algebras and prevents inequivalent left/right transformer
+instance paths. Install the intended algebra locally at each verification
+boundary.
 
 ## The `Std.Do` quarantine
 

--- a/docs/wiki/repo-map.md
+++ b/docs/wiki/repo-map.md
@@ -26,7 +26,9 @@ PolyFun/
                      machines whose transition functions are admissible
   Control/           monad/comonad and LTS infrastructure (Coalgebra,
                      Comonad, Lawful, Free, Iter, Bisimulation, LTS/Trace),
-                     including exact monadic support (Monad/Support)
+                     including the program-logic kernel
+                     (Monad/{Algebra, Support}) and the core-Std.Do
+                     quarantine root (Do/Basic)
   Logic/             small logic helpers (HEq)
 
 docs/wiki/           agent-facing notes (this directory)
@@ -88,6 +90,11 @@ Logic/HEq, Control/{Coalgebra, Comonad, Lawful, Monad, Bisimulation, LTS/Trace}
   (Cslib.Foundations.Semantics.LTS.Bisimulation): the transition-system theory
   is cslib's, reached through `Control.LTS.toLts`.
 
+Control/Monad/Algebra -> Control/Monad/Algebra/Relational
+Control/Monad/Hom -> Control/Monad/Support
+Control/Monad/Support -> Control/Do/Basic  (also imports Std.Tactic.Do; see
+  the quarantine rule in program-logic.md)
+
 PFunctor/Lens/{Basic, Cartesian, State}
   -> PFunctor/Lens/{Composite, Distributivity, Factorization, Duoidal}
   -> PFunctor/{InternalHom, CartesianClosed, Adjunctions, Comonoid}
@@ -95,6 +102,8 @@ PFunctor/Lens/{Basic, Cartesian, State}
 PFunctor/Lens/Basic -> PFunctor/SubstMonoid
 PFunctor/{Free/Path, SubstMonoid} -> PFunctor/Free/Polynomial
 PFunctor/Free/Path + Control/Monad/Support -> PFunctor/Free/Support
+PFunctor/{Free/Support, Handler} -> PFunctor/Free/WP
+Control/Do/Basic + PFunctor/Free/WP -> PFunctor/Free/Do
 PFunctor/Comonoid -> PFunctor/Comonoid/Category
 PFunctor/{Comonoid, Lens/Duoidal} -> PFunctor/Comonoid/Tensor
 PFunctor/{SubstMonoid, Comonoid, InternalHom, Lens/Duoidal}
@@ -243,6 +252,10 @@ plain imports, and reducibility is exposed declaration-by-declaration.
   [`interaction.md`](interaction.md).
 - Adding monad / comonad helpers, lawful re-exports, or free-monad
   algebra: start in `PolyFun/Control/`.
+- Program-logic work (`MAlgOrdered`, `MAlgRelOrdered`, `MonadSupport`,
+  `wpFold`, `Std.Do` bridges): start with
+  [`program-logic.md`](program-logic.md); definitions live under
+  `PolyFun/Control/Monad/` and `PolyFun/PFunctor/Free/{Support, WP, Do}.lean`.
 - Updating notation: start in `PolyFun/Interaction/UC/Notation.lean`. See
   [`notation.md`](notation.md).
 

--- a/docs/wiki/repo-map.md
+++ b/docs/wiki/repo-map.md
@@ -91,7 +91,6 @@ Logic/HEq, Control/{Coalgebra, Comonad, Lawful, Monad, Bisimulation, LTS/Trace}
   is cslib's, reached through `Control.LTS.toLts`.
 
 Control/Monad/Algebra -> Control/Monad/Algebra/Relational
-Control/Monad/Hom -> Control/Monad/Support
 Control/Monad/Support -> Control/Do/Basic  (also imports Std.Tactic.Do; see
   the quarantine rule in program-logic.md)
 
@@ -252,7 +251,7 @@ plain imports, and reducibility is exposed declaration-by-declaration.
   [`interaction.md`](interaction.md).
 - Adding monad / comonad helpers, lawful re-exports, or free-monad
   algebra: start in `PolyFun/Control/`.
-- Program-logic work (`MAlgOrdered`, `MAlgRelOrdered`, `MonadSupport`,
+- Program-logic work (`MAlgOrdered`, `MAlgRelOrdered`, `ExactMonadAttach`,
   `wpFold`, `Std.Do` bridges): start with
   [`program-logic.md`](program-logic.md); definitions live under
   `PolyFun/Control/Monad/` and `PolyFun/PFunctor/Free/{Support, WP, Do}.lean`.


### PR DESCRIPTION
## Summary

Stacked on #138. Adds the extrinsic verification-condition substrate over the polynomial free monad, the quarantined core-`Std.Do` bridge, and — now that support rests on core's `MonadAttach` — `WPSound` adequacy in both directions.

- upstream `MAlgRelOrdered` from VCVio's `ToMathlib/Control/Monad/RelationalAlgebra.lean` into `Control/Monad/Algebra/Relational.lean` near-verbatim: relational `rwp`/`RelWP`/`Triple`, asynchronous one-sided bind rules, structural pure rules, `StateT`/`OptionT`/`ExceptT` side-lifts, and the `StrictBind` / `Anchored` subclasses
- add `OpSpec P l` per-operation predicate-transformer specifications and the syntactic fold `FreeM.wpFold` (`PFunctor/Free/WP.lean`); the demonic and angelic `Prop` specs recover the `AllOutputs`/`SomeOutput` judgments; every monotone spec induces an ordered monad algebra (`OpSpec.toMAlgOrdered`)
- add the semantic `FreeM.wpVia` through a `Handler` and the soundness theorems `wpFold_le_wpVia` / `wpFold_eq_wpVia` — the generic engine behind downstream handler-specification reasoning
- add the two-file core-`Std.Do` quarantine: `Control/Do/Basic.lean` (transport `WP`/`WPMonad` along a monad morphism; demonic `MonadAttach.toWP`/`toWPMonad` at `.pure`) and `PFunctor/Free/Do.lean` (scoped demonic instances under `PFunctor.FreeM.DemonicWP`, `wpMonadOfHandler`, and the `Spec.lift` `@[spec]` lemma), so `mvcgen` decomposes `do`-programs over `FreeM P` with uninterpreted operations
- add `WPSound` adequacy: `MonadAttach.toWPSound` proves the demonic interpretation sound in core's sense (the `Ensures` witness is literally `attach` with the postcondition re-tagged), and `support_subset_of_wp` / `allOutputs_of_wp` convert *any* `WPSound` proof — including an `mvcgen`-discharged one — into a support fact
- document the layer in `docs/reading/program-logic-landscape.md` and `docs/wiki/program-logic.md`, and state the `Std.Tactic.Do` quarantine as gotcha #12 / AGENTS.md gotcha #8

## Design notes

- Only `Control/Do/Basic.lean`, `PFunctor/Free/Do.lean`, and `PolyFunTest/Do/` may import `Std.Tactic.Do`; everything they export is a construction or a scoped instance, never a global `WP` instance — a global one would race downstream registrations on reducible unfoldings such as oracle-computation types.
- `support_subset_of_wp` needs only `LawfulMonadAttach`, not exactness, so it also applies to `StateT`/`ReaderT`/`EStateM`, where `ExactMonadAttach` is unavailable.
- Reasoning goes through `WPSound.of_wp_canReturn` (stable `Std.Do` namespace); core's `Internal.MayReturn.canReturn_eq` is cited but not depended upon.
- PolyFun takes no Loom2 or Iris dependency and stays probability-free; quantitative carriers, couplings, handler specs, and tactics remain downstream.

## Validation

`lake build`, `lake lint`, `lake test`, `./scripts/validate.sh --axioms` (zero-debt baseline preserved). `PolyFunTest/Do/FreeM.lean` exercises the full round trip: `mvcgen` closes a triple over a free program with uninterpreted operations, and the result is read back as a support fact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
