### PR TITLE
feat(realizability): add representation invariance and codability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,8 +89,10 @@ and depend on this library.
   admissible. Closed under `ofFn`, input precomposition, result
   postcomposition, `bind`, interface transport, and class refinement.
   Instances: unconstrained, finite-state, Mathlib-`Computable`, and a bridge
-  from any class of word functions. *Generic only* — cost measures and
-  concrete complexity classes live downstream.
+  from any class of word functions. `Representation.lean` supplies mutual
+  admissible translation, boundary-level realizability invariance, and
+  admissible word encode/decode retractions. *Generic only* — cost measures
+  and concrete complexity classes live downstream.
 - `PolyFun/Control/`: monad and comonad infrastructure transitively
   required by the above (coalgebra, comonad, free / freecont monad
   algebra, monad iter / hom, lawful re-exports).

--- a/PolyFun.lean
+++ b/PolyFun.lean
@@ -235,4 +235,5 @@ public import PolyFun.Realizability.Basic
 public import PolyFun.Realizability.Closure
 public import PolyFun.Realizability.Instances
 public import PolyFun.Realizability.Machine
+public import PolyFun.Realizability.Representation
 public import PolyFun.Realizability.StepClass

--- a/PolyFun/Realizability/Instances.lean
+++ b/PolyFun/Realizability/Instances.lean
@@ -306,9 +306,11 @@ structure WordDistrib {W : Type u} (Q : (W → W) → Prop) (P : WordPairing Q)
 /-- The step class built from a class `Q` of word functions on `W` that contains
 the identity and is closed under composition.
 
-A type is representable by an injective encoding into `W` — injectivity is the
-only semantic demand, exactly as for a raw bit encoding — and a function is
-admissible when some `Q`-function intertwines the encodings. -/
+A type is representable by an injective encoding into `W` and a function is
+admissible when some `Q`-function intertwines the encodings. This is intentionally
+the raw bridge: security-sensitive boundaries need a separately pinned
+admissible encode/decode retraction, since injectivity alone does not make the
+representation complexity-invariant. -/
 def ofWordClass (W : Type u) (Q : (W → W) → Prop) (hid : Q id)
     (hcomp : ∀ {f g : W → W}, Q f → Q g → Q (g ∘ f)) : StepClass.{u, u} where
   Str A := { encode : A → W // Function.Injective encode }

--- a/PolyFun/Realizability/Representation.lean
+++ b/PolyFun/Realizability/Representation.lean
@@ -1,0 +1,402 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+module
+
+public import PolyFun.Realizability.Basic
+
+/-!
+# Translation and coding of admissible representations
+
+`StepClass.Str A` is deliberately data: admissibility depends on a chosen
+representation of `A`. This module records the two certificates needed to use
+that freedom without making a complexity statement representation-dependent.
+
+* `StepClass.PolyTranslatable a b` says that the identity on the represented
+  type is admissible in both directions between `a` and `b`. It induces an
+  invariance theorem for `StepClass.Hom`, componentwise translation of
+  realizability boundaries, and equivalences for bounded and unbounded
+  realizability.
+* `StepClass.PolyCodable word rep` gives an admissible encoding into a pinned
+  word representation and an admissible partial decoder which retracts it.
+  Injectivity follows from the retraction; it is not the only hypothesis.
+
+The unqualified prefix `Poly` names the PolyFun-side structural certificate.
+Whether admissibility means polynomial time, computability, finiteness, or
+something else is determined by the ambient `StepClass`.
+
+`CodeRetract` separates the semantic retraction from admissibility, and has
+constructors for products, sums, optional values, and dependent families.
+Their codecs are explicit because a bare word type carries no canonical
+pairing or tagging discipline.
+-/
+
+@[expose] public section
+
+universe u v
+
+namespace PFunctor
+namespace StepClass
+
+variable {C : StepClass.{u, v}}
+
+/-! ## Mutually admissible representations -/
+
+/-- Two representations of the same type are polynomially translatable relative
+to `C` when the identity function is admissible in both directions.
+
+The name does not assert polynomial time on its own: that interpretation comes
+from the chosen step class. -/
+structure PolyTranslatable {A : Type u} (a b : C.Str A) : Prop where
+  /-- Translate from `a` to `b` without changing the represented value. -/
+  forward : C.Hom a b id
+  /-- Translate from `b` to `a` without changing the represented value. -/
+  backward : C.Hom b a id
+
+namespace PolyTranslatable
+
+/-- Every representation translates to itself. -/
+@[refl]
+theorem refl {A : Type u} (a : C.Str A) : PolyTranslatable a a :=
+  ⟨C.id_mem a, C.id_mem a⟩
+
+/-- Representation translation is symmetric. -/
+@[symm]
+theorem symm {A : Type u} {a b : C.Str A} (h : PolyTranslatable a b) :
+    PolyTranslatable b a :=
+  ⟨h.backward, h.forward⟩
+
+/-- Representation translations compose. -/
+@[trans]
+theorem trans {A : Type u} {a b d : C.Str A} (hab : PolyTranslatable a b)
+    (hbd : PolyTranslatable b d) : PolyTranslatable a d where
+  forward := hab.forward.postcomp_id hbd.forward
+  backward := hbd.backward.postcomp_id hab.backward
+
+/-- Admissibility is invariant under polynomially translatable source and target
+representations. -/
+theorem hom_iff {A B : Type u} {a a' : C.Str A} {b b' : C.Str B}
+    (ha : PolyTranslatable a a') (hb : PolyTranslatable b b') (f : A → B) :
+    C.Hom a b f ↔ C.Hom a' b' f := by
+  constructor
+  · intro hf
+    exact (hf.precomp_id ha.backward).postcomp_id hb.forward
+  · intro hf
+    exact (hf.precomp_id ha.forward).postcomp_id hb.backward
+
+/-- Product representations translate componentwise. -/
+theorem prod [P : C.HasProd] {A B : Type u} {a a' : C.Str A} {b b' : C.Str B}
+    (ha : PolyTranslatable a a') (hb : PolyTranslatable b b') :
+    PolyTranslatable (P.prod a b) (P.prod a' b') where
+  forward := P.map_id_mem ha.forward hb.forward
+  backward := P.map_id_mem ha.backward hb.backward
+
+/-- Sum representations translate componentwise. -/
+theorem sum [S : C.HasSum] {A B : Type u} {a a' : C.Str A} {b b' : C.Str B}
+    (ha : PolyTranslatable a a') (hb : PolyTranslatable b b') :
+    PolyTranslatable (S.sum a b) (S.sum a' b') where
+  forward := S.map_id_mem ha.forward hb.forward
+  backward := S.map_id_mem ha.backward hb.backward
+
+/-- Optional-value representations translate with their payloads. -/
+theorem option [C.HasProd] [O : C.HasOption] {A : Type u} {a a' : C.Str A}
+    (ha : PolyTranslatable a a') :
+    PolyTranslatable (O.option a) (O.option a') where
+  forward := O.map_id_mem ha.forward
+  backward := O.map_id_mem ha.backward
+
+end PolyTranslatable
+
+/-! ## Semantic word retractions -/
+
+/-- An encoding of `A` into words `W` with a partial decoder that is a left
+inverse on every encoded value. -/
+structure CodeRetract (W A : Type u) where
+  /-- Encode a value as a word. -/
+  encode : A → W
+  /-- Decode a word when it is a valid code. -/
+  decode : W → Option A
+  /-- Every encoded value decodes to itself. -/
+  decode_encode : ∀ value, decode (encode value) = some value
+
+/-- Pairing and projections used to combine two codes in one word. -/
+structure CodePairing (W : Type u) where
+  /-- Combine two words. -/
+  pair : W → W → W
+  /-- Read the first component of a paired word. -/
+  fst : W → W
+  /-- Read the second component of a paired word. -/
+  snd : W → W
+  /-- First projection after pairing. -/
+  fst_pair : ∀ left right, fst (pair left right) = left
+  /-- Second projection after pairing. -/
+  snd_pair : ∀ left right, snd (pair left right) = right
+
+/-- Tags and a partial tag decoder used to combine two code spaces. -/
+structure CodeSum (W : Type u) where
+  /-- Encode a left payload. -/
+  inl : W → W
+  /-- Encode a right payload. -/
+  inr : W → W
+  /-- Recover a tagged payload. -/
+  split : W → Option (W ⊕ W)
+  /-- Decode a left tag. -/
+  split_inl : ∀ word, split (inl word) = some (Sum.inl word)
+  /-- Decode a right tag. -/
+  split_inr : ∀ word, split (inr word) = some (Sum.inr word)
+
+/-- Tags and a partial tag decoder for optional codes. -/
+structure CodeOption (W : Type u) where
+  /-- The absent-value code. -/
+  noneCode : W
+  /-- Tag a present payload. -/
+  someCode : W → W
+  /-- Recover the optional payload represented by a word. -/
+  split : W → Option (Option W)
+  /-- Decode the absent-value code. -/
+  split_none : split noneCode = Option.some Option.none
+  /-- Decode a present-value code. -/
+  split_some : ∀ word, split (someCode word) = Option.some (Option.some word)
+
+namespace CodeRetract
+
+/-- The identity word code. -/
+def id (W : Type u) : CodeRetract W W where
+  encode := _root_.id
+  decode := some
+  decode_encode _ := rfl
+
+/-- Compose two semantic coding retractions. -/
+def trans {W A B : Type u} (outer : CodeRetract W A)
+    (inner : CodeRetract A B) : CodeRetract W B where
+  encode value := outer.encode (inner.encode value)
+  decode word := (outer.decode word).bind inner.decode
+  decode_encode value := by
+    rw [outer.decode_encode, Option.bind_some, inner.decode_encode]
+
+/-- Product codes from a word pairing. -/
+def prod {W A B : Type u} (pairing : CodePairing W)
+    (left : CodeRetract W A) (right : CodeRetract W B) :
+    CodeRetract W (A × B) where
+  encode value := pairing.pair (left.encode value.1) (right.encode value.2)
+  decode word := (left.decode (pairing.fst word)).bind fun leftValue =>
+    (right.decode (pairing.snd word)).map fun rightValue => (leftValue, rightValue)
+  decode_encode value := by
+    rcases value with ⟨leftValue, rightValue⟩
+    rw [pairing.fst_pair, pairing.snd_pair, left.decode_encode,
+      Option.bind_some, right.decode_encode, Option.map_some]
+
+/-- Sum codes from a partial tag decoder. -/
+def sum {W A B : Type u} (codec : CodeSum W) (left : CodeRetract W A)
+    (right : CodeRetract W B) : CodeRetract W (A ⊕ B) where
+  encode
+    | Sum.inl value => codec.inl (left.encode value)
+    | Sum.inr value => codec.inr (right.encode value)
+  decode word := (codec.split word).bind fun
+    | Sum.inl payload => (left.decode payload).map Sum.inl
+    | Sum.inr payload => (right.decode payload).map Sum.inr
+  decode_encode value := by
+    cases value with
+    | inl value => simp [codec.split_inl, left.decode_encode]
+    | inr value => simp [codec.split_inr, right.decode_encode]
+
+/-- Optional codes from an absent code and a present-value tag. -/
+def option {W A : Type u} (codec : CodeOption W) (payload : CodeRetract W A) :
+    CodeRetract W (Option A) where
+  encode
+    | none => codec.noneCode
+    | some value => codec.someCode (payload.encode value)
+  decode word := (codec.split word).bind fun
+    | none => some none
+    | some encoded => (payload.decode encoded).map some
+  decode_encode value := by
+    cases value with
+    | none => simp [codec.split_none]
+    | some value => simp [codec.split_some, payload.decode_encode]
+
+/-- Codes for a dependent family, represented as a sigma type. The index and
+the selected fiber value are paired after being encoded separately. -/
+def sigma {W I : Type u} {A : I → Type u} (pairing : CodePairing W)
+    (index : CodeRetract W I) (value : ∀ i, CodeRetract W (A i)) :
+    CodeRetract W (Σ i, A i) where
+  encode entry := pairing.pair (index.encode entry.1) ((value entry.1).encode entry.2)
+  decode word := (index.decode (pairing.fst word)).bind fun i =>
+    ((value i).decode (pairing.snd word)).map (Sigma.mk i)
+  decode_encode entry := by
+    rcases entry with ⟨i, entry⟩
+    simp [pairing.fst_pair, pairing.snd_pair, index.decode_encode,
+      (value i).decode_encode]
+
+/-- A semantic coding retraction has an injective encoder. -/
+theorem encode_injective {W A : Type u} (coding : CodeRetract W A) :
+    Function.Injective coding.encode := by
+  intro left right hencode
+  apply Option.some.inj
+  calc
+    some left = coding.decode (coding.encode left) := (coding.decode_encode left).symm
+    _ = coding.decode (coding.encode right) := congrArg coding.decode hencode
+    _ = some right := coding.decode_encode right
+
+end CodeRetract
+
+/-! ## Admissible word coding -/
+
+/-- An admissible word encoding and decoding retraction.
+
+Unlike a raw injective encoding, this structure exposes a decoder in the ambient
+step class and proves that decoding retracts encoding. For a polynomial-time
+step class this is the word-level codability certificate needed to rule out
+encodings that hide non-computable advice. -/
+structure PolyCodable [C.HasProd] [O : C.HasOption] {W A : Type u}
+    (word : C.Str W) (rep : C.Str A) where
+  /-- The semantic coding retraction. -/
+  toCodeRetract : CodeRetract W A
+  /-- Encoding is admissible from the represented value to words. -/
+  encode_mem : C.Hom rep word toCodeRetract.encode
+  /-- Partial decoding is admissible from words to represented optional values. -/
+  decode_mem : C.Hom word (O.option rep) toCodeRetract.decode
+
+namespace PolyCodable
+
+variable [C.HasProd] [O : C.HasOption] {W A : Type u} {word : C.Str W}
+  {rep : C.Str A}
+
+/-- The encoder of an admissible coding. -/
+abbrev encode (coding : PolyCodable word rep) : A → W :=
+  coding.toCodeRetract.encode
+
+/-- The decoder of an admissible coding. -/
+abbrev decode (coding : PolyCodable word rep) : W → Option A :=
+  coding.toCodeRetract.decode
+
+/-- Decoding retracts encoding. -/
+theorem decode_encode (coding : PolyCodable word rep) (value : A) :
+    coding.decode (coding.encode value) = some value :=
+  coding.toCodeRetract.decode_encode value
+
+/-- A polynomially codable representation has an injective word encoder. -/
+theorem encode_injective (coding : PolyCodable word rep) :
+    Function.Injective coding.encode :=
+  coding.toCodeRetract.encode_injective
+
+/-- Forget admissible decoding and retain the raw injective encoder expected by
+word-class representations. -/
+def toEncoding (coding : PolyCodable word rep) :
+    { encode : A → W // Function.Injective encode } :=
+  ⟨coding.encode, coding.encode_injective⟩
+
+/-- Attach admissibility proofs to a semantic coding retraction. -/
+def ofCodeRetract (coding : CodeRetract W A)
+    (encode_mem : C.Hom rep word coding.encode)
+    (decode_mem : C.Hom word (O.option rep) coding.decode) :
+    PolyCodable word rep :=
+  ⟨coding, encode_mem, decode_mem⟩
+
+end PolyCodable
+
+end StepClass
+
+/-! ## Boundary translation and realizability invariance -/
+
+namespace DynSystem.DynComputation
+namespace Boundary
+
+variable {C : StepClass.{u, v}} {p : PFunctor.{u, u}} {A B : Type u}
+
+/-- Componentwise polynomial translatability of two realizability boundaries. -/
+structure PolyTranslatable (left right : Boundary C p A B) : Prop where
+  /-- Input representations translate in both directions. -/
+  input : StepClass.PolyTranslatable left.input right.input
+  /-- Result representations translate in both directions. -/
+  out : StepClass.PolyTranslatable left.out right.out
+  /-- Query-position representations translate in both directions. -/
+  pos : StepClass.PolyTranslatable left.pos right.pos
+  /-- Tagged-answer representations translate in both directions. -/
+  idx : StepClass.PolyTranslatable left.idx right.idx
+
+namespace PolyTranslatable
+
+/-- Boundary translation is reflexive. -/
+@[refl]
+theorem refl (bd : Boundary C p A B) : PolyTranslatable bd bd :=
+  ⟨StepClass.PolyTranslatable.refl bd.input,
+    StepClass.PolyTranslatable.refl bd.out,
+    StepClass.PolyTranslatable.refl bd.pos,
+    StepClass.PolyTranslatable.refl bd.idx⟩
+
+/-- Boundary translation is symmetric. -/
+@[symm]
+theorem symm {left right : Boundary C p A B}
+    (h : PolyTranslatable left right) : PolyTranslatable right left :=
+  ⟨h.input.symm, h.out.symm, h.pos.symm, h.idx.symm⟩
+
+/-- Boundary translations compose. -/
+@[trans]
+theorem trans {left middle right : Boundary C p A B}
+    (hlm : PolyTranslatable left middle) (hmr : PolyTranslatable middle right) :
+    PolyTranslatable left right :=
+  ⟨hlm.input.trans hmr.input, hlm.out.trans hmr.out,
+    hlm.pos.trans hmr.pos, hlm.idx.trans hmr.idx⟩
+
+/-- Derived one-step-readout representations translate componentwise. -/
+theorem head [S : C.HasSum] {left right : Boundary C p A B}
+    (h : PolyTranslatable left right) :
+    StepClass.PolyTranslatable left.head right.head :=
+  h.out.sum h.pos
+
+/-- Derived state-and-answer representations translate componentwise while the
+chosen hidden-state representation stays fixed. -/
+theorem stateIdx [P : C.HasProd] {left right : Boundary C p A B}
+    (h : PolyTranslatable left right) {State : Type u} (state : C.Str State) :
+    StepClass.PolyTranslatable (left.stateIdx state) (right.stateIdx state) :=
+  (StepClass.PolyTranslatable.refl state).prod h.idx
+
+end PolyTranslatable
+
+end Boundary
+
+variable {C : StepClass.{u, v}} [P : C.HasProd] [S : C.HasSum]
+  [O : C.HasOption] {p : PFunctor.{u, u}} [DecidableEq p.A]
+  {A B : Type u} {left right : Boundary C p A B}
+  {program : A → FreeM p B}
+
+/-- Transport a realization across componentwise polynomially translatable
+boundary representations without changing its machine or hidden-state layout. -/
+def Realization.translateBoundary (h : left.PolyTranslatable right)
+    (R : Realization C left) : Realization C right where
+  machine := R.machine
+  state := R.state
+  init_mem := (h.input.hom_iff (StepClass.PolyTranslatable.refl R.state)
+    R.machine.init).mp R.init_mem
+  head_mem := ((StepClass.PolyTranslatable.refl R.state).hom_iff h.head
+    R.machine.head).mp R.head_mem
+  update_mem := ((h.stateIdx R.state).hom_iff
+    (StepClass.PolyTranslatable.refl (O.option R.state))
+    R.machine.update?).mp R.update_mem
+
+/-- Unbounded realizability is invariant under componentwise polynomial
+translation of every pinned boundary representation. -/
+theorem isRealizableBy_iff_of_boundary_polyTranslatable
+    (h : left.PolyTranslatable right) :
+    IsRealizableBy C left program ↔ IsRealizableBy C right program := by
+  constructor
+  · rintro ⟨R, hR⟩
+    exact ⟨R.translateBoundary h, hR⟩
+  · rintro ⟨R, hR⟩
+    exact ⟨R.translateBoundary h.symm, hR⟩
+
+/-- Bounded realizability is invariant under componentwise polynomial
+translation of every pinned boundary representation, at the same query budget. -/
+theorem isRealizableWithin_iff_of_boundary_polyTranslatable
+    (h : left.PolyTranslatable right) (k : ℕ) :
+    IsRealizableWithin C left program k ↔ IsRealizableWithin C right program k := by
+  constructor
+  · rintro ⟨R, hR⟩
+    exact ⟨R.translateBoundary h, hR⟩
+  · rintro ⟨R, hR⟩
+    exact ⟨R.translateBoundary h.symm, hR⟩
+
+end DynSystem.DynComputation
+end PFunctor

--- a/PolyFun/Realizability/StepClass.lean
+++ b/PolyFun/Realizability/StepClass.lean
@@ -89,6 +89,24 @@ theorem Hom.congr {A B : Type u} {a : C.Str A} {b : C.Str B} {f g : A → B}
     (h : C.Hom a b f) (hfg : ∀ x, f x = g x) : C.Hom a b g := by
   rwa [← funext hfg]
 
+/-- Change the source representation along an admissible identity map.
+
+This law hides the normalization of `f ∘ id` at the `StepClass` boundary, so
+clients transporting a morphism do not depend on the reducibility of function
+composition. -/
+theorem Hom.precomp_id {A B : Type u} {a a' : C.Str A} {b : C.Str B}
+    {f : A → B} (hf : C.Hom a b f) (hid : C.Hom a' a id) : C.Hom a' b f :=
+  (C.comp_mem hid hf).congr (fun _ ↦ rfl)
+
+/-- Change the target representation along an admissible identity map.
+
+This law hides the normalization of `id ∘ f` at the `StepClass` boundary, so
+clients transporting a morphism do not depend on the reducibility of function
+composition. -/
+theorem Hom.postcomp_id {A B : Type u} {a : C.Str A} {b b' : C.Str B}
+    {f : A → B} (hf : C.Hom a b f) (hid : C.Hom b b' id) : C.Hom a b' f :=
+  (C.comp_mem hf hid).congr (fun _ ↦ rfl)
+
 /-! ## Products -/
 
 /-- A step class with admissible binary products.
@@ -118,6 +136,16 @@ theorem HasProd.map_mem [P : C.HasProd] {A B A' B' : Type u} {a : C.Str A}
   intro x
   cases x
   rfl
+
+/-- Admissible identity maps act componentwise on a product while denoting the
+identity on the underlying product type. -/
+theorem HasProd.map_id_mem [P : C.HasProd] {A B : Type u} {a a' : C.Str A}
+    {b b' : C.Str B} (ha : C.Hom a a' id) (hb : C.Hom b b' id) :
+    C.Hom (P.prod a b) (P.prod a' b') id :=
+  (P.map_mem ha hb).congr (by
+    intro value
+    cases value
+    rfl)
 
 /-- Pairing an admissible function with a fixed second component. -/
 theorem HasProd.pairRight_mem [P : C.HasProd] {A B D : Type u} {a : C.Str A}
@@ -189,6 +217,15 @@ theorem HasSum.map_mem [S : C.HasSum] {A B A' B' : Type u} {a : C.Str A}
   intro x
   cases x <;> rfl
 
+/-- Admissible identity maps act componentwise on a sum while denoting the
+identity on the underlying sum type. -/
+theorem HasSum.map_id_mem [S : C.HasSum] {A B : Type u} {a a' : C.Str A}
+    {b b' : C.Str B} (ha : C.Hom a a' id) (hb : C.Hom b b' id) :
+    C.Hom (S.sum a b) (S.sum a' b') id :=
+  (S.map_mem ha hb).congr (by
+    intro value
+    cases value <;> rfl)
+
 /-! ## Optional values -/
 
 /-- A step class with admissible optional values.
@@ -221,6 +258,15 @@ class HasOption (C : StepClass.{u, v}) [P : C.HasProd] where
   obindCtx_mem : ∀ {A B E : Type u} {a : C.Str A} {b : C.Str B} {e : C.Str E}
     {k : A × E → Option B}, C.Hom (P.prod a e) (option b) k →
       C.Hom (P.prod (option a) e) (option b) fun y => y.1.bind fun j => k (j, y.2)
+
+/-- An admissible identity map acts on optional values while denoting the
+identity on the underlying optional-value type. -/
+theorem HasOption.map_id_mem [C.HasProd] [O : C.HasOption] {A : Type u}
+    {a a' : C.Str A} (ha : C.Hom a a' id) :
+    C.Hom (O.option a) (O.option a') id :=
+  (O.omap_mem ha).congr (by
+    intro value
+    cases value <;> rfl)
 
 /-! ## Distributivity -/
 

--- a/PolyFunTest/Realizability/RepresentationExamples.lean
+++ b/PolyFunTest/Realizability/RepresentationExamples.lean
@@ -1,0 +1,130 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+module
+
+public import PolyFun.Realizability.Instances
+public import PolyFun.Realizability.Representation
+
+/-!
+# Representation translation and coding examples
+
+These examples pin the ordinary-import surface for representation invariance
+and exercise each semantic word-code constructor.
+-/
+
+@[expose] public section
+
+namespace PFunctor.RealizabilityRepresentationExamples
+
+open PFunctor
+open PFunctor.DynSystem.DynComputation
+
+/-! ## A syntax tree used as a word universe -/
+
+inductive Word where
+  | atom : Nat → Word
+  | pair : Word → Word → Word
+  | inl : Word → Word
+  | inr : Word → Word
+  | none : Word
+  | some : Word → Word
+deriving DecidableEq
+
+def pairing : StepClass.CodePairing Word where
+  pair := Word.pair
+  fst
+    | .pair left _ => left
+    | word => word
+  snd
+    | .pair _ right => right
+    | word => word
+  fst_pair _ _ := rfl
+  snd_pair _ _ := rfl
+
+def sumCodec : StepClass.CodeSum Word where
+  inl := Word.inl
+  inr := Word.inr
+  split
+    | .inl word => some (Sum.inl word)
+    | .inr word => some (Sum.inr word)
+    | _ => none
+  split_inl _ := rfl
+  split_inr _ := rfl
+
+def optionCodec : StepClass.CodeOption Word where
+  noneCode := Word.none
+  someCode := Word.some
+  split
+    | .none => some none
+    | .some word => some (some word)
+    | _ => none
+  split_none := rfl
+  split_some _ := rfl
+
+def natCode : StepClass.CodeRetract Word Nat where
+  encode := Word.atom
+  decode
+    | .atom value => some value
+    | _ => none
+  decode_encode _ := rfl
+
+example (left right : Nat) :
+    (natCode.prod pairing natCode).decode
+      ((natCode.prod pairing natCode).encode (left, right)) = some (left, right) :=
+  (natCode.prod pairing natCode).decode_encode (left, right)
+
+example (value : Nat ⊕ Nat) :
+    (natCode.sum sumCodec natCode).decode
+      ((natCode.sum sumCodec natCode).encode value) = some value :=
+  (natCode.sum sumCodec natCode).decode_encode value
+
+example (value : Option Nat) :
+    (natCode.option optionCodec).decode
+      ((natCode.option optionCodec).encode value) = some value :=
+  (natCode.option optionCodec).decode_encode value
+
+def fiberCode (_ : Bool) : StepClass.CodeRetract Word Nat := natCode
+
+def boolCode : StepClass.CodeRetract Word Bool where
+  encode
+    | false => Word.inl (Word.atom 0)
+    | true => Word.inr (Word.atom 0)
+  decode
+    | .inl (.atom 0) => some false
+    | .inr (.atom 0) => some true
+    | _ => none
+  decode_encode value := by cases value <;> rfl
+
+example (entry : Σ _ : Bool, Nat) :
+    (boolCode.sigma pairing fiberCode).decode
+      ((boolCode.sigma pairing fiberCode).encode entry) = some entry :=
+  (boolCode.sigma pairing fiberCode).decode_encode entry
+
+/-! ## Admissible coding and boundary invariance -/
+
+def natPolyCodable : StepClass.PolyCodable
+    (C := StepClass.unconstrained.{0, 0}) (W := Word) (A := Nat)
+    PUnit.unit PUnit.unit :=
+  StepClass.PolyCodable.ofCodeRetract natCode True.intro True.intro
+
+example : Function.Injective natPolyCodable.encode :=
+  natPolyCodable.encode_injective
+
+example {C : StepClass.{0, 0}} {A B : Type} {a a' : C.Str A}
+    {b b' : C.Str B} (ha : C.PolyTranslatable a a')
+    (hb : C.PolyTranslatable b b') (f : A → B) :
+    C.Hom a b f ↔ C.Hom a' b' f :=
+  ha.hom_iff hb f
+
+example {C : StepClass.{0, 0}} [C.HasProd] [C.HasSum] [C.HasOption]
+    {p : PFunctor.{0, 0}} [DecidableEq p.A] {A B : Type}
+    {left right : Boundary C p A B} {program : A → FreeM p B}
+    (h : left.PolyTranslatable right) (k : Nat) :
+    IsRealizableWithin C left program k ↔
+      IsRealizableWithin C right program k :=
+  isRealizableWithin_iff_of_boundary_polyTranslatable h k
+
+end PFunctor.RealizabilityRepresentationExamples

--- a/docs/wiki/realizability.md
+++ b/docs/wiki/realizability.md
@@ -17,7 +17,7 @@ finite-state realizability, machines with computable transitions, and — the
 motivating case downstream — the polynomial-time adversary model used in
 cryptography.
 
-## The Four Modules
+## The Five Modules
 
 ```text
 PolyFun/Realizability/
@@ -30,6 +30,9 @@ PolyFun/Realizability/
   Closure.lean      closure under ofFn, precomp, mapResult, seqComp (bind),
                     wrap (interface transport), and class refinement
   Instances.lean    unconstrained, finite, computable, WordClass
+  Representation.lean
+                    mutual translation and invariance of representations;
+                    admissible word encode/decode retractions
 ```
 
 `Machine.lean` and `StepClass.lean` are independent; `Basic.lean` joins them.
@@ -233,6 +236,31 @@ These are client obligations rather than extra fields of `IsRealizableWithin`:
 the latter intentionally remains a qualitative admissibility predicate plus a
 visible-query bound.
 
+## Representation Invariance And Codability
+
+`StepClass.PolyTranslatable a b` contains admissibility proofs for the identity
+in both directions between two representations of the same type. Its `hom_iff`
+theorem makes admissibility invariant under translated source and target
+representations. Products, sums, and optional-value representations inherit the
+certificate componentwise.
+
+`Boundary.PolyTranslatable` applies that condition to the input, result,
+position, and tagged-answer representations. The theorems
+`isRealizableBy_iff_of_boundary_polyTranslatable` and
+`isRealizableWithin_iff_of_boundary_polyTranslatable` transport one machine
+witness in both directions without changing its hidden-state representation or
+query budget. This is the explicit invariance theorem needed before replacing a
+pinned cryptographic boundary encoding.
+
+`StepClass.PolyCodable word rep` is stronger than an injective bit encoding. It
+contains a semantic `CodeRetract` with `decode (encode value) = some value`, an
+admissibility proof for the encoder, and an admissibility proof for the partial
+decoder. Consequently the encoder is injective, but an injective function whose
+range cannot be decoded in the ambient class does not qualify. `CodeRetract`
+constructors build product, sum, option, and dependent-sigma codes from explicit
+word pairing/tagging codecs; admissibility remains a separate proof so a
+concrete complexity library must expose the operations it actually closes.
+
 ## Universe Discipline
 
 `StepClass.Str` speaks about types in a single universe, so the realizability
@@ -256,8 +284,11 @@ def ofWordClass (W : Type u) (Q : (W → W) → Prop) (hid : Q id)
   Hom eA eB f := ∃ q, Q q ∧ ∀ x, q (eA.1 x) = eB.1 (f x)
 ```
 
-Injectivity of the encoding is the only semantic demand, exactly as for a raw bit
-encoding.
+Injectivity is deliberately the only demand of this low-level bridge, exactly as
+for a raw bit encoding. A cryptographic boundary must additionally pin a
+`PolyCodable` certificate (or an equivalent canonical-code theorem); existential
+choice of this raw representation would permit an injective encoding with no
+admissible decoder.
 
 Products and sums are *not* automatic. They need a pairing codec and a tagging
 scheme whose operations the word class admits, supplied as `WordPairing` and

--- a/docs/wiki/repo-map.md
+++ b/docs/wiki/repo-map.md
@@ -207,8 +207,7 @@ Interaction/UC/OpenProcessModel -> Interaction/UC/OpenProcessFactorization
 PFunctor/Basic -> Realizability/StepClass
 PFunctor/Dynamical/DynComputation/Bounded -> Realizability/Machine
 Realizability/{StepClass, Machine} -> Realizability/Basic
-  -> Realizability/Closure
-  -> Realizability/Instances
+Realizability/Basic -> Realizability/{Closure, Instances, Representation}
   (Instances additionally draws on Mathlib's Computability and Fintype layers;
    nothing under PFunctor/, ITree/, or Interaction/ depends on Realizability/)
 ```

--- a/docs/wiki/uc.md
+++ b/docs/wiki/uc.md
@@ -116,7 +116,10 @@ sequential bind remains expressible. State growth must either be charged
 additively or be restricted by an explicit cap whose completeness cost is
 documented. Boundary encodings additionally need polynomial translation
 invariance and a word-level coding retraction; injectivity alone is not a
-complexity-invariant interface.
+complexity-invariant interface. The generic certificates are
+`StepClass.PolyTranslatable`, `Boundary.PolyTranslatable`, and
+`StepClass.PolyCodable`; a VCVio complexity class must instantiate their
+admissibility fields quantitatively.
 
 ## Related-Model Lessons
 


### PR DESCRIPTION
## Summary

- add `StepClass.PolyTranslatable` and prove admissibility invariance under mutually admissible representations
- lift translation through products, sums, options, and realizability boundaries
- prove bounded and unbounded realizability invariant under translated pinned boundaries
- add `CodeRetract` and `StepClass.PolyCodable` with explicit encode/decode retraction, rather than treating injectivity as a sufficient cryptographic encoding discipline
- add product, sum, option, and dependent-sigma coding constructors plus compiled examples
- add public `StepClass.Hom.precomp_id` / `postcomp_id` and structured identity-map laws so clients do not normalize function composition with `change` or rewrite-then-`rfl`

## Why

The raw `ofWordClass` bridge deliberately accepts any injective encoding. That is useful as a low-level construction, but by itself permits a caching/halting-advice encoding that makes a boundary-dependent complexity statement vacuous. `PolyCodable` is the stronger boundary certificate: its partial decoder is admissible and provably retracts the encoder. `PolyTranslatable` supplies the separate invariance theorem needed to change a pinned representation safely.

This is the PolyFun-side structural gate identified while stress-testing the VCVio PPT/UC work. Concrete polynomial-time witnesses remain downstream; no cryptographic semantics are introduced here.

## Validation

- `./scripts/validate.sh --lint --test --axioms`
- 2,094 test-library jobs
- 8,793 PolyFun declarations, zero sorry/non-standard-axiom taint
