### PR TITLE
refactor(control): build the transition-system layer on cslib's LTS

### DIFF
--- a/PolyFun/Control/Bisimulation.lean
+++ b/PolyFun/Control/Bisimulation.lean
@@ -6,6 +6,7 @@ Authors: Devon Tuma
 module
 
 public import Mathlib.Logic.Relation
+public import Cslib.Foundations.Semantics.LTS.Bisimulation
 
 /-!
 # Simulation and bisimulation for labelled transition systems
@@ -37,6 +38,25 @@ The matching transitions are:
 The closure lemmas below make the inclusions
 `strong ⊆ delay ⊆ weak` and composition of simulations reusable by
 downstream models.
+
+## Relation to `Cslib.LTS`
+
+This `LTS` is *move-indexed*: a state exposes a type of moves, each with a
+target and a label.  That is the polynomial-coalgebra presentation, and it is
+what lets `DynSystem` and `ITree` adapt into this layer.  cslib's `Cslib.LTS` is
+*relation-indexed*: a single `Tr : State → Label → State → Prop`.
+
+`LTS.toLts` projects the former onto the latter and `Option Obs` supplies the
+silent label through `Cslib.HasTau`, after which cslib's development applies
+verbatim: `SilentSteps` is its `τSTr`, `WeakStep` is its saturated transition
+`STr`, and the strong and weak simulation and bisimulation notions here agree
+with `Cslib.LTS.IsSimulation`, `IsBisimulation`, `IsSWBisimulation`, and
+`WeakBisimilarity` on the projection.  The `Relation to cslib` section at the
+end of this file records those correspondences and derives the consequences
+that cslib proves and this file does not, in particular that bisimilarity is
+itself the largest bisimulation.
+
+The *delay* spectrum has no cslib counterpart and is developed here.
 -/
 
 @[expose] public section
@@ -674,5 +694,193 @@ itself. -/
     exact ⟨s₁, s₂, h₁₂, h₂₃⟩
 
 end WeakBisimulationEquivalent
+
+/-! ## Relation to cslib
+
+`LTS.toLts` is the projection onto `Cslib.LTS`; every correspondence below is
+stated against it.  The step-level ones are definitional, and the
+relation-level ones transport cslib's theory onto the notions defined above.
+-/
+
+section Cslib
+
+/-- `none` is the silent label, so an optionally-observed transition system is a
+cslib transition system with a distinguished `τ`.
+
+cslib declares this same instance, but inside
+`Cslib/Computability/Automata/EpsilonNA/Basic.lean`, where it is reachable only
+by importing the ε-NFA development. Repeating it here is cheaper than taking
+that dependency, and the two agree definitionally, so having both in scope is
+harmless. It belongs next to `HasTau` itself upstream. -/
+instance instHasTauOption : Cslib.HasTau (Option Obs) := ⟨none⟩
+
+@[simp] theorem hasTau_option_τ : (Cslib.HasTau.τ : Option Obs) = none := rfl
+
+/-- The relation-indexed transition system underlying a move-indexed one:
+forget which move justified a transition and keep only that one exists. -/
+def LTS.toLts (L : LTS.{uObs, uState, uMove} Obs) : Cslib.LTS L.State (Option Obs) :=
+  ⟨L.Step⟩
+
+variable (L : LTS.{uObs, uState, uMove} Obs)
+
+@[simp] theorem LTS.toLts_tr {s t : L.State} {label : Option Obs} :
+    L.toLts.Tr s label t ↔ L.Step s label t := Iff.rfl
+
+/-- The silent closure is cslib's `τ`-closure. -/
+@[simp] theorem LTS.τSTr_toLts {s t : L.State} :
+    L.toLts.τSTr s t ↔ L.SilentSteps s t := Iff.rfl
+
+/-- A weak transition is cslib's saturated transition.  The two definitions
+differ in shape — one is a match on the label, the other an inductive — but
+describe the same relation. -/
+theorem LTS.sTr_toLts_iff {s t : L.State} {label : Option Obs} :
+    L.toLts.STr s label t ↔ L.WeakStep s label t := by
+  constructor
+  · rintro (_ | ⟨hpre, hstep, hpost⟩)
+    · exact Relation.ReflTransGen.refl
+    · cases label with
+      | none => exact (hpre.trans (Relation.ReflTransGen.single hstep)).trans hpost
+      | some obs => exact ⟨_, _, hpre, hstep, hpost⟩
+  · intro h
+    cases label with
+    | none =>
+        induction h with
+        | refl => exact .refl
+        | tail _ hlast ih =>
+            cases ih with
+            | refl => exact .tr Relation.ReflTransGen.refl hlast Relation.ReflTransGen.refl
+            | tr hpre hstep hpost =>
+                exact .tr hpre hstep (hpost.trans (Relation.ReflTransGen.single hlast))
+    | some obs =>
+        obtain ⟨before, after, hpre, hvis, hpost⟩ := h
+        exact .tr hpre hvis hpost
+
+/-- Saturating the projection exposes exactly the weak transitions. -/
+theorem LTS.saturate_toLts_tr_iff {s t : L.State} {label : Option Obs} :
+    L.toLts.saturate.Tr s label t ↔ L.WeakStep s label t := L.sTr_toLts_iff
+
+variable {L}
+
+/-! ### Correspondence of the strong spectrum -/
+
+theorem isStrongSimulation_iff {L₁ : LTS.{uObs, uState₁, uMove₁} Obs}
+    {L₂ : LTS.{uObs, uState₂, uMove₂} Obs} {rel : L₁.State → L₂.State → Prop} :
+    IsStrongSimulation L₁ L₂ rel ↔ Cslib.LTS.IsSimulation L₁.toLts L₂.toLts rel :=
+  ⟨fun h _ _ hrel _ _ hstep => h hrel hstep,
+    fun h _ _ hrel _ _ hstep => h _ _ hrel _ _ hstep⟩
+
+theorem isStrongBisimulation_iff {L₁ : LTS.{uObs, uState₁, uMove₁} Obs}
+    {L₂ : LTS.{uObs, uState₂, uMove₂} Obs} {rel : L₁.State → L₂.State → Prop} :
+    IsStrongBisimulation L₁ L₂ rel ↔ Cslib.LTS.IsBisimulation L₁.toLts L₂.toLts rel := by
+  constructor
+  · exact fun h _ _ hrel _ =>
+      ⟨fun _ hstep => h.forward hrel hstep, fun _ hstep => h.backward hrel hstep⟩
+  · intro h
+    constructor
+    · intro s₁ s₂ hrel label t₁ hstep
+      exact (h hrel label).1 t₁ hstep
+    · intro s₂ s₁ hrel label t₂ hstep
+      exact (h hrel label).2 t₂ hstep
+
+theorem strongBisimilar_iff {L₁ : LTS.{uObs, uState₁, uMove₁} Obs}
+    {L₂ : LTS.{uObs, uState₂, uMove₂} Obs} {s₁ : L₁.State} {s₂ : L₂.State} :
+    StrongBisimilar L₁ L₂ s₁ s₂ ↔ Cslib.LTS.Bisimilarity L₁.toLts L₂.toLts s₁ s₂ :=
+  ⟨fun ⟨rel, hb, hrel⟩ => ⟨rel, hrel, isStrongBisimulation_iff.mp hb⟩,
+    fun ⟨rel, hrel, hb⟩ => ⟨rel, isStrongBisimulation_iff.mpr hb, hrel⟩⟩
+
+/-! ### Correspondence of the weak spectrum -/
+
+theorem isWeakSimulation_iff {L₁ : LTS.{uObs, uState₁, uMove₁} Obs}
+    {L₂ : LTS.{uObs, uState₂, uMove₂} Obs} {rel : L₁.State → L₂.State → Prop} :
+    IsWeakSimulation L₁ L₂ rel ↔
+      Cslib.LTS.IsSimulation L₁.toLts L₂.toLts.saturate rel := by
+  constructor
+  · exact fun h _ _ hrel _ _ hstep =>
+      let ⟨t₂, hw, hr⟩ := h hrel hstep
+      ⟨t₂, L₂.sTr_toLts_iff.mpr hw, hr⟩
+  · exact fun h _ _ hrel _ _ hstep =>
+      let ⟨t₂, hs, hr⟩ := h _ _ hrel _ _ hstep
+      ⟨t₂, L₂.sTr_toLts_iff.mp hs, hr⟩
+
+/-- The weak bisimulations of this file are cslib's *sw*-bisimulations: the
+challenge is a single transition and the answer a weak one. -/
+theorem isWeakBisimulation_iff_isSWBisimulation {L₁ : LTS.{uObs, uState₁, uMove₁} Obs}
+    {L₂ : LTS.{uObs, uState₂, uMove₂} Obs} {rel : L₁.State → L₂.State → Prop} :
+    IsWeakBisimulation L₁ L₂ rel ↔ Cslib.LTS.IsSWBisimulation L₁.toLts L₂.toLts rel := by
+  constructor
+  · refine fun h _ _ hrel _ => ⟨fun _ hstep => ?_, fun _ hstep => ?_⟩
+    · obtain ⟨t₂, hw, hr⟩ := h.forward hrel hstep
+      exact ⟨t₂, L₂.sTr_toLts_iff.mpr hw, hr⟩
+    · obtain ⟨t₁, hw, hr⟩ := h.backward hrel hstep
+      exact ⟨t₁, L₁.sTr_toLts_iff.mpr hw, hr⟩
+  · intro h
+    constructor
+    · intro s₁ s₂ hrel label t₁ hstep
+      obtain ⟨t₂, hs, hr⟩ := (h hrel label).1 t₁ hstep
+      exact ⟨t₂, L₂.sTr_toLts_iff.mp hs, hr⟩
+    · intro s₂ s₁ hrel label t₂ hstep
+      obtain ⟨t₁, hs, hr⟩ := (h hrel label).2 t₂ hstep
+      exact ⟨t₁, L₁.sTr_toLts_iff.mp hs, hr⟩
+
+/-- Weak bisimulation in the single-challenge sense of this file coincides with
+bisimulation of the saturated systems.  This is Sangiorgi's Lemma 4.2.10, proved
+in cslib and transported here. -/
+theorem isWeakBisimulation_iff {L₁ : LTS.{uObs, uState₁, uMove₁} Obs}
+    {L₂ : LTS.{uObs, uState₂, uMove₂} Obs} {rel : L₁.State → L₂.State → Prop} :
+    IsWeakBisimulation L₁ L₂ rel ↔ Cslib.LTS.IsWeakBisimulation L₁.toLts L₂.toLts rel :=
+  isWeakBisimulation_iff_isSWBisimulation.trans
+    Cslib.LTS.isWeakBisimulation_iff_isSWBisimulation.symm
+
+theorem weakBisimilar_iff {L₁ : LTS.{uObs, uState₁, uMove₁} Obs}
+    {L₂ : LTS.{uObs, uState₂, uMove₂} Obs} {s₁ : L₁.State} {s₂ : L₂.State} :
+    WeakBisimilar L₁ L₂ s₁ s₂ ↔ Cslib.LTS.WeakBisimilarity L₁.toLts L₂.toLts s₁ s₂ :=
+  ⟨fun ⟨rel, hb, hrel⟩ => ⟨rel, hrel, isWeakBisimulation_iff.mp hb⟩,
+    fun ⟨rel, hrel, hb⟩ => ⟨rel, isWeakBisimulation_iff.mpr hb, hrel⟩⟩
+
+/-! ### Bisimilarity as the largest bisimulation
+
+cslib proves these for its own notions (`Bisimilarity.isBisimulation`,
+`IsBisimulation.le_bisimilarity`, `Bisimilarity.gfp`); the correspondences above
+make them available here, but stating them directly is shorter than
+transporting.  This file did not previously record them.
+-/
+
+/-- Strong bisimilarity is itself a strong bisimulation. -/
+theorem StrongBisimilar.isStrongBisimulation (L₁ : LTS.{uObs, uState₁, uMove₁} Obs)
+    (L₂ : LTS.{uObs, uState₂, uMove₂} Obs) :
+    IsStrongBisimulation L₁ L₂ (StrongBisimilar L₁ L₂) := by
+  constructor
+  · rintro s₁ s₂ ⟨rel, hb, hrel⟩ label t₁ hstep
+    obtain ⟨t₂, hstep₂, hrel₂⟩ := hb.forward hrel hstep
+    exact ⟨t₂, hstep₂, rel, hb, hrel₂⟩
+  · rintro s₂ s₁ ⟨rel, hb, hrel⟩ label t₂ hstep
+    obtain ⟨t₁, hstep₁, hrel₁⟩ := hb.backward hrel hstep
+    exact ⟨t₁, hstep₁, rel, hb, hrel₁⟩
+
+/-- Weak bisimilarity is itself a weak bisimulation. -/
+theorem WeakBisimilar.isWeakBisimulation (L₁ : LTS.{uObs, uState₁, uMove₁} Obs)
+    (L₂ : LTS.{uObs, uState₂, uMove₂} Obs) :
+    IsWeakBisimulation L₁ L₂ (WeakBisimilar L₁ L₂) := by
+  constructor
+  · rintro s₁ s₂ ⟨rel, hb, hrel⟩ label t₁ hstep
+    obtain ⟨t₂, hstep₂, hrel₂⟩ := hb.forward hrel hstep
+    exact ⟨t₂, hstep₂, rel, hb, hrel₂⟩
+  · rintro s₂ s₁ ⟨rel, hb, hrel⟩ label t₂ hstep
+    obtain ⟨t₁, hstep₁, hrel₁⟩ := hb.backward hrel hstep
+    exact ⟨t₁, hstep₁, rel, hb, hrel₁⟩
+
+/-- Strong bisimilarity is the largest strong bisimulation. -/
+theorem IsStrongBisimulation.le_strongBisimilar {L₁ : LTS.{uObs, uState₁, uMove₁} Obs}
+    {L₂ : LTS.{uObs, uState₂, uMove₂} Obs} {rel : L₁.State → L₂.State → Prop}
+    (h : IsStrongBisimulation L₁ L₂ rel) {s₁ : L₁.State} {s₂ : L₂.State} (hrel : rel s₁ s₂) :
+    StrongBisimilar L₁ L₂ s₁ s₂ := ⟨rel, h, hrel⟩
+
+/-- Weak bisimilarity is the largest weak bisimulation. -/
+theorem IsWeakBisimulation.le_weakBisimilar {L₁ : LTS.{uObs, uState₁, uMove₁} Obs}
+    {L₂ : LTS.{uObs, uState₂, uMove₂} Obs} {rel : L₁.State → L₂.State → Prop}
+    (h : IsWeakBisimulation L₁ L₂ rel) {s₁ : L₁.State} {s₂ : L₂.State} (hrel : rel s₁ s₂) :
+    WeakBisimilar L₁ L₂ s₁ s₂ := ⟨rel, h, hrel⟩
+
+end Cslib
 
 end Control

--- a/PolyFun/Control/LTS/Trace.lean
+++ b/PolyFun/Control/LTS/Trace.lean
@@ -55,6 +55,38 @@ def traces (s : L.State) : Set (List Obs) :=
 @[simp] theorem nil_mem_traces (s : L.State) : [] ∈ L.traces s :=
   ⟨s, .nil s⟩
 
+/-! ## Relation to cslib
+
+`WeakTrace` records only the *visible* observations, so it is a `List Obs`,
+whereas a cslib multi-step transition is labelled by a `List Label` that may
+still mention the silent label.  Tagging every observation recovers the cslib
+trace of the saturated system: a visible trace `[o₁, …, oₙ]` here is the
+multi-step trace `[some o₁, …, some oₙ]` there.
+-/
+
+/-- A finite visible trace is a multi-step transition of the saturated
+projection whose labels are all visible. -/
+theorem weakTrace_iff_mTr {s t : L.State} {observations : List Obs} :
+    L.WeakTrace s observations t ↔
+      L.toLts.saturate.MTr s (observations.map some) t := by
+  constructor
+  · intro h
+    induction h with
+    | nil _ => exact .refl
+    | cons head _ ih => exact .stepL (L.sTr_toLts_iff.mpr head) ih
+  · intro h
+    induction observations generalizing s with
+    | nil => cases h; exact .nil _
+    | cons obs rest ih =>
+        rcases h with _ | ⟨hhead, htail⟩
+        exact .cons (L.sTr_toLts_iff.mp hhead) (ih htail)
+
+/-- Membership in the visible trace set, transported to cslib's trace set. -/
+theorem mem_traces_iff_mem_toLts {s : L.State} {observations : List Obs} :
+    observations ∈ L.traces s ↔
+      observations.map some ∈ L.toLts.saturate.traces s :=
+  ⟨fun ⟨t, h⟩ => ⟨t, L.weakTrace_iff_mTr.mp h⟩, fun ⟨t, h⟩ => ⟨t, L.weakTrace_iff_mTr.mpr h⟩⟩
+
 end Control.LTS
 
 namespace Control

--- a/PolyFunTest/Control/BisimulationExamples.lean
+++ b/PolyFunTest/Control/BisimulationExamples.lean
@@ -6,6 +6,7 @@ Authors: Devon Tuma
 module
 
 public import PolyFun.Control.Bisimulation
+public import PolyFun.Control.LTS.Trace
 
 /-!
 # Examples for labelled-transition bisimulation
@@ -180,5 +181,55 @@ example : plainLTS.DelayStep () (some true) () :=
 
 example : plainLTS.WeakStep () (some true) () :=
   ((show plainLTS.Step () (some true) () from ⟨(), rfl, rfl⟩).delay).weak
+
+/-! ## The cslib bridge
+
+These are the canaries for `Control.LTS.toLts`: the step-level correspondences
+must stay definitional, and the relation-level ones must carry concrete facts in
+both directions.
+-/
+
+/-- A transition of the projection is a transition, definitionally. -/
+example : plainLTS.toLts.Tr () (some true) () ↔ plainLTS.Step () (some true) () := Iff.rfl
+
+/-- A silent closure is cslib's `τ`-closure, definitionally. -/
+example : idleLTS.toLts.τSTr () () ↔ idleLTS.SilentSteps () () := Iff.rfl
+
+/-- The silent idle move is a genuine `τ`-transition of the projection. -/
+example : idleLTS.toLts.Tr () Cslib.HasTau.τ () := ⟨false, rfl, rfl⟩
+
+/-- A weak transition is cslib's saturated transition. -/
+example : idleLTS.toLts.STr () (some true) () :=
+  idleLTS.sTr_toLts_iff.mpr
+    ((show idleLTS.Step () (some true) () from ⟨true, rfl, rfl⟩).delay).weak
+
+/-- Weak bisimilarity transports onto cslib's. -/
+example : Cslib.LTS.WeakBisimilarity idleLTS.toLts plainLTS.toLts () () :=
+  weakBisimilar_iff.mp idle_weak_plain_state
+
+/-- Strong bisimilarity transports in both directions. -/
+example : Cslib.LTS.Bisimilarity plainLTS.toLts plainLTS.toLts () () :=
+  strongBisimilar_iff.mp (StrongBisimilar.refl plainLTS ())
+
+example : StrongBisimilar plainLTS plainLTS () () :=
+  strongBisimilar_iff.mpr (Cslib.LTS.HomBisimilarity.refl (lts := plainLTS.toLts) ())
+
+/-- Weak bisimulation here is cslib's single-challenge weak bisimulation, and
+hence -- by Sangiorgi 4.2.10, proved upstream -- bisimulation of the saturated
+systems. -/
+example {rel : Unit → Unit → Prop} (h : IsWeakBisimulation idleLTS plainLTS rel) :
+    Cslib.LTS.IsWeakBisimulation idleLTS.toLts plainLTS.toLts rel :=
+  isWeakBisimulation_iff.mp h
+
+/-- Bisimilarity is itself a bisimulation. -/
+example : IsStrongBisimulation plainLTS plainLTS (StrongBisimilar plainLTS plainLTS) :=
+  StrongBisimilar.isStrongBisimulation plainLTS plainLTS
+
+/-- A visible trace tags to the corresponding cslib trace of the saturated
+system. -/
+example : [some true] ∈ plainLTS.toLts.saturate.traces () := by
+  refine (plainLTS.mem_traces_iff_mem_toLts (observations := [true])).mp ⟨(), ?_⟩
+  exact .cons ((show plainLTS.Step () (some true) () from ⟨(), rfl, rfl⟩).delay).weak
+    (LTS.WeakTrace.nil (L := plainLTS) ())
 
 end Control.BisimulationExamples

--- a/docs/wiki/bisimulation.md
+++ b/docs/wiki/bisimulation.md
@@ -36,6 +36,50 @@ Closure lemmas lift simulations across silent/delay/weak paths, and the
 inclusions `strong ⊆ delay ⊆ weak` are explicit. State and move universes are
 independent on the two sides.
 
+### Relation to cslib
+
+The *theory* of these notions is cslib's, not PolyFun's. `Control.LTS` is
+move-indexed — a state exposes a type of moves, each with a target and a label —
+which is the polynomial-coalgebra presentation and is what lets `DynSystem` and
+`ITree` adapt into this layer. cslib's `Cslib.LTS` is relation-indexed. `Step`
+projects one onto the other:
+
+```lean
+instance : Cslib.HasTau (Option Obs) := ⟨none⟩
+def Control.LTS.toLts (L : LTS Obs) : Cslib.LTS L.State (Option Obs) := ⟨L.Step⟩
+```
+
+Two step-level correspondences are definitional (`toLts_tr`, `τSTr_toLts`): a
+silent closure *is* cslib's `τSTr`. `sTr_toLts_iff` identifies `WeakStep` with
+cslib's saturated transition `STr`, and the relation-level correspondences
+follow:
+
+| PolyFun | cslib |
+|---|---|
+| `IsStrongSimulation` | `IsSimulation` on `toLts` |
+| `IsStrongBisimulation` | `IsBisimulation` on `toLts` |
+| `StrongBisimilar` | `Bisimilarity` on `toLts` |
+| `IsWeakSimulation` | `IsSimulation` into `toLts.saturate` |
+| `IsWeakBisimulation` | `IsSWBisimulation`, hence `IsWeakBisimulation` |
+| `WeakBisimilar` | `WeakBisimilarity` |
+| `LTS.WeakTrace s obs t` | `MTr` of `toLts.saturate` at `obs.map some` |
+
+The weak entry is the substantive one. PolyFun's weak bisimulation issues a
+*single* transition as the challenge and answers with a weak one — which is
+exactly cslib's `IsSWBisimulation`, not its `IsWeakBisimulation` (bisimulation
+of the saturated systems). That the two agree is Sangiorgi's Lemma 4.2.10,
+proved in cslib and transported by `isWeakBisimulation_iff`. PolyFun never
+proved it.
+
+`WeakTrace` records only the *visible* observations, so it is a `List Obs` where
+a cslib trace is a `List Label`; tagging each observation with `some` recovers
+the cslib trace of the saturated system.
+
+**The delay spectrum has no cslib counterpart** and is developed in PolyFun. It
+is load-bearing — `OpenProcessActivationEquiv` is delay bisimulation, not weak —
+so it is the clearest upstream contribution candidate. See
+[`../reading/upstream-alignment.md`](../reading/upstream-alignment.md).
+
 ## Dynamical systems
 
 `DynSystem.behavior : S → M p` is the unique map into the terminal

--- a/docs/wiki/repo-map.md
+++ b/docs/wiki/repo-map.md
@@ -83,6 +83,9 @@ PFunctor/Dynamical/DynComputation/Bounded
 
 Logic/HEq, Control/{Coalgebra, Comonad, Lawful, Monad, Bisimulation, LTS/Trace}
   (free-standing helpers, depended on by both PFunctor and ITree)
+  Control/Bisimulation additionally imports cslib
+  (Cslib.Foundations.Semantics.LTS.Bisimulation): the transition-system theory
+  is cslib's, reached through `Control.LTS.toLts`.
 
 PFunctor/Lens/{Basic, Cartesian, State}
   -> PFunctor/Lens/{Composite, Distributivity, Factorization, Duoidal}


### PR DESCRIPTION
Stacked on #141 (the survey memo). Review that first; this PR's diff is the second commit.

## Why

`Control/Bisimulation.lean` re-derived a transition-system theory that **cslib already ships** in `Cslib/Foundations/Semantics/LTS/` — and cslib is already a pinned PolyFun dependency, so there was never a dependency cost to reusing it. This connects the two rather than maintaining both.

## What changed

Nothing was deleted and no existing definition or lemma statement moved, so downstream is untouched. What's added is the projection and the correspondences over it.

PolyFun's `LTS` **stays move-indexed** (`Move : State → Type`, `next`, `label`). That is the polynomial-coalgebra presentation, and it is what lets `DynSystem` and `ITree` adapt into this layer — it is genuinely PolyFun's shape. cslib's is relation-indexed, and `Step` projects onto it:

```lean
instance : Cslib.HasTau (Option Obs) := ⟨none⟩
def Control.LTS.toLts (L : LTS Obs) : Cslib.LTS L.State (Option Obs) := ⟨L.Step⟩
```

`toLts_tr` and `τSTr_toLts` are `Iff.rfl` — a silent closure **is** cslib's `τSTr`. `sTr_toLts_iff` identifies `WeakStep` with cslib's saturated transition `STr`, and the relation-level correspondences follow: `IsStrongSimulation`/`IsStrongBisimulation`/`StrongBisimilar` ↔ `IsSimulation`/`IsBisimulation`/`Bisimilarity`, and `IsWeakSimulation` ↔ `IsSimulation` into `toLts.saturate`.

## The substantive part

PolyFun's weak bisimulation issues a **single** transition as the challenge and answers with a weak one. That is cslib's `IsSWBisimulation` — *not* its `IsWeakBisimulation`, which is bisimulation of the saturated systems. That the two coincide is **Sangiorgi's Lemma 4.2.10**, proved in cslib and transported here as `isWeakBisimulation_iff`. PolyFun had no such theorem.

Also now recorded: bisimilarity is itself a bisimulation, and is the largest one, in both flavours. Both were true before and never stated.

For traces, `WeakTrace` keeps only the *visible* observations, so it is a `List Obs` where a cslib trace is a `List Label`. `weakTrace_iff_mTr` tags each observation with `some` to recover the multi-step trace of the saturated projection.

## What stays PolyFun's

**The delay spectrum has no cslib counterpart**, and it is load-bearing: `Interaction/UC/OpenProcess.lean:971` uses `DelayBisimulationEquivalent` for `OpenProcessActivationEquiv`, because the structural `openTheory` laws prove the stronger delay notion rather than merely weak bisimulation. It stays here, and it is the clearest upstream contribution candidate the survey turned up.

One other gap worth noting: cslib's `Bisimilarity.symm` is stated for a single state type, while its `WeakBisimilarity.symm` is cross-type. PolyFun's is cross-type and cross-universe in both flavours, so that one does not transport — also worth reporting upstream.

## Tests

`PolyFunTest/Control/BisimulationExamples.lean` gains the bridge canaries: the two definitional correspondences as `Iff.rfl` (so a future upstream change that breaks defeq fails CI rather than degrading silently), and concrete facts transported in both directions on the existing worked systems.

## Validation

`./scripts/validate.sh --lint --test --axioms` passes: build, docs integrity, module scopes, import graph, environment linters, test library, and the axiom sweep at zero taint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
