### PR TITLE
refactor: reuse upstream for temporal operators, Pi-monoid traces, and category instances

### DIFF
--- a/PolyFun/Control/Trace.lean
+++ b/PolyFun/Control/Trace.lean
@@ -6,6 +6,7 @@ Authors: Quang Dao
 module
 
 public import Mathlib.Algebra.Group.Pi.Basic
+public import Mathlib.Algebra.Group.Pi.Lemmas
 public import Mathlib.Algebra.Group.Hom.Defs
 
 /-!
@@ -131,13 +132,14 @@ Bundle `map φ` as a monoid homomorphism on the trace monoid.
 
 This is the manifest algebraic content of `map`: post-composing a trace with
 a monoid hom is itself a monoid hom on the pointwise-monoid `Trace ω X`.
--/
-@[simps]
-def mapHom [Monoid ω] [Monoid ω'] (φ : ω →* ω') :
-    Trace ω X →* Trace ω' X where
-  toFun := map φ
-  map_one' := map_one φ
-  map_mul' := map_mul φ
+Because `Trace ω X` is reducibly the Pi type `X → ω`, this is Mathlib's
+`MonoidHom.compLeft`, which needs only `MulOneClass`. -/
+def mapHom [MulOneClass ω] [MulOneClass ω'] (φ : ω →* ω') :
+    Trace ω X →* Trace ω' X :=
+  φ.compLeft X
+
+@[simp] theorem mapHom_apply [MulOneClass ω] [MulOneClass ω'] (φ : ω →* ω') (t : Trace ω X) :
+    mapHom φ t = map φ t := rfl
 
 end Trace
 

--- a/PolyFun/Interaction/Concurrent/Fairness.lean
+++ b/PolyFun/Interaction/Concurrent/Fairness.lean
@@ -7,6 +7,7 @@ Authors: Quang Dao
 module
 
 public import PolyFun.Interaction.Concurrent.Run
+public import Mathlib.Order.Filter.AtTopBot.Basic
 
 /-!
 # Fairness of dynamic concurrent runs
@@ -34,6 +35,16 @@ namespace Concurrent
 namespace ProcessOver
 namespace Run
 
+/-! ## Temporal operators
+
+The two persistence operators are Mathlib's filter quantifiers at
+`Filter.atTop`: "from some time onward" is `∀ᶠ`, and "at arbitrarily late
+times" is `∃ᶠ`.  Defining them that way rather than by hand makes the whole
+`Filter` API — monotonicity, closure under conjunction, the interaction of the
+two quantifiers — available to fairness and liveness arguments.  cslib's
+`ωSequence` temporal layer uses the same encoding.
+-/
+
 /-- `Always P` means that the temporal property `P` holds at every time
 index. -/
 def Always (P : Nat → Prop) : Prop := ∀ n, P n
@@ -42,33 +53,29 @@ def Always (P : Nat → Prop) : Prop := ∀ n, P n
 def Eventually (P : Nat → Prop) : Prop := ∃ n, P n
 
 /-- `EventuallyAlways P` means that from some time onward, `P` keeps holding
-forever. -/
-def EventuallyAlways (P : Nat → Prop) : Prop :=
-  ∃ N, ∀ n, N ≤ n → P n
+forever: `P` holds eventually with respect to `Filter.atTop`. -/
+def EventuallyAlways (P : Nat → Prop) : Prop := ∀ᶠ n in Filter.atTop, P n
+
+/-- `InfinitelyOften P` means that `P` holds at arbitrarily late time indices:
+`P` holds frequently with respect to `Filter.atTop`. -/
+def InfinitelyOften (P : Nat → Prop) : Prop := ∃ᶠ n in Filter.atTop, P n
 
 /-- Characterize eventual persistence by a cutoff after which the property
 holds at every later index. -/
 theorem eventuallyAlways_iff {P : Nat → Prop} :
     EventuallyAlways P ↔ ∃ N, ∀ n, N ≤ n → P n :=
-  Iff.rfl
-
-/-- `InfinitelyOften P` means that `P` holds at arbitrarily late time
-indices. -/
-def InfinitelyOften (P : Nat → Prop) : Prop :=
-  ∀ N, ∃ n, N ≤ n ∧ P n
+  Filter.eventually_atTop
 
 /-- Characterize infinite recurrence by the existence of a witness at or
 after every requested index. -/
 theorem infinitelyOften_iff {P : Nat → Prop} :
     InfinitelyOften P ↔ ∀ N, ∃ n, N ≤ n ∧ P n :=
-  Iff.rfl
+  Filter.frequently_atTop
 
 /-- A property that eventually holds forever also holds infinitely often. -/
 theorem infinitelyOften_of_eventuallyAlways {P : Nat → Prop} :
-    EventuallyAlways P → InfinitelyOften P := by
-  rw [eventuallyAlways_iff, infinitelyOften_iff]
-  rintro ⟨N, hN⟩ N'
-  exact ⟨max N N', le_max_right _ _, hN _ (le_max_left _ _)⟩
+    EventuallyAlways P → InfinitelyOften P :=
+  Filter.Eventually.frequently
 
 theorem always_mono {P Q : Nat → Prop} (himp : ∀ n, P n → Q n) : Always P → Always Q :=
   fun hP n => himp n (hP n)
@@ -78,11 +85,11 @@ theorem eventually_mono {P Q : Nat → Prop} (himp : ∀ n, P n → Q n) : Event
 
 theorem eventuallyAlways_mono {P Q : Nat → Prop} (himp : ∀ n, P n → Q n) :
     EventuallyAlways P → EventuallyAlways Q :=
-  fun ⟨N, hP⟩ => ⟨N, fun n hn => himp n (hP n hn)⟩
+  fun hP => hP.mono himp
 
 theorem infinitelyOften_mono {P Q : Nat → Prop} (himp : ∀ n, P n → Q n) :
     InfinitelyOften P → InfinitelyOften Q :=
-  fun hP N => (hP N).imp fun n h => ⟨h.1, himp n h.2⟩
+  fun hP => hP.mono himp
 
 end Run
 

--- a/PolyFun/Interaction/Concurrent/Liveness.lean
+++ b/PolyFun/Interaction/Concurrent/Liveness.lean
@@ -7,6 +7,7 @@ Authors: Quang Dao
 module
 
 public import PolyFun.Interaction.Concurrent.Run
+public import Mathlib.Order.Filter.AtTopBot.Basic
 
 /-!
 # Safety and liveness predicates over concurrent runs
@@ -70,12 +71,23 @@ def EventuallyState
   ∃ n, P (run.state n)
 
 /-- `InfinitelyOftenState P run` means that `P` holds at arbitrarily late
-states of `run`. -/
+states of `run`: the state predicate holds frequently with respect to
+`Filter.atTop`.  This is the same encoding the temporal operators in
+`Concurrent/Fairness.lean` use. -/
 def InfinitelyOftenState
     {Γ : Interaction.TypeTree.Node.Context.{w, w₂}}
     {P : Type v} {process : ProcessOver P Γ}
     (P : StatePred process) (run : ProcessOver.Run process) : Prop :=
-  ∀ N, ∃ n, N ≤ n ∧ P (run.state n)
+  ∃ᶠ n in Filter.atTop, P (run.state n)
+
+/-- Characterize infinite recurrence of a state predicate by a witness at or
+after every requested index. -/
+theorem infinitelyOftenState_iff
+    {Γ : Interaction.TypeTree.Node.Context.{w, w₂}}
+    {P : Type v} {process : ProcessOver P Γ}
+    {P : StatePred process} {run : ProcessOver.Run process} :
+    InfinitelyOftenState P run ↔ ∀ N, ∃ n, N ≤ n ∧ P (run.state n) :=
+  Filter.frequently_atTop
 
 /-- Monotonicity of `AlwaysState`. -/
 theorem alwaysState_mono
@@ -104,10 +116,8 @@ theorem infinitelyOftenState_mono
     {P Q : StatePred process}
     (himp : ∀ p, P p → Q p) :
     ∀ {run : ProcessOver.Run process},
-      InfinitelyOftenState P run → InfinitelyOftenState Q run := by
-  intro run hP N
-  rcases hP N with ⟨n, hn, hPn⟩
-  exact ⟨n, hn, himp _ hPn⟩
+      InfinitelyOftenState P run → InfinitelyOftenState Q run :=
+  fun hP => hP.mono fun _ h => himp _ h
 
 end Run
 

--- a/PolyFun/PFunctor/Category.lean
+++ b/PolyFun/PFunctor/Category.lean
@@ -12,7 +12,21 @@ public import Mathlib.CategoryTheory.Monoidal.Category
 /-!
 # Categories of Polynomial Functors
 
-We define the various categories of polynomial functors, where morphisms are lenses or charts.
+Polynomial functors carry two different categorical structures on the *same*
+objects: lenses and charts. A `Category` instance is keyed on its object type,
+so both cannot be registered on `PFunctor` itself — instance search would pick
+one arbitrarily and `≫` / `𝟙` would silently mean whichever won.
+
+Following the treatment of `CategoryTheory.Cat`, `RelCat`, `KleisliCat`, and
+`PartialFun` in Mathlib, each structure therefore gets its own carrier:
+
+* `PFunctor.LensCat`, with `Lens` as morphisms. This is the category **Poly**
+  of Spivak–Niu.
+* `PFunctor.ChartCat`, with `Chart` as morphisms.
+
+`LensCat.of` / `ChartCat.of` move a `PFunctor` into the chosen carrier, and
+`LensCat.as` / `ChartCat.as` move back. Both are definitional, so a proof about
+a polynomial functor transports to its categorical avatar by `rfl`.
 -/
 
 @[expose] public section
@@ -23,22 +37,66 @@ open CategoryTheory
 
 namespace PFunctor
 
--- Category instance using Lens as morphisms
-instance lensCategory : Category PFunctor.{uA, uB} where
-  Hom P Q := Lens P Q
-  id P := Lens.id P
-  comp f g := Lens.comp g f -- Note the order: g ∘ f for f ≫ g
+/-! ## Lenses -/
+
+-- The position and direction universes stay independent, exactly as they do
+-- for `PFunctor` itself; the carrier only ever mentions them jointly.
+set_option linter.checkUnivs false in
+/-- `PFunctor` regarded as the category whose morphisms are lenses: the
+category **Poly**. -/
+def LensCat : Type max (uA + 1) (uB + 1) := PFunctor.{uA, uB}
+
+namespace LensCat
+
+/-- Regard a polynomial functor as an object of `LensCat`. -/
+abbrev of (P : PFunctor.{uA, uB}) : LensCat.{uA, uB} := P
+
+/-- Regard an object of `LensCat` as a polynomial functor. -/
+abbrev as (P : LensCat.{uA, uB}) : PFunctor.{uA, uB} := P
+
+instance instCategory : Category LensCat.{uA, uB} where
+  Hom P Q := Lens P.as Q.as
+  id P := Lens.id P.as
+  comp f g := Lens.comp g f
   id_comp _ := rfl
   comp_id _ := rfl
   assoc _ _ _ := rfl
 
--- Category instance using Chart as morphisms
-instance chartCategory : Category PFunctor.{uA, uB} where
-  Hom P Q := Chart P Q
-  id P := Chart.id P
-  comp f g := Chart.comp g f -- Note the order: g ∘ f for f ≫ g
+@[simp] theorem id_eq (P : LensCat.{uA, uB}) : 𝟙 P = Lens.id P.as := rfl
+
+@[simp] theorem comp_eq {P Q R : LensCat.{uA, uB}} (f : P ⟶ Q) (g : Q ⟶ R) :
+    f ≫ g = Lens.comp g f := rfl
+
+end LensCat
+
+/-! ## Charts -/
+
+-- Independent position and direction universes, as for `LensCat` above.
+set_option linter.checkUnivs false in
+/-- `PFunctor` regarded as the category whose morphisms are charts. -/
+def ChartCat : Type max (uA + 1) (uB + 1) := PFunctor.{uA, uB}
+
+namespace ChartCat
+
+/-- Regard a polynomial functor as an object of `ChartCat`. -/
+abbrev of (P : PFunctor.{uA, uB}) : ChartCat.{uA, uB} := P
+
+/-- Regard an object of `ChartCat` as a polynomial functor. -/
+abbrev as (P : ChartCat.{uA, uB}) : PFunctor.{uA, uB} := P
+
+instance instCategory : Category ChartCat.{uA, uB} where
+  Hom P Q := Chart P.as Q.as
+  id P := Chart.id P.as
+  comp f g := Chart.comp g f
   id_comp _ := rfl
   comp_id _ := rfl
   assoc _ _ _ := rfl
+
+@[simp] theorem id_eq (P : ChartCat.{uA, uB}) : 𝟙 P = Chart.id P.as := rfl
+
+@[simp] theorem comp_eq {P Q R : ChartCat.{uA, uB}} (f : P ⟶ Q) (g : Q ⟶ R) :
+    f ≫ g = Chart.comp g f := rfl
+
+end ChartCat
 
 end PFunctor

--- a/PolyFunTest/Interaction/Concurrent/Examples.lean
+++ b/PolyFunTest/Interaction/Concurrent/Examples.lean
@@ -459,13 +459,17 @@ example :
 
 example :
     Process.Ticketed.WeakFairOn loopTicketed trueRun true := by
-  intro _ N
+  intro _
+  rw [ProcessOver.Run.infinitelyOften_iff]
+  intro N
   refine ⟨N, Nat.le_refl _, ?_⟩
   simp [ProcessOver.Ticketed.firedAt, loopTicketed, trueRun]
 
 example :
     Process.Ticketed.StrongFairOn loopTicketed trueRun true := by
-  intro _ N
+  intro _
+  rw [ProcessOver.Run.infinitelyOften_iff]
+  intro N
   refine ⟨N, Nat.le_refl _, ?_⟩
   simp [ProcessOver.Ticketed.firedAt, loopTicketed, trueRun]
 


### PR DESCRIPTION
Three unrelated hygiene items from the upstream-alignment survey (#141). Independent of the other PRs — branches off `main`.

## 1. `PFunctor/Category.lean` had a genuine defect

It registered **two** `Category PFunctor.{uA, uB}` instances — `lensCategory` and `chartCategory` — on the *same* object type. A `Category` instance is keyed on its objects, so instance search picked one arbitrarily and `≫` / `𝟙` on `PFunctor` silently meant whichever won.

Fixed the way Mathlib handles exactly this (`Cat`, `RelCat`, `KleisliCat`, `PartialFun`): each structure gets its own carrier, `PFunctor.LensCat` (the category **Poly**) and `PFunctor.ChartCat`, with definitional `of` / `as` to move between a polynomial functor and its categorical avatar. Nothing imported this file and neither instance was used anywhere, so the fix is self-contained — but it's the one item in the sweep that was actually broken rather than merely duplicated.

## 2. Temporal operators are Mathlib's filter quantifiers

`EventuallyAlways` and `InfinitelyOften` (`Concurrent/Fairness.lean`) and `InfinitelyOftenState` (`Concurrent/Liveness.lean`) were hand-rolled as `∃ N, ∀ n, N ≤ n → P n` and `∀ N, ∃ n, N ≤ n ∧ P n`. Those are *definitionally* the right-hand sides of `Filter.eventually_atTop` and `Filter.frequently_atTop`, so they are now `∀ᶠ` and `∃ᶠ` at `Filter.atTop`.

Three hand-proved monotonicity lemmas and the eventually-implies-frequently lemma collapse to `Filter.Eventually.mono`, `Filter.Frequently.mono`, and `Filter.Eventually.frequently`, and the rest of the filter API becomes available to fairness and liveness arguments. cslib's `ωSequence` temporal layer uses the same encoding, so this also lines the two libraries up.

One consequence worth knowing: the `_iff` lemmas are now the interface for unfolding, since the definitions are no longer literally the quantifier nest. Two examples in `PolyFunTest/Interaction/Concurrent/Examples.lean` were destructuring the old definition directly and now `rw [infinitelyOften_iff]` first. That's the only downstream change.

## 3. `Control/Trace.lean`'s `mapHom` is `MonoidHom.compLeft`

`Trace ω X` is reducibly the Pi type `X → ω`, so bundling `map φ` as a monoid hom is exactly Mathlib's pointwise post-composition hom — which needs only `MulOneClass`, weakening the previous `Monoid` hypothesis.

## A correction to the memo

The survey listed `Logic/HEq.lean`, the two `find_home` sections, and `List.take_set_self` / `List.drop_set_self` under *adopt*. Checking them properly — `exact?` against full Mathlib — **none of them are subsumed upstream**. They are upstream *contribution* candidates, not reuse candidates, and are left untouched here. #141 is updated to say so.

## Validation

`./scripts/validate.sh --lint --test --axioms` passes: build, docs integrity, module scopes, import graph, environment linters, test library, axiom sweep at zero taint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
