### PR TITLE
feat(ipfunctor): add equivalence bridges

### DIFF
--- a/PolyFun/IPFunctor/Chart/Basic.lean
+++ b/PolyFun/IPFunctor/Chart/Basic.lean
@@ -46,6 +46,23 @@ structure Chart (P : IPFunctor.{uI, uJ, uA₁, uB₁} I J)
 
 namespace Chart
 
+/-- Two indexed charts are equal when their position maps agree pointwise and
+their response maps agree after transport along that position equality. -/
+@[ext (iff := false)]
+theorem ext {P : IPFunctor.{uI, uJ, uA₁, uB₁} I J}
+    {Q : IPFunctor.{uI, uJ, uA₂, uB₂} I J} (c₁ c₂ : Chart P Q)
+    (hA : ∀ j a, c₁.toFunA j a = c₂.toFunA j a)
+    (hB : ∀ j a, c₁.toFunB j a = (hA j a) ▸ c₂.toFunB j a) : c₁ = c₂ := by
+  rcases c₁ with ⟨toFunA₁, toFunB₁, src_eq₁⟩
+  rcases c₂ with ⟨toFunA₂, toFunB₂, src_eq₂⟩
+  have h : toFunA₁ = toFunA₂ := funext fun j => funext (hA j)
+  subst h
+  have h' : toFunB₁ = toFunB₂ := by
+    funext j a
+    simpa using hB j a
+  subst h'
+  rfl
+
 /-- The identity chart. -/
 protected def id (P : IPFunctor.{uI, uJ, uA, uB} I J) : Chart P P where
   toFunA _ := id

--- a/PolyFun/IPFunctor/Equiv/Basic.lean
+++ b/PolyFun/IPFunctor/Equiv/Basic.lean
@@ -97,32 +97,6 @@ def trans (e₁ : P ≃ₚ Q) (e₂ : Q ≃ₚ R) : P ≃ₚ R where
 
 /-! ## Lens and chart equivalences -/
 
-private theorem lens_ext (l₁ l₂ : Lens P Q)
-    (hA : ∀ j a, l₁.toFunA j a = l₂.toFunA j a)
-    (hB : ∀ j a, l₁.toFunB j a = (hA j a) ▸ l₂.toFunB j a) : l₁ = l₂ := by
-  rcases l₁ with ⟨toFunA₁, toFunB₁, src_eq₁⟩
-  rcases l₂ with ⟨toFunA₂, toFunB₂, src_eq₂⟩
-  have h : toFunA₁ = toFunA₂ := funext fun j => funext (hA j)
-  subst h
-  have h' : toFunB₁ = toFunB₂ := by
-    funext j a
-    simpa using hB j a
-  subst h'
-  rfl
-
-private theorem chart_ext (c₁ c₂ : Chart P Q)
-    (hA : ∀ j a, c₁.toFunA j a = c₂.toFunA j a)
-    (hB : ∀ j a, c₁.toFunB j a = (hA j a) ▸ c₂.toFunB j a) : c₁ = c₂ := by
-  rcases c₁ with ⟨toFunA₁, toFunB₁, src_eq₁⟩
-  rcases c₂ with ⟨toFunA₂, toFunB₂, src_eq₂⟩
-  have h : toFunA₁ = toFunA₂ := funext fun j => funext (hA j)
-  subst h
-  have h' : toFunB₁ = toFunB₂ := by
-    funext j a
-    simpa using hB j a
-  subst h'
-  rfl
-
 /-- The lens underlying a structural equivalence. Positions move forward through
 `equivA`, while responses pull back through the inverse of `equivB`. -/
 def toLens (e : P ≃ₚ Q) : Lens P Q where
@@ -198,7 +172,7 @@ is the identity indexed lens. -/
 @[simp]
 theorem symm_toLens_comp_toLens (e : P ≃ₚ Q) :
     Lens.comp e.symm.toLens e.toLens = Lens.id P := by
-  refine lens_ext _ _ (fun j a => by
+  refine Lens.ext _ _ (fun j a => by
     change (e.symm.equivA j) (e.equivA j a) = a
     exact (e.equivA j).symm_apply_apply a) ?_
   intro j a
@@ -215,7 +189,7 @@ equivalence is the identity indexed lens. -/
 @[simp]
 theorem toLens_comp_symm_toLens (e : P ≃ₚ Q) :
     Lens.comp e.toLens e.symm.toLens = Lens.id Q := by
-  refine lens_ext _ _ (fun j a => by
+  refine Lens.ext _ _ (fun j a => by
     change (e.equivA j) (e.symm.equivA j a) = a
     exact (e.equivA j).apply_symm_apply a) ?_
   intro j a
@@ -301,7 +275,7 @@ is the identity indexed chart. -/
 @[simp]
 theorem symm_toChart_comp_toChart (e : P ≃ₚ Q) :
     Chart.comp e.symm.toChart e.toChart = Chart.id P := by
-  refine chart_ext _ _ (fun j a => by
+  refine Chart.ext _ _ (fun j a => by
     change (e.symm.equivA j) (e.equivA j a) = a
     exact (e.equivA j).symm_apply_apply a) ?_
   intro j a
@@ -315,7 +289,7 @@ structural equivalence is the identity indexed chart. -/
 @[simp]
 theorem toChart_comp_symm_toChart (e : P ≃ₚ Q) :
     Chart.comp e.toChart e.symm.toChart = Chart.id Q := by
-  refine chart_ext _ _ (fun j a => by
+  refine Chart.ext _ _ (fun j a => by
     change (e.equivA j) (e.symm.equivA j a) = a
     exact (e.equivA j).apply_symm_apply a) ?_
   intro j a

--- a/PolyFun/IPFunctor/Equiv/Basic.lean
+++ b/PolyFun/IPFunctor/Equiv/Basic.lean
@@ -5,7 +5,8 @@ Authors: Devon Tuma
 -/
 module
 
-public import PolyFun.IPFunctor.Basic
+public import PolyFun.IPFunctor.Chart.Basic
+public import PolyFun.IPFunctor.Lens.Basic
 
 /-!
 # Structural Equivalences Between Indexed Polynomial Functors
@@ -17,6 +18,10 @@ law `src_eq`.
 
 This is the indexed analogue of [`PFunctor.Equiv`](../../PFunctor/Equiv/Basic.lean). Like the
 non-indexed version, it is strictly stronger than lens or chart equivalence.
+
+Every structural equivalence has canonical images in the indexed lens and chart
+categories, exposed by `IPFunctor.Equiv.toLensEquiv` and
+`IPFunctor.Equiv.toChartEquiv`.
 -/
 
 @[expose] public section
@@ -89,6 +94,251 @@ def trans (e₁ : P ≃ₚ Q) (e₂ : Q ≃ₚ R) : P ≃ₚ R where
   equivB j a := (e₁.equivB j a).trans (e₂.equivB j (e₁.equivA j a))
   src_eq j a b :=
     (e₁.src_eq j a b).trans (e₂.src_eq j (e₁.equivA j a) (e₁.equivB j a b))
+
+/-! ## Lens and chart equivalences -/
+
+private theorem lens_ext (l₁ l₂ : Lens P Q)
+    (hA : ∀ j a, l₁.toFunA j a = l₂.toFunA j a)
+    (hB : ∀ j a, l₁.toFunB j a = (hA j a) ▸ l₂.toFunB j a) : l₁ = l₂ := by
+  rcases l₁ with ⟨toFunA₁, toFunB₁, src_eq₁⟩
+  rcases l₂ with ⟨toFunA₂, toFunB₂, src_eq₂⟩
+  have h : toFunA₁ = toFunA₂ := funext fun j => funext (hA j)
+  subst h
+  have h' : toFunB₁ = toFunB₂ := by
+    funext j a
+    simpa using hB j a
+  subst h'
+  rfl
+
+private theorem chart_ext (c₁ c₂ : Chart P Q)
+    (hA : ∀ j a, c₁.toFunA j a = c₂.toFunA j a)
+    (hB : ∀ j a, c₁.toFunB j a = (hA j a) ▸ c₂.toFunB j a) : c₁ = c₂ := by
+  rcases c₁ with ⟨toFunA₁, toFunB₁, src_eq₁⟩
+  rcases c₂ with ⟨toFunA₂, toFunB₂, src_eq₂⟩
+  have h : toFunA₁ = toFunA₂ := funext fun j => funext (hA j)
+  subst h
+  have h' : toFunB₁ = toFunB₂ := by
+    funext j a
+    simpa using hB j a
+  subst h'
+  rfl
+
+/-- The lens underlying a structural equivalence. Positions move forward through
+`equivA`, while responses pull back through the inverse of `equivB`. -/
+def toLens (e : P ≃ₚ Q) : Lens P Q where
+  toFunA j := e.equivA j
+  toFunB j a := (e.equivB j a).symm
+  src_eq j a d := by
+    simpa only [_root_.Equiv.apply_symm_apply] using
+      e.src_eq j a ((e.equivB j a).symm d)
+
+@[simp]
+theorem toLens_toFunA (e : P ≃ₚ Q) (j : J) (a : P.A j) :
+    e.toLens.toFunA j a = e.equivA j a := rfl
+
+@[simp]
+theorem toLens_toFunB (e : P ≃ₚ Q) (j : J) (a : P.A j)
+    (d : Q.B j (e.equivA j a)) :
+    e.toLens.toFunB j a d = (e.equivB j a).symm d := rfl
+
+@[simp]
+theorem toLens_refl (P : IPFunctor.{uI, uJ, uA₁, uB₁} I J) :
+    (refl P).toLens = Lens.id P := rfl
+
+@[simp]
+theorem toLens_trans (e₁ : P ≃ₚ Q) (e₂ : Q ≃ₚ R) :
+    (e₁.trans e₂).toLens = Lens.comp e₂.toLens e₁.toLens := rfl
+
+private theorem equivB_symm_apply_of_eq (e : P ≃ₚ Q) (j : J)
+    {a a' : P.A j} (ha : e.equivA j a = e.equivA j a') (b : P.B j a') :
+    (e.equivB j a).symm
+        ((_root_.Equiv.cast (congrArg (Q.B j) ha)).symm ((e.equivB j a') b)) =
+      _root_.cast (congrArg (P.B j) ((e.equivA j).injective ha).symm) b := by
+  have ha' : a = a' := (e.equivA j).injective ha
+  cases ha'
+  simp
+
+private theorem equivB_symm_apply (e : P ≃ₚ Q) (j : J) (a : P.A j)
+    (b : P.B j ((e.equivA j).symm (e.equivA j a))) :
+    (e.equivB j a).symm ((e.symm.equivB j (e.equivA j a)).symm b) =
+      _root_.cast (congrArg (P.B j) ((e.equivA j).symm_apply_apply a)) b := by
+  have hEqA :
+      e.equivA j a = e.equivA j ((e.equivA j).symm (e.equivA j a)) := by
+    simp
+  simp only [IPFunctor.Equiv.symm]
+  exact equivB_symm_apply_of_eq (e := e) (j := j)
+    (a := a) (a' := (e.equivA j).symm (e.equivA j a))
+    (ha := hEqA) (b := b)
+
+private theorem symm_equivB_symm_apply (e : P ≃ₚ Q) (j : J) (a : Q.A j)
+    (b : Q.B j (e.equivA j ((e.equivA j).symm a))) :
+    (e.symm.equivB j a).symm ((e.equivB j ((e.equivA j).symm a)).symm b) =
+      _root_.cast (congrArg (Q.B j) ((e.equivA j).apply_symm_apply a)) b := by
+  change
+    ((_root_.Equiv.cast
+      (congrArg (Q.B j) ((_root_.Equiv.symm_apply_eq (e.equivA j)).mp rfl))).symm
+      ((e.equivB j ((e.equivA j).symm a))
+        ((e.equivB j ((e.equivA j).symm a)).symm b))) = _
+  rw [_root_.Equiv.apply_symm_apply (e.equivB j ((e.equivA j).symm a)) b]
+  change
+    _root_.cast
+        (congrArg (Q.B j) ((_root_.Equiv.symm_apply_eq (e.equivA j)).mp rfl)).symm b =
+      _root_.cast (congrArg (Q.B j) ((e.equivA j).apply_symm_apply a)) b
+  simp
+
+private theorem eqRec_id_apply {A : Sort*} {B : A → Sort*}
+    {a₁ a₀ : A} (h : a₁ = a₀) (x : B a₀) :
+    Eq.rec (motive := fun a _ => B a → B a₁) id h x =
+      _root_.cast (congrArg B h).symm x := by
+  cases h
+  rfl
+
+/-- Pulling responses back through a structural equivalence and its inverse
+is the identity indexed lens. -/
+@[simp]
+theorem symm_toLens_comp_toLens (e : P ≃ₚ Q) :
+    Lens.comp e.symm.toLens e.toLens = Lens.id P := by
+  refine lens_ext _ _ (fun j a => by
+    change (e.symm.equivA j) (e.equivA j a) = a
+    exact (e.equivA j).symm_apply_apply a) ?_
+  intro j a
+  funext b
+  simp only [Lens.comp, Lens.id, toLens, Function.comp_apply, id_eq]
+  have hb := equivB_symm_apply (e := e) (j := j) (a := a) (b := b)
+  have h₀ : a = (e.equivA j).symm (e.equivA j a) :=
+    ((e.equivA j).symm_apply_apply a).symm
+  have hr := eqRec_id_apply (B := P.B j) (h := h₀) (x := b)
+  exact hb.trans hr.symm
+
+/-- Pulling responses back through the inverse and then the original structural
+equivalence is the identity indexed lens. -/
+@[simp]
+theorem toLens_comp_symm_toLens (e : P ≃ₚ Q) :
+    Lens.comp e.toLens e.symm.toLens = Lens.id Q := by
+  refine lens_ext _ _ (fun j a => by
+    change (e.equivA j) (e.symm.equivA j a) = a
+    exact (e.equivA j).apply_symm_apply a) ?_
+  intro j a
+  funext b
+  simp only [Lens.comp, Lens.id, toLens, Function.comp_apply, id_eq]
+  have hb := symm_equivB_symm_apply (e := e) (j := j) (a := a) (b := b)
+  have h₀ : a = e.equivA j ((e.equivA j).symm a) :=
+    ((_root_.Equiv.symm_apply_eq (e.equivA j)).mp rfl)
+  have hr := eqRec_id_apply (B := Q.B j) (h := h₀) (x := b)
+  exact hb.trans hr.symm
+
+/-- Convert a structural equivalence to an isomorphism in the indexed lens
+category. -/
+def toLensEquiv (e : P ≃ₚ Q) : Lens.Equiv P Q where
+  toLens := e.toLens
+  invLens := e.symm.toLens
+  left_inv := symm_toLens_comp_toLens e
+  right_inv := toLens_comp_symm_toLens e
+
+@[simp]
+theorem toLensEquiv_toLens (e : P ≃ₚ Q) : e.toLensEquiv.toLens = e.toLens := rfl
+
+@[simp]
+theorem toLensEquiv_invLens (e : P ≃ₚ Q) : e.toLensEquiv.invLens = e.symm.toLens := rfl
+
+/-- The chart underlying a structural equivalence. Both positions and
+responses move forward through their fiberwise equivalences. -/
+def toChart (e : P ≃ₚ Q) : Chart P Q where
+  toFunA j := e.equivA j
+  toFunB j a := e.equivB j a
+  src_eq j a b := (e.src_eq j a b).symm
+
+@[simp]
+theorem toChart_toFunA (e : P ≃ₚ Q) (j : J) (a : P.A j) :
+    e.toChart.toFunA j a = e.equivA j a := rfl
+
+@[simp]
+theorem toChart_toFunB (e : P ≃ₚ Q) (j : J) (a : P.A j) (b : P.B j a) :
+    e.toChart.toFunB j a b = e.equivB j a b := rfl
+
+@[simp]
+theorem toChart_refl (P : IPFunctor.{uI, uJ, uA₁, uB₁} I J) :
+    (refl P).toChart = Chart.id P := rfl
+
+@[simp]
+theorem toChart_trans (e₁ : P ≃ₚ Q) (e₂ : Q ≃ₚ R) :
+    (e₁.trans e₂).toChart = Chart.comp e₂.toChart e₁.toChart := rfl
+
+private theorem forward_equivB_roundtrip (e : P ≃ₚ Q) (j : J) (a : P.A j)
+    (b : P.B j a) :
+    e.symm.equivB j (e.equivA j a) (e.equivB j a b) =
+      _root_.cast
+        (congrArg (P.B j) ((e.equivA j).symm_apply_apply a).symm) b := by
+  change
+    (((_root_.Equiv.cast _).trans
+      (e.equivB j ((e.equivA j).symm (e.equivA j a))).symm) (e.equivB j a b)) = _
+  simp only [_root_.Equiv.trans_apply]
+  exact equivB_symm_apply_of_eq e j
+    (a := (e.equivA j).symm (e.equivA j a)) (a' := a)
+    (ha := (e.equivA j).apply_symm_apply _) (b := b)
+
+private theorem reverse_equivB_roundtrip (e : P ≃ₚ Q) (j : J) (a : Q.A j)
+    (b : Q.B j a) :
+    e.equivB j ((e.equivA j).symm a) (e.symm.equivB j a b) =
+      _root_.cast
+        (congrArg (Q.B j) ((e.equivA j).apply_symm_apply a).symm) b := by
+  change
+    (e.equivB j ((e.equivA j).symm a))
+      (((_root_.Equiv.cast _).trans
+        (e.equivB j ((e.equivA j).symm a)).symm) b) = _
+  simp [_root_.Equiv.trans_apply]
+
+private theorem eqRec_id_apply_codomain
+    {A : Sort*} {B : A → Sort*} {a₀ a₁ : A}
+    (h : a₀ = a₁) (x : B a₀) :
+    Eq.rec (motive := fun a _ => B a₀ → B a) id h x =
+      _root_.cast (congrArg B h) x := by
+  subst h
+  rfl
+
+/-- Pushing responses forward through a structural equivalence and its inverse
+is the identity indexed chart. -/
+@[simp]
+theorem symm_toChart_comp_toChart (e : P ≃ₚ Q) :
+    Chart.comp e.symm.toChart e.toChart = Chart.id P := by
+  refine chart_ext _ _ (fun j a => by
+    change (e.symm.equivA j) (e.equivA j a) = a
+    exact (e.equivA j).symm_apply_apply a) ?_
+  intro j a
+  funext b
+  simp only [Chart.comp, Chart.id, toChart, Function.comp_apply]
+  rw [forward_equivB_roundtrip]
+  exact (eqRec_id_apply_codomain ((e.equivA j).symm_apply_apply a).symm b).symm
+
+/-- Pushing responses forward through the inverse and then the original
+structural equivalence is the identity indexed chart. -/
+@[simp]
+theorem toChart_comp_symm_toChart (e : P ≃ₚ Q) :
+    Chart.comp e.toChart e.symm.toChart = Chart.id Q := by
+  refine chart_ext _ _ (fun j a => by
+    change (e.equivA j) (e.symm.equivA j a) = a
+    exact (e.equivA j).apply_symm_apply a) ?_
+  intro j a
+  funext b
+  simp only [Chart.comp, Chart.id, toChart, Function.comp_apply]
+  change e.equivB j ((e.equivA j).symm a) (e.symm.equivB j a b) = _
+  rw [reverse_equivB_roundtrip]
+  exact (eqRec_id_apply_codomain ((e.equivA j).apply_symm_apply a).symm b).symm
+
+/-- Convert a structural equivalence to an isomorphism in the indexed chart
+category. -/
+def toChartEquiv (e : P ≃ₚ Q) : Chart.Equiv P Q where
+  toChart := e.toChart
+  invChart := e.symm.toChart
+  left_inv := symm_toChart_comp_toChart e
+  right_inv := toChart_comp_symm_toChart e
+
+@[simp]
+theorem toChartEquiv_toChart (e : P ≃ₚ Q) : e.toChartEquiv.toChart = e.toChart := rfl
+
+@[simp]
+theorem toChartEquiv_invChart (e : P ≃ₚ Q) :
+    e.toChartEquiv.invChart = e.symm.toChart := rfl
 
 end Equiv
 

--- a/PolyFun/IPFunctor/Lens/Basic.lean
+++ b/PolyFun/IPFunctor/Lens/Basic.lean
@@ -46,6 +46,23 @@ structure Lens (P : IPFunctor.{uI, uJ, uA₁, uB₁} I J) (Q : IPFunctor.{uI, uJ
 
 namespace Lens
 
+/-- Two indexed lenses are equal when their position maps agree pointwise and
+their response maps agree after transport along that position equality. -/
+@[ext (iff := false)]
+theorem ext {P : IPFunctor.{uI, uJ, uA₁, uB₁} I J}
+    {Q : IPFunctor.{uI, uJ, uA₂, uB₂} I J} (l₁ l₂ : Lens P Q)
+    (hA : ∀ j a, l₁.toFunA j a = l₂.toFunA j a)
+    (hB : ∀ j a, l₁.toFunB j a = (hA j a) ▸ l₂.toFunB j a) : l₁ = l₂ := by
+  rcases l₁ with ⟨toFunA₁, toFunB₁, src_eq₁⟩
+  rcases l₂ with ⟨toFunA₂, toFunB₂, src_eq₂⟩
+  have h : toFunA₁ = toFunA₂ := funext fun j => funext (hA j)
+  subst h
+  have h' : toFunB₁ = toFunB₂ := by
+    funext j a
+    simpa using hB j a
+  subst h'
+  rfl
+
 /-- The identity lens. -/
 protected def id (P : IPFunctor.{uI, uJ, uA, uB} I J) : Lens P P where
   toFunA _ := id

--- a/PolyFunTest/IPFunctor/EquivTests.lean
+++ b/PolyFunTest/IPFunctor/EquivTests.lean
@@ -1,0 +1,166 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+module
+
+public import PolyFun.IPFunctor.Equiv.Basic
+
+/-!
+# Regression Tests for Indexed Polynomial Equivalence Bridges
+
+These producer canaries exercise the canonical conversions from
+`IPFunctor.Equiv` to indexed lens and chart equivalences. The concrete fixture
+uses a non-involutive three-cycle on both positions and responses, and its
+source index depends on whether those values agree. This distinguishes forward
+and inverse maps as well as lens pullback from chart pushforward.
+-/
+
+@[expose] public section
+
+universe uI uJ uA₁ uA₂ uB₁ uB₂
+
+namespace IPFunctorEquivTests
+
+inductive Three where
+  | zero
+  | one
+  | two
+deriving DecidableEq
+
+def cycle : Three → Three
+  | .zero => .one
+  | .one => .two
+  | .two => .zero
+
+def uncycle : Three → Three
+  | .zero => .two
+  | .one => .zero
+  | .two => .one
+
+def cycleEquiv : Three ≃ Three where
+  toFun := cycle
+  invFun := uncycle
+  left_inv x := by cases x <;> rfl
+  right_inv x := by cases x <;> rfl
+
+/-- Source polynomial for the concrete bridge canaries. Its child index is
+`true` exactly when the position and response select the same branch. -/
+def P : IPFunctor Bool Unit where
+  A _ := Three
+  B _ _ := Three
+  src _ a b := decide (a = b)
+
+/-- Target polynomial for the concrete bridge canaries. It has a separate
+declaration so the tests exercise an actual cross-polynomial conversion. -/
+def Q : IPFunctor Bool Unit where
+  A _ := Three
+  B _ _ := Three
+  src _ a b := decide (a = b)
+
+/-- A nonidentity structural equivalence preserving the response-dependent
+source index by cycling positions and responses together. -/
+def equiv : IPFunctor.Equiv P Q where
+  equivA _ := cycleEquiv
+  equivB _ _ := cycleEquiv
+  src_eq _ a b := by cases a <;> cases b <;> rfl
+
+/-! ## Lens conversion -/
+
+example : equiv.toLensEquiv.toLens.toFunA () Three.zero = Three.one := rfl
+
+-- Lens responses pull back, so the forward lens applies the inverse cycle.
+example :
+    equiv.toLensEquiv.toLens.toFunB () Three.zero Three.two = Three.one := rfl
+
+example : equiv.toLensEquiv.invLens.toFunA () Three.zero = Three.two := rfl
+
+-- The inverse lens pulls back through the inverse equivalence, hence cycles.
+example :
+    equiv.toLensEquiv.invLens.toFunB () Three.zero Three.zero = Three.one := rfl
+
+-- The converted `src_eq` observes the response-dependent child index.
+example :
+    P.src () Three.zero
+        (equiv.toLensEquiv.toLens.toFunB () Three.zero Three.two) =
+      Q.src () (equiv.toLensEquiv.toLens.toFunA () Three.zero) Three.two :=
+  equiv.toLensEquiv.toLens.src_eq () Three.zero Three.two
+
+example :
+    P.src () Three.zero
+      (equiv.toLensEquiv.toLens.toFunB () Three.zero Three.two) = false := rfl
+
+example :
+    P.src () Three.zero
+      (equiv.toLensEquiv.toLens.toFunB () Three.zero Three.one) = true := rfl
+
+example : IPFunctor.Lens.comp equiv.symm.toLens equiv.toLens = IPFunctor.Lens.id P := by simp
+
+example : IPFunctor.Lens.comp equiv.toLens equiv.symm.toLens = IPFunctor.Lens.id Q := by simp
+
+example : (IPFunctor.Equiv.refl P).toLens = IPFunctor.Lens.id P := by simp
+
+example :
+    (equiv.trans equiv.symm).toLens = IPFunctor.Lens.comp equiv.symm.toLens equiv.toLens :=
+  IPFunctor.Equiv.toLens_trans equiv equiv.symm
+
+/-! ## Chart conversion -/
+
+example : equiv.toChartEquiv.toChart.toFunA () Three.zero = Three.one := rfl
+
+-- Chart responses move forward through the same nontrivial cycle as positions.
+example :
+    equiv.toChartEquiv.toChart.toFunB () Three.zero Three.zero = Three.one := rfl
+
+example : equiv.toChartEquiv.invChart.toFunA () Three.zero = Three.two := rfl
+
+example :
+    equiv.toChartEquiv.invChart.toFunB () Three.zero Three.zero = Three.two := rfl
+
+-- The chart conversion preserves the same dependent source behavior covariantly.
+example :
+    Q.src () (equiv.toChartEquiv.toChart.toFunA () Three.zero)
+        (equiv.toChartEquiv.toChart.toFunB () Three.zero Three.two) =
+      P.src () Three.zero Three.two :=
+  equiv.toChartEquiv.toChart.src_eq () Three.zero Three.two
+
+example : Q.src () (equiv.toChartEquiv.toChart.toFunA () Three.zero)
+    (equiv.toChartEquiv.toChart.toFunB () Three.zero Three.two) = false := rfl
+
+example : Q.src () (equiv.toChartEquiv.toChart.toFunA () Three.zero)
+    (equiv.toChartEquiv.toChart.toFunB () Three.zero Three.zero) = true := rfl
+
+example : IPFunctor.Chart.comp equiv.symm.toChart equiv.toChart = IPFunctor.Chart.id P := by simp
+
+example : IPFunctor.Chart.comp equiv.toChart equiv.symm.toChart = IPFunctor.Chart.id Q := by simp
+
+example : (IPFunctor.Equiv.refl P).toChart = IPFunctor.Chart.id P := by simp
+
+example :
+    (equiv.trans equiv.symm).toChart = IPFunctor.Chart.comp equiv.symm.toChart equiv.toChart :=
+  IPFunctor.Equiv.toChart_trans equiv equiv.symm
+
+/-! ## Independent universes -/
+
+section MixedUniverses
+
+variable {I : Type uI} {J : Type uJ}
+  {P₁ : IPFunctor.{uI, uJ, uA₁, uB₁} I J}
+  {Q₁ : IPFunctor.{uI, uJ, uA₂, uB₂} I J}
+
+example (e : IPFunctor.Equiv P₁ Q₁) : IPFunctor.Lens.Equiv P₁ Q₁ := e.toLensEquiv
+
+example (e : IPFunctor.Equiv P₁ Q₁) : IPFunctor.Chart.Equiv P₁ Q₁ := e.toChartEquiv
+
+example (e : IPFunctor.Equiv P₁ Q₁) :
+    IPFunctor.Lens.comp e.symm.toLens e.toLens = IPFunctor.Lens.id P₁ := by
+  simp
+
+example (e : IPFunctor.Equiv P₁ Q₁) :
+    IPFunctor.Chart.comp e.symm.toChart e.toChart = IPFunctor.Chart.id P₁ := by
+  simp
+
+end MixedUniverses
+
+end IPFunctorEquivTests

--- a/docs/wiki/ipfunctor.md
+++ b/docs/wiki/ipfunctor.md
@@ -190,9 +190,10 @@ equality of *index values*, not of types — so most concrete morphisms discharg
 it by `rfl`. Object maps along a lens / chart, however, may need to transport
 children through `src_eq` because they live in fibers over `src ...`.
 
-Only the core structure (identity, composition, `Equiv`) is provided today;
-the monoidal / distributive layer mirrored from `PFunctor.Lens` is a future
-addition.
+Structural equivalences convert canonically to both `Lens.Equiv` and
+`Chart.Equiv`, including identity, composition, inverse, and round-trip laws.
+The monoidal / distributive layer mirrored from `PFunctor.Lens` remains a
+future addition.
 
 ## Composition
 


### PR DESCRIPTION
## Summary

This PR adds the canonical bridges from `IPFunctor.Equiv` to indexed lens and chart equivalences.

It now provides:

- `toLens` / `toLensEquiv` and `toChart` / `toChartEquiv`;
- projection, identity, composition, inverse, and round-trip simp laws;
- public owner-layer `IPFunctor.Lens.ext` and `IPFunctor.Chart.ext` principles for dependent morphism equality;
- focused dependent, mixed-universe regression tests and updated indexed-functor documentation.

### Diff metadata

- Base: `fe2a140744eaa9e52144f785eae182ed1357fb68` (`main`)
- Head: `17798812dc1e9d332906392e72dbd8e5ed805eb0`
- Commits: 5
- Files changed: 5
- Diff: 429 insertions, 4 deletions

## Motivation

`IPFunctor.Equiv` is stronger than both indexed lens and chart equivalence, but the indexed API did not expose the corresponding conversions. Downstream users therefore could not reuse a structural equivalence through the categorical interfaces, and generic dependent extensionality was missing from the `Lens` and `Chart` owner modules.

## Change surface

| Area | Before | After |
|---|---|---|
| Lens bridge | No indexed conversion | `toLens`, `toLensEquiv`, projections and laws |
| Chart bridge | No indexed conversion | `toChart`, `toChartEquiv`, projections and laws |
| Equality API | Consumer-local proof machinery | Public dependent `Lens.ext` and `Chart.ext` |
| Tests | No focused bridge coverage | Non-involutive, source-sensitive, mixed-universe canaries |

Lens responses pull back through `equivB.symm`; chart responses push forward through `equivB`. Both packaged equivalences use `e.symm` for their inverse morphisms and prove both dependent round trips. The public extensionality laws transport response maps along pointwise position equality and are consumed by the bridge proofs.

## Compatibility and scope

This is an additive public API change. Existing declarations are unchanged. The indexed monoidal/distributive morphism layer remains intentionally deferred.

## Validation completed at `1779881`

- targeted builds for indexed Lens, Chart, Equiv, and the regression module;
- `./scripts/validate.sh --lint --test --axioms` on the exact head;
- full warning-as-error build, generated-import and docs checks, environment lint, and all tests;
- axiom sweep: 8,938 declarations across 243 modules, with zero `sorryAx` and zero non-standard-axiom taint;
- separate text-style lint and diff/prohibited-token hygiene checks;
- independent Lean review: no remaining findings, exact-head approval.

## Reviewer map

1. `PolyFun/IPFunctor/Lens/Basic.lean` and `Chart/Basic.lean` — owner-layer extensionality.
2. `PolyFun/IPFunctor/Equiv/Basic.lean` — bridge definitions and dependent round trips.
3. `PolyFunTest/IPFunctor/EquivTests.lean` — branch, variance, source, inverse, and universe canaries.
4. `docs/wiki/ipfunctor.md` — public capability update.

Closes #117
