### PR TITLE
fix: preserve deprecated tensor simps lemmas

### DIFF
--- a/PolyFun/PFunctor/Equiv/Basic.lean
+++ b/PolyFun/PFunctor/Equiv/Basic.lean
@@ -481,6 +481,10 @@ def yTensor : y ⊗ P ≃ₚ P where
 
 @[deprecated (since := "2026-08-17")] alias tensorX := tensorY
 @[deprecated (since := "2026-08-17")] alias xTensor := yTensor
+@[deprecated (since := "2026-08-17")] alias tensorX_equivA := tensorY_equivA
+@[deprecated (since := "2026-08-17")] alias tensorX_equivB := tensorY_equivB
+@[deprecated (since := "2026-08-17")] alias xTensor_equivA := yTensor_equivA
+@[deprecated (since := "2026-08-17")] alias xTensor_equivB := yTensor_equivB
 
 /-- Tensor product of polynomial functors is commutative up to equivalence -/
 @[simps]

--- a/PolyFunTest/PFunctor/Equiv/DeprecatedCompatibility.lean
+++ b/PolyFunTest/PFunctor/Equiv/DeprecatedCompatibility.lean
@@ -1,0 +1,44 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+module
+
+public import PolyFun.PFunctor.Equiv.Basic
+
+/-!
+# Direct-import compatibility for the former `X` equivalence API
+
+These canaries import only `PFunctor.Equiv.Basic`. They ensure downstream files
+using the `@[simps]` lemmas generated for the former `tensorX` and `xTensor`
+names keep elaborating without relying on an aggregate import.
+-/
+
+@[expose] public section
+
+open scoped PFunctor
+
+namespace PFunctor.Equiv
+
+set_option linter.deprecated false in
+example (P : PFunctor.{0, 0}) :
+    (tensorX.{0, 0, 0, 0} P).equivA = _root_.Equiv.prodPUnit P.A :=
+  tensorX_equivA.{0, 0, 0, 0} P
+
+set_option linter.deprecated false in
+example (P : PFunctor.{0, 0}) (a : (P ⊗ X).A) :
+    (tensorX.{0, 0, 0, 0} P).equivB a = _root_.Equiv.prodPUnit (P.B a.1) :=
+  tensorX_equivB.{0, 0, 0, 0} P a
+
+set_option linter.deprecated false in
+example (P : PFunctor.{0, 0}) :
+    (xTensor.{0, 0, 0, 0} P).equivA = _root_.Equiv.punitProd P.A :=
+  xTensor_equivA.{0, 0, 0, 0} P
+
+set_option linter.deprecated false in
+example (P : PFunctor.{0, 0}) (a : (X ⊗ P).A) :
+    (xTensor.{0, 0, 0, 0} P).equivB a = _root_.Equiv.punitProd (P.B a.2) :=
+  xTensor_equivB.{0, 0, 0, 0} P a
+
+end PFunctor.Equiv


### PR DESCRIPTION
## Summary

- restore deprecated aliases for the four public simps lemmas generated by the former tensorX and xTensor definitions
- add direct-import compatibility canaries covering all four names against the deprecated expressions
- preserve the y-based API as canonical

## Regression

PR #132 aliased tensorX and xTensor after renaming their definitions, but aliases do not recreate the separately generated tensorX_equivA, tensorX_equivB, xTensor_equivA, and xTensor_equivB declarations. Downstream source using those public theorem names stopped elaborating.

## Validation

- lake build PolyFunTest --wfail (1,322 jobs)
- ./scripts/validate.sh --lint --axioms (library build, module/import/docs checks, environment lint, fixture matrix, zero-taint sweep across 9,013 declarations / 244 modules)
- lake exe lint-style

No mathematical statement or executable behavior changes; this restores only the deprecated source-compatibility surface.