### PR TITLE
docs: harden documentation review guardrails

### DIFF
--- a/.github/workflows/docs-integrity.yml
+++ b/.github/workflows/docs-integrity.yml
@@ -18,5 +18,7 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.12"
+      - name: Test docs integrity checker
+        run: python3 ./scripts/test-docs-integrity.py
       - name: Check docs integrity
         run: python3 ./scripts/check-docs-integrity.py

--- a/PolyFun/Control/Lawful/Basic.lean
+++ b/PolyFun/Control/Lawful/Basic.lean
@@ -8,8 +8,8 @@ module
 /-!
 # Monad laws restated via `do` notation
 
-Lean 4.29 changed `do`-notation elaboration so that the desugared bind may use a `Bind`
-instance that differs syntactically from `Monad.toBind`. This prevents the standard
+Lean's `do`-notation elaboration may choose a `Bind` instance that differs syntactically
+from `Monad.toBind`. This prevents the standard
 `pure_bind`, `bind_assoc`, and `bind_pure` lemmas from matching `do`-block goals via
 `simp` or `rw`.
 

--- a/PolyFun/Control/Monad/Iter.lean
+++ b/PolyFun/Control/Monad/Iter.lean
@@ -36,7 +36,7 @@ flip the convention; we stick with `inl = continue`, `inr = stop`.)
 
 ## Implementation notes
 
-Lean 4.32 provides the function
+Lean provides the function
 `whileM : (β → m (β ⊕ α)) → β → m α`, with the same branch
 convention as `iterM`, but not a typeclass or a corresponding lawful interface.
 Core `whileM` is implemented by partial recursion and requires `Nonempty α`.

--- a/PolyFun/IPFunctor/Notation.lean
+++ b/PolyFun/IPFunctor/Notation.lean
@@ -22,15 +22,15 @@ IPFunctor.FreeM.bind :
 
 The continuation must accept the per-leaf post-state `s'`, so a standard
 `Bind (IPFunctor.FreeM P s)` instance cannot express it. This file plugs
-into the Lean 4.29 extensible do-elaborator (`@[doElem_elab …]`) to make
+into Lean's extensible do-elaborator (`@[doElem_elab …]`) to make
 ordinary `do { let x ← e; … }` blocks elaborate to the right
 `IPFunctor.FreeM.bind`-tree, threading a fresh post-state through each step.
 
 ## Activating the new elaborator
 
-Lean 4.29 ships *two* `do` elaborators: the legacy one (active by default)
-and a new extensible one. Our overrides plug into the new one, so users
-must opt in by setting
+The pinned Lean toolchain ships *two* `do` elaborators: the legacy one
+(active by default) and a new extensible one. Our overrides plug into the new
+one, so users must opt in by setting
 
 ```
 set_option backward.do.legacy false

--- a/PolyFun/IPFunctor/Notation.lean
+++ b/PolyFun/IPFunctor/Notation.lean
@@ -26,34 +26,16 @@ into Lean's extensible do-elaborator (`@[doElem_elab …]`) to make
 ordinary `do { let x ← e; … }` blocks elaborate to the right
 `IPFunctor.FreeM.bind`-tree, threading a fresh post-state through each step.
 
-## Activating the new elaborator
+## Elaborator selection
 
-The pinned Lean toolchain ships *two* `do` elaborators: the legacy one
-(active by default) and a new extensible one. Our overrides plug into the new
-one, so users must opt in by setting
-
-```
-set_option backward.do.legacy false
-```
-
-at the top of any file that wants `do`-notation for `IPFunctor.FreeM`.
-To opt in *project-wide*, add the option to your `lakefile.toml`:
-
-```toml
-[leanOptions]
-backward.do.legacy = false
-```
+The pinned Lean toolchain ships both legacy and extensible `do` elaborators.
+The extensible elaborator is the default (`backward.do.legacy` is `false`), so
+no option is needed to use this module. Setting `backward.do.legacy true`
+selects the legacy elaborator, where these overrides are unavailable.
 
 Other monads in the same file continue to work — our elaborators check
 the expected type and `throwUnsupportedSyntax` for non-`IPFunctor.FreeM`
 monads, falling back to the builtin.
-
-**Roadmap.** `backward.do.legacy` is a transitional flag (note the
-`backward.` prefix). When upstream Lean flips the default to `false`
-and eventually retires the option, the `set_option` lines in the test
-sections of these files come out and the docstrings are updated. A
-`grep -rn 'backward.do.legacy' PolyFun/` finds every site that needs
-touching.
 
 ## Supported subset
 

--- a/PolyFun/IPFunctor/Notation/Deterministic.lean
+++ b/PolyFun/IPFunctor/Notation/Deterministic.lean
@@ -5,18 +5,18 @@ Authors: Devon Tuma
 -/
 module
 
--- `Notation` defines the generic single-index `FreeM` overrides; importing
--- it transitively here forces our deterministic-`FreeM` override to be
--- registered *after*, so the keyed-attribute lookup tries it first. Without
--- this, downstream `import` order would silently determine which override
--- fires for `FreeM`-shaped `do`-blocks. See `Notation/Mixed.lean` for the
--- regression test.
 public import PolyFun.IPFunctor.Notation
 public import Lean.Elab.Do
 meta import Lean.Parser.Do
 
 /-!
 # `do`-notation for `IPFunctor.FreeM` with deterministic transitions
+
+Importing `PolyFun.IPFunctor.Notation` transitively here registers the generic
+single-index overrides before the deterministic ones. The keyed-attribute
+lookup therefore tries the deterministic override first, independently of
+downstream import order. `PolyFunTest/IPFunctor/Notation/Mixed.lean` pins this
+priority contract.
 
 The single-index `do`-notation in
 [`PolyFun/IPFunctor/Notation.lean`](../Notation.lean) restricts the
@@ -42,11 +42,8 @@ than the generic state-polymorphic one.
 
 ## Activation
 
-Users must
-* set `set_option backward.do.legacy false` (or, project-wide, via
-  `[leanOptions]` in `lakefile.toml` — see
-  [`../Notation.lean`](../Notation.lean) for the roadmap on this
-  transitional flag), and
+The extensible `do` elaborator is already the pinned toolchain's default. Users
+must
 * provide an `IPFunctor.DeterministicTransitions P` instance, and
 * express each monadic step using `IPFunctor.FreeM.lift` directly (or a
   `@[reducible]` alias). Steps that don't reduce to

--- a/PolyFun/IPFunctor/Notation/Indexed.lean
+++ b/PolyFun/IPFunctor/Notation/Indexed.lean
@@ -18,7 +18,7 @@ post-state statically. Its bind has signature
 chains compose naturally under ordinary `do`-notation.
 
 Like the single-index variant in `PolyFun/IPFunctor/Notation.lean`, this
-file plugs into the Lean 4.29 extensible do-elaborator. Users opt in by
+file plugs into Lean's extensible do-elaborator. Users opt in by
 setting `set_option backward.do.legacy false` (or, project-wide, via
 `[leanOptions]` in `lakefile.toml` — see
 [`../Notation.lean`](../Notation.lean) for the roadmap on this

--- a/PolyFun/IPFunctor/Notation/Indexed.lean
+++ b/PolyFun/IPFunctor/Notation/Indexed.lean
@@ -18,12 +18,9 @@ post-state statically. Its bind has signature
 chains compose naturally under ordinary `do`-notation.
 
 Like the single-index variant in `PolyFun/IPFunctor/Notation.lean`, this
-file plugs into Lean's extensible do-elaborator. Users opt in by
-setting `set_option backward.do.legacy false` (or, project-wide, via
-`[leanOptions]` in `lakefile.toml` — see
-[`../Notation.lean`](../Notation.lean) for the roadmap on this
-transitional flag). Our overrides check the expected type and fall
-through (`throwUnsupportedSyntax`) for any monad other than
+file plugs into Lean's extensible do-elaborator, which is the default in the
+pinned toolchain. No option is required. Our overrides check the expected type
+and fall through (`throwUnsupportedSyntax`) for any monad other than
 `IPFunctor.FreeM₂ P s t`.
 
 ## Why three flavors of `IPFunctor` `do`-notation?

--- a/PolyFunTest/IPFunctor/DeterministicNotationTests.lean
+++ b/PolyFunTest/IPFunctor/DeterministicNotationTests.lean
@@ -19,8 +19,6 @@ corresponding `PFunctor.FreeM` trees.
 
 @[expose] public section
 
-set_option backward.do.legacy false
-
 namespace IPFunctorFreeMDetNotationTests
 
 /-- The same demo `IPFunctor.Endo` as the other `Notation` files. Both states

--- a/PolyFunTest/IPFunctor/Examples.lean
+++ b/PolyFunTest/IPFunctor/Examples.lean
@@ -51,8 +51,6 @@ W-type.
 
 @[expose] public section
 
-set_option backward.do.legacy false
-
 namespace IPFunctor.Examples
 
 /-! ## Two-phase protocol fixture -/

--- a/PolyFunTest/IPFunctor/IndexedNotationTests.lean
+++ b/PolyFunTest/IPFunctor/IndexedNotationTests.lean
@@ -19,8 +19,6 @@ trees to the corresponding `PFunctor.FreeM` trees.
 
 @[expose] public section
 
-set_option backward.do.legacy false
-
 namespace IPFunctorFreeM₂NotationTests
 
 /-- A tiny `IPFunctor.Endo` over `Bool`. State `false` lets you `flip` (→ `true`);

--- a/PolyFunTest/IPFunctor/Notation/Mixed.lean
+++ b/PolyFunTest/IPFunctor/Notation/Mixed.lean
@@ -27,8 +27,6 @@ rather than at downstream call sites.
 
 @[expose] public section
 
-set_option backward.do.legacy false
-
 namespace IPFunctorMixedNotationTests
 
 /-- Shared demo `IPFunctor.Endo` over `Bool`, identical to the per-file

--- a/PolyFunTest/IPFunctor/NotationTests.lean
+++ b/PolyFunTest/IPFunctor/NotationTests.lean
@@ -24,8 +24,6 @@ would shadow).
 
 @[expose] public section
 
-set_option backward.do.legacy false
-
 namespace IPFunctorNotationTests
 
 /-- A tiny `IPFunctor.Endo` over `Bool`. At state `false` only a trivial "flip"

--- a/docs/wiki/generated-files.md
+++ b/docs/wiki/generated-files.md
@@ -18,10 +18,13 @@ Edit the source of truth, not the output.
 - `./scripts/check-imports.sh` is the lightweight read-only check used in
   CI: it regenerates `PolyFun.lean` to a temp file and diffs against the
   committed copy.
-- `./scripts/check-docs-integrity.py` validates the CLAUDE.md symlink and
-  resolves all internal markdown links in tracked top-level docs and
-  `docs/`. Run it (or `./scripts/validate.sh`, which calls it) after any
-  doc rename, move, or deletion. CI runs this via
+- `./scripts/check-docs-integrity.py` validates the CLAUDE.md symlink,
+  resolves internal markdown links and repository-rooted Lean paths in tracked
+  top-level docs and `docs/`, and checks that production/test Lean files keep a
+  module docstring in the standard post-import prologue slot. Its regression
+  fixtures live in `./scripts/test-docs-integrity.py`; the validation wrapper
+  and CI run both scripts. Run them after any documentation or Lean-module
+  rename, move, addition, or deletion. CI runs this via
   [`../../.github/workflows/docs-integrity.yml`](../../.github/workflows/docs-integrity.yml).
 - If a path looks derived, confirm its source of truth before editing it.
 - The wiki itself is *not* generated. Keep it maintained with source changes;

--- a/docs/wiki/gotchas.md
+++ b/docs/wiki/gotchas.md
@@ -101,10 +101,10 @@ metavariables.
 resolve independently. Keep `α β : Type` (not `Type u`) when a single
 universe suffices.
 
-### 8. `do`-notation bind uses a different `Bind` instance (Lean 4.29+)
+### 8. `do`-notation bind uses a different `Bind` instance
 
-Lean 4.29 changed `do`-block elaboration so the desugared bind may use
-a `Bind` instance that differs syntactically from `Monad.toBind`. This
+Lean's `do`-block elaboration may use a `Bind` instance that differs
+syntactically from `Monad.toBind`. This
 means `pure_bind`, `bind_assoc`, and `bind_pure` won't fire via `simp`
 or `rw` on goals produced by `do` notation in special cases of more
 non-standard instances.

--- a/docs/wiki/ipfunctor-do-notation.md
+++ b/docs/wiki/ipfunctor-do-notation.md
@@ -2,7 +2,7 @@
 
 Three parallel files in
 [`PolyFun/IPFunctor/Notation/`](../../PolyFun/IPFunctor/Notation/) plug
-custom `@[doElem_elab]` overrides into Lean 4.29's extensible
+custom `@[doElem_elab]` overrides into Lean's extensible
 do-elaborator so that ordinary `do { let x ← e; … }` blocks elaborate
 to the right `bind`-trees over `IPFunctor.FreeM` and `IPFunctor.FreeM₂`.
 

--- a/docs/wiki/ipfunctor-do-notation.md
+++ b/docs/wiki/ipfunctor-do-notation.md
@@ -14,11 +14,10 @@ which serves as the live-Lean companion to this prose.
 
 ## Activation
 
-All three flavors require `set_option backward.do.legacy false` (or a
-project-wide entry in `[leanOptions]` of `lakefile.toml`). This switches
-Lean from the legacy do-elaborator to the new extensible one, which is
-where our overrides plug in. The flag is transitional; when upstream
-Lean retires it the lines come out.
+The extensible `do` elaborator is already the pinned Lean toolchain's default,
+so all three flavors work without an option. Setting
+`backward.do.legacy true` explicitly selects the legacy elaborator, where the
+custom overrides are unavailable.
 
 ## The three flavors at a glance
 
@@ -67,7 +66,6 @@ want the type to record the start and end phases.
 
 ```lean
 import PolyFun.IPFunctor.Notation.Indexed
-set_option backward.do.legacy false
 
 def init : IPFunctor.FreeM₂ proto Phase.opn Phase.counting Unit :=
   IPFunctor.FreeM₂.liftBind () (fun _ => IPFunctor.FreeM₂.pure ())
@@ -94,7 +92,6 @@ known post-state.
 
 ```lean
 import PolyFun.IPFunctor.Notation.Deterministic
-set_option backward.do.legacy false
 
 instance : IPFunctor.DeterministicTransitions proto where
   next
@@ -134,7 +131,6 @@ state-specific gets the *state mismatch* diagnostic.
 
 ```lean
 import PolyFun.IPFunctor.Notation
-set_option backward.do.legacy false
 
 example : IPFunctor.FreeM proto Phase.opn Unit := do
   let _ ← init

--- a/docs/wiki/ipfunctor.md
+++ b/docs/wiki/ipfunctor.md
@@ -56,7 +56,7 @@ indexed-monad shape that `IPFunctor.FreeM₂` instantiates.
 | [`PolyFun/IPFunctor/Lens/Basic.lean`](../../PolyFun/IPFunctor/Lens/Basic.lean) | `IPFunctor.Lens P Q` — Cartesian lens between indexed polynomials with the source-index preservation law `src_eq`. Identity, composition, `Lens.Equiv`. |
 | [`PolyFun/IPFunctor/Chart/Basic.lean`](../../PolyFun/IPFunctor/Chart/Basic.lean) | `IPFunctor.Chart P Q` — covariant chart (dual to lens) with `src_eq` in the chart direction. Identity, composition, `Chart.Equiv`. |
 | [`PolyFun/IPFunctor/Equiv/Basic.lean`](../../PolyFun/IPFunctor/Equiv/Basic.lean) | `IPFunctor.Equiv P Q` (`≃ₚ`) — structural equivalence with fiberwise `A` / `B` equivalences plus `src_eq`. |
-| [`PolyFun/IPFunctor/Notation.lean`](../../PolyFun/IPFunctor/Notation.lean) | `@[doElem_elab]` overrides for the pinned Lean toolchain, making ordinary `do { let x ← e; … }` elaborate to `IPFunctor.FreeM.bind`-trees. Custom diagnostics for state mismatches and non-polymorphic remainders. Opt in with `set_option backward.do.legacy false`. |
+| [`PolyFun/IPFunctor/Notation.lean`](../../PolyFun/IPFunctor/Notation.lean) | `@[doElem_elab]` overrides for the pinned Lean toolchain, making ordinary `do { let x ← e; … }` elaborate to `IPFunctor.FreeM.bind`-trees. Custom diagnostics for state mismatches and non-polymorphic remainders. |
 | [`PolyFun/IPFunctor/Notation/Indexed.lean`](../../PolyFun/IPFunctor/Notation/Indexed.lean) | `do`-notation for `IPFunctor.FreeM₂`. Statically-tracked intermediate states; chains of any length compose. Adds the `Pure (IPFunctor.FreeM₂ P s s)` instance. |
 | [`PolyFun/IPFunctor/Notation/Deterministic.lean`](../../PolyFun/IPFunctor/Notation/Deterministic.lean) | `do`-notation for `IPFunctor.FreeM` with a `DeterministicTransitions P` class. Specializes `IPFunctor.FreeM.lift`-style steps to a concrete source index. |
 | [`PolyFunTest/IPFunctor/Examples.lean`](../../PolyFunTest/IPFunctor/Examples.lean) | Worked examples: a two-phase protocol compiled three ways (`IPFunctor.FreeM₂`, deterministic `IPFunctor.FreeM`, Σ-bundled erase via `toSigmaFreeM`), plus a `PFunctor.FreeM.equivW_of_isEmpty` round-trip. |
@@ -257,9 +257,10 @@ do-elaborator. See
 [`ipfunctor-do-notation.md`](ipfunctor-do-notation.md) for a worked
 walkthrough with a small two-phase-protocol example.
 
-All three require `set_option backward.do.legacy false` and check
-the expected monad type before activating, so other monads in the same file
-are unaffected.
+The extensible elaborator is the pinned toolchain's default, so no option is
+required. All three check the expected monad type before activating, leaving
+other monads in the same file unaffected. Setting `backward.do.legacy true`
+selects Lean's legacy elaborator and disables these extensions.
 
 The elaborator detectors use `Meta.withTransparency .reducible <| whnf m`
 so the `IPFunctor.FreeM` / `IPFunctor.FreeM₂` head — defined as a plain

--- a/docs/wiki/ipfunctor.md
+++ b/docs/wiki/ipfunctor.md
@@ -56,7 +56,7 @@ indexed-monad shape that `IPFunctor.FreeM₂` instantiates.
 | [`PolyFun/IPFunctor/Lens/Basic.lean`](../../PolyFun/IPFunctor/Lens/Basic.lean) | `IPFunctor.Lens P Q` — Cartesian lens between indexed polynomials with the source-index preservation law `src_eq`. Identity, composition, `Lens.Equiv`. |
 | [`PolyFun/IPFunctor/Chart/Basic.lean`](../../PolyFun/IPFunctor/Chart/Basic.lean) | `IPFunctor.Chart P Q` — covariant chart (dual to lens) with `src_eq` in the chart direction. Identity, composition, `Chart.Equiv`. |
 | [`PolyFun/IPFunctor/Equiv/Basic.lean`](../../PolyFun/IPFunctor/Equiv/Basic.lean) | `IPFunctor.Equiv P Q` (`≃ₚ`) — structural equivalence with fiberwise `A` / `B` equivalences plus `src_eq`. |
-| [`PolyFun/IPFunctor/Notation.lean`](../../PolyFun/IPFunctor/Notation.lean) | Lean 4.29 `@[doElem_elab]` overrides making ordinary `do { let x ← e; … }` elaborate to `IPFunctor.FreeM.bind`-trees. Custom diagnostics for state mismatches and non-polymorphic remainders. Opt in with `set_option backward.do.legacy false`. |
+| [`PolyFun/IPFunctor/Notation.lean`](../../PolyFun/IPFunctor/Notation.lean) | `@[doElem_elab]` overrides for the pinned Lean toolchain, making ordinary `do { let x ← e; … }` elaborate to `IPFunctor.FreeM.bind`-trees. Custom diagnostics for state mismatches and non-polymorphic remainders. Opt in with `set_option backward.do.legacy false`. |
 | [`PolyFun/IPFunctor/Notation/Indexed.lean`](../../PolyFun/IPFunctor/Notation/Indexed.lean) | `do`-notation for `IPFunctor.FreeM₂`. Statically-tracked intermediate states; chains of any length compose. Adds the `Pure (IPFunctor.FreeM₂ P s s)` instance. |
 | [`PolyFun/IPFunctor/Notation/Deterministic.lean`](../../PolyFun/IPFunctor/Notation/Deterministic.lean) | `do`-notation for `IPFunctor.FreeM` with a `DeterministicTransitions P` class. Specializes `IPFunctor.FreeM.lift`-style steps to a concrete source index. |
 | [`PolyFunTest/IPFunctor/Examples.lean`](../../PolyFunTest/IPFunctor/Examples.lean) | Worked examples: a two-phase protocol compiled three ways (`IPFunctor.FreeM₂`, deterministic `IPFunctor.FreeM`, Σ-bundled erase via `toSigmaFreeM`), plus a `PFunctor.FreeM.equivW_of_isEmpty` round-trip. |
@@ -252,7 +252,7 @@ read the state back.
 
 ## `do`-notation flavors
 
-Three parallel `do`-notation files plug into Lean 4.29's extensible
+Three parallel `do`-notation files plug into Lean's extensible
 do-elaborator. See
 [`ipfunctor-do-notation.md`](ipfunctor-do-notation.md) for a worked
 walkthrough with a small two-phase-protocol example.

--- a/docs/wiki/quickstart.md
+++ b/docs/wiki/quickstart.md
@@ -27,8 +27,10 @@ local validation. By default it runs:
    Interaction public-scope policy is respected)
 3. `./scripts/check-imports.sh` (umbrella `PolyFun.lean` matches the
    tracked source tree)
-4. `python3 ./scripts/check-docs-integrity.py` (CLAUDE.md symlink and
-   tracked-markdown link resolution)
+4. `python3 ./scripts/test-docs-integrity.py` and
+   `python3 ./scripts/check-docs-integrity.py` (checker regression fixtures,
+   CLAUDE.md symlink, tracked-markdown links, repository-rooted Lean paths,
+   and module docstrings in their standard prologue position)
 
 ## Validation By Change Type
 
@@ -78,6 +80,7 @@ issue:
 lake build
 ./scripts/check-modules.sh
 ./scripts/check-imports.sh
+python3 ./scripts/test-docs-integrity.py
 python3 ./scripts/check-docs-integrity.py
 ```
 
@@ -114,12 +117,13 @@ deliberately outside the `lake lint` scope.
   checks that `PolyFun.lean` matches the tracked source tree. `Check
   Library File Imports` is a required status check on `main`.
 - [`../../.github/workflows/docs-integrity.yml`](../../.github/workflows/docs-integrity.yml):
-  runs `./scripts/check-docs-integrity.py` (CLAUDE.md symlink, tracked
-  markdown link resolution). `Check Docs Integrity` is a required status
-  check on `main`. This is the agent-documentation liveness check: any
-  PR that breaks an internal link in `AGENTS.md`, `README.md`,
-  `CONTRIBUTING.md`, `REFERENCES.md`, or any tracked page under `docs/`
-  will fail this job.
+  runs the checker's regression fixtures and `./scripts/check-docs-integrity.py`
+  (CLAUDE.md symlink, tracked markdown links, repository-rooted Lean paths,
+  and module docstrings). `Check Docs Integrity` is a required status check
+  on `main`. This is the agent-documentation liveness check: any PR that
+  breaks an internal link or documented Lean path in `AGENTS.md`, `README.md`,
+  `CONTRIBUTING.md`, `REFERENCES.md`, or a tracked page under `docs/`, or drops
+  a production/test module docstring from its prologue, will fail this job.
 - [`../../.github/workflows/linting.yml`](../../.github/workflows/linting.yml):
   runs the community `leanprover-community/lint-style-action` (the Lean-based
   Mathlib text style linter: copyright headers, line length, module

--- a/docs/wiki/review-hardening.md
+++ b/docs/wiki/review-hardening.md
@@ -23,6 +23,14 @@ Every substantial pull request records four passes:
    simp orientation, environment linters, axiom cleanliness, generated files,
    and the accuracy of source or paper claims.
 
+The maintenance pass is source-backed: compare module docstrings and wiki
+claims to the declarations and imports that actually ship, then check the
+agent guide against the repository tree. Treat version-specific prose,
+repository-rooted paths written as code, and descriptions copied across a
+dependency boundary as likely drift points. `scripts/check-docs-integrity.py`
+checks both markdown links and repository-rooted Lean paths, but semantic
+accuracy still requires review.
+
 ## Upstream-First Mathematics
 
 Before adding a generic definition or lemma, search the pinned Lean core,
@@ -45,6 +53,9 @@ A merge-ready change must have:
 - minimal, correctly classified imports and no accidental transitive API;
 - an explicit public API delta, including removals and instance changes;
 - ordinary-import canaries for load-bearing public laws;
+- tests placed on the narrowest useful surface: ordinary-import canaries for
+  public API, focused proof regressions beside the owning subsystem, and
+  worked examples in `PolyFunTest/` rather than production modules;
 - minimized regressions for every discovered failure or counterexample;
 - satisfiable assumptions and statements that cover their documented scope;
 - Mathlib-style names, intrinsic docstrings, and lint-clean simp declarations;

--- a/scripts/check-docs-integrity.py
+++ b/scripts/check-docs-integrity.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import re
 import subprocess
 import sys
+from collections.abc import Iterator
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -35,7 +36,16 @@ TRACKED_PATHS = [
 
 MARKDOWN_LINK_RE = re.compile(r"(?<!!)\[[^\]]+\]\(([^)]+)\)")
 LEAN_PATH_RE = re.compile(
-    r"(?<![A-Za-z0-9_./])((?:PolyFun|PolyFunTest)/[A-Za-z0-9_./-]+\.lean)"
+    r"(?<![A-Za-z0-9_./])"
+    r"((?:PolyFun|PolyFunTest)/(?:"
+    r"[A-Za-z0-9_./-]+\.lean|"
+    r"[A-Za-z0-9_./-]*\{[A-Za-z0-9_./, -]+\}(?:[A-Za-z0-9_./-]*\.lean)?"
+    r"))"
+    r"(?![A-Za-z0-9_./-])"
+)
+MODULE_COMMAND_RE = re.compile(r"^module[ \t]*$", re.MULTILINE)
+IMPORT_COMMAND_RE = re.compile(
+    r"(?:(?:public|private|meta)[ \t]+)*import(?:[ \t]+all)?[ \t]+[^\n]+"
 )
 
 
@@ -102,22 +112,64 @@ def check_markdown_links() -> list[str]:
     return errors
 
 
+def expand_lean_path(expression: str) -> list[str]:
+    """Expand one literal or single-brace repository-rooted Lean path."""
+    if "{" not in expression:
+        return [expression]
+    prefix, choices_and_suffix = expression.split("{", 1)
+    choices, suffix = choices_and_suffix.split("}", 1)
+    return [prefix + choice.strip() + suffix for choice in choices.split(",")]
+
+
+def lean_paths(text: str) -> Iterator[str]:
+    """Yield every literal Lean path represented in documentation text."""
+    for expression in LEAN_PATH_RE.findall(text):
+        yield from expand_lean_path(expression)
+
+
+def missing_lean_paths(text: str, repo_root: Path = REPO_ROOT) -> list[str]:
+    """Return documented Lean paths that do not exist under ``repo_root``."""
+    return sorted(
+        rel_path
+        for rel_path in set(lean_paths(text))
+        if not (repo_root / rel_path).exists()
+    )
+
+
 def check_lean_paths() -> list[str]:
     errors: list[str] = []
     for doc_file in tracked_markdown_files():
         text = doc_file.read_text()
-        for rel_path in sorted(set(LEAN_PATH_RE.findall(text))):
-            if not (REPO_ROOT / rel_path).exists():
-                rel_doc = doc_file.relative_to(REPO_ROOT)
-                errors.append(f"Missing Lean path in {rel_doc}: {rel_path}")
+        for rel_path in missing_lean_paths(text):
+            rel_doc = doc_file.relative_to(REPO_ROOT)
+            errors.append(f"Missing Lean path in {rel_doc}: {rel_path}")
     return errors
+
+
+def has_module_docstring(text: str) -> bool:
+    """Check for a module docstring in the standard post-import prologue slot."""
+    module_match = MODULE_COMMAND_RE.search(text)
+    if module_match is None:
+        return False
+
+    offset = module_match.end()
+    while True:
+        whitespace = re.match(r"\s*", text[offset:])
+        assert whitespace is not None
+        offset += whitespace.end()
+        if text.startswith("/-!", offset):
+            return True
+        import_match = IMPORT_COMMAND_RE.match(text, offset)
+        if import_match is None:
+            return False
+        offset = import_match.end()
 
 
 def check_module_docstrings() -> list[str]:
     errors: list[str] = []
     for source_root in (REPO_ROOT / "PolyFun", REPO_ROOT / "PolyFunTest"):
         for lean_file in source_root.rglob("*.lean"):
-            if "/-!" not in lean_file.read_text():
+            if not has_module_docstring(lean_file.read_text()):
                 rel_path = lean_file.relative_to(REPO_ROOT)
                 errors.append(f"Missing module docstring: {rel_path}")
     return errors

--- a/scripts/check-docs-integrity.py
+++ b/scripts/check-docs-integrity.py
@@ -4,6 +4,9 @@
 Checks:
 1. `CLAUDE.md` exists and is a symlink to `AGENTS.md`.
 2. Local markdown links in tracked top-level docs and `docs/` resolve.
+3. Repository-rooted Lean paths in those documents resolve even when they
+   are written as code rather than markdown links.
+4. Every production and test Lean module has a module documentation comment.
 
 Exit code 0 if all checks pass, 1 otherwise.
 """
@@ -31,6 +34,9 @@ TRACKED_PATHS = [
 ]
 
 MARKDOWN_LINK_RE = re.compile(r"(?<!!)\[[^\]]+\]\(([^)]+)\)")
+LEAN_PATH_RE = re.compile(
+    r"(?<![A-Za-z0-9_./])((?:PolyFun|PolyFunTest)/[A-Za-z0-9_./-]+\.lean)"
+)
 
 
 def tracked_markdown_files() -> list[Path]:
@@ -96,6 +102,27 @@ def check_markdown_links() -> list[str]:
     return errors
 
 
+def check_lean_paths() -> list[str]:
+    errors: list[str] = []
+    for doc_file in tracked_markdown_files():
+        text = doc_file.read_text()
+        for rel_path in sorted(set(LEAN_PATH_RE.findall(text))):
+            if not (REPO_ROOT / rel_path).exists():
+                rel_doc = doc_file.relative_to(REPO_ROOT)
+                errors.append(f"Missing Lean path in {rel_doc}: {rel_path}")
+    return errors
+
+
+def check_module_docstrings() -> list[str]:
+    errors: list[str] = []
+    for source_root in (REPO_ROOT / "PolyFun", REPO_ROOT / "PolyFunTest"):
+        for lean_file in source_root.rglob("*.lean"):
+            if "/-!" not in lean_file.read_text():
+                rel_path = lean_file.relative_to(REPO_ROOT)
+                errors.append(f"Missing module docstring: {rel_path}")
+    return errors
+
+
 def main() -> int:
     all_errors: list[str] = []
 
@@ -104,6 +131,12 @@ def main() -> int:
 
     print("Checking tracked markdown links...")
     all_errors.extend(check_markdown_links())
+
+    print("Checking repository-rooted Lean paths...")
+    all_errors.extend(check_lean_paths())
+
+    print("Checking Lean module docstrings...")
+    all_errors.extend(check_module_docstrings())
 
     if all_errors:
         print(f"\n{len(all_errors)} issue(s) found:\n")

--- a/scripts/test-docs-integrity.py
+++ b/scripts/test-docs-integrity.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Regression tests for ``check-docs-integrity.py``."""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).with_name("check-docs-integrity.py")
+SPEC = importlib.util.spec_from_file_location("check_docs_integrity", SCRIPT_PATH)
+assert SPEC is not None and SPEC.loader is not None
+CHECKER = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(CHECKER)
+
+
+class ModuleDocstringTests(unittest.TestCase):
+    def test_standard_module_docstring(self) -> None:
+        text = """/- header -/
+
+module
+
+public import PolyFun.PFunctor.Basic
+import all PolyFun.PFunctor.Free.Basic
+public meta import Lean.Elab.Do.Basic
+
+/-! # Module documentation -/
+
+public section
+"""
+        self.assertTrue(CHECKER.has_module_docstring(text))
+
+    def test_later_section_comment_is_not_module_docstring(self) -> None:
+        text = """/- header -/
+
+module
+
+public import PolyFun.PFunctor.Basic
+
+public section
+
+/-! ## Later section -/
+"""
+        self.assertFalse(CHECKER.has_module_docstring(text))
+
+
+class LeanPathTests(unittest.TestCase):
+    def test_literal_and_grouped_paths_expand(self) -> None:
+        text = """
+`PolyFun/PFunctor/Basic.lean`
+`PolyFun/PFunctor/Dynamical/{Responder, Game}.lean`
+`PolyFun/ITree/{Basic.lean,Bisim/Defs.lean}`
+"""
+        self.assertEqual(
+            set(CHECKER.lean_paths(text)),
+            {
+                "PolyFun/PFunctor/Basic.lean",
+                "PolyFun/PFunctor/Dynamical/Responder.lean",
+                "PolyFun/PFunctor/Dynamical/Game.lean",
+                "PolyFun/ITree/Basic.lean",
+                "PolyFun/ITree/Bisim/Defs.lean",
+            },
+        )
+
+    def test_missing_member_of_group_is_reported(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            existing = repo_root / "PolyFun/PFunctor/Existing.lean"
+            existing.parent.mkdir(parents=True)
+            existing.write_text("module\n")
+            text = "`PolyFun/PFunctor/{Existing, DefinitelyMissing}.lean`"
+            self.assertEqual(
+                CHECKER.missing_lean_paths(text, repo_root),
+                ["PolyFun/PFunctor/DefinitelyMissing.lean"],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -64,6 +64,7 @@ echo "# Checking umbrella imports"
 
 echo ""
 echo "# Checking docs integrity"
+python3 ./scripts/test-docs-integrity.py
 python3 ./scripts/check-docs-integrity.py
 
 if (( run_lint )); then


### PR DESCRIPTION
## Summary

- replace version-pinned elaborator prose with descriptions of the current semantic contract
- document source-backed maintenance and appropriate test surfaces
- extend documentation integrity checks to repository-rooted Lean paths and module docstrings

## Validation

- ./scripts/validate.sh --lint --test --axioms
- python3 scripts/check-docs-integrity.py
- git diff --cached --check

The full validation run covered build, lint, all 106 test/example modules, and the zero-taint axiom sweep.