### PR TITLE
feat(control): indexed support, WriterT support, and the modal-pair bridge

### DIFF
--- a/PolyFun/Control/Do/Basic.lean
+++ b/PolyFun/Control/Do/Basic.lean
@@ -129,14 +129,26 @@ theorem erasesTo_of_map_eq {α : Type u} {P : α → Prop} {y : m (Subtype P)} {
     (h : Subtype.val <$> y = x) : Std.Do.Internal.ErasesTo y x :=
   ⟨fun {_} k => by rw [← h, bind_map_left]⟩
 
-/-- An "always" judgment yields the `Ensures` witness core's soundness class wants. -/
-theorem ensures_of_allOutputs {α : Type u} {x : m α} {P : α → Prop}
-    (h : AllOutputs P x) : Std.Do.Internal.Ensures P x :=
+omit [ExactMonadAttach m] in
+/-- An "always" judgment yields the `Ensures` witness core's soundness class wants.
+
+Stated at `WeaklyLawfulMonadAttach` rather than `ExactMonadAttach`: the witness is built
+from `attach` and its bind-faithfulness alone, and needs nothing about how possible
+outputs compose. That matters because `StateT`, `ReaderT`, and `EStateM` have the weak
+class but provably not the exact one. -/
+theorem ensures_of_allOutputs {α : Type u} [WeaklyLawfulMonadAttach m] {x : m α}
+    {P : α → Prop} (h : AllOutputs P x) : Std.Do.Internal.Ensures P x :=
   ⟨⟨(fun z : Subtype (CanReturn x) => (⟨z.1, h z.1 z.2⟩ : Subtype P)) <$> MonadAttach.attach x,
     erasesTo_of_map_eq (by rw [Functor.map_map]; exact WeaklyLawfulMonadAttach.map_attach)⟩⟩
 
-/-- The demonic interpretation is sound in core's sense. Not an instance. -/
-theorem toWPSound : letI := toWP (m := m); WPSound m .pure :=
+omit [ExactMonadAttach m] in
+/-- The demonic interpretation is sound in core's sense. Not an instance.
+
+Like `ensures_of_allOutputs` this needs only the weak class, so the *soundness* of the
+demonic reading is available for every monad core equips — including the stateful ones.
+What exactness buys is `toWPMonad`, i.e. the `wp_bind` law, not soundness. -/
+theorem toWPSound [WeaklyLawfulMonadAttach m] :
+    letI := toWP (m := m); WPSound m .pure :=
   letI := toWP (m := m)
   { ensures_of_wp := fun {_ _ _} hwp => ensures_of_allOutputs (hwp True.intro) }
 

--- a/PolyFun/Control/Monad/Support.lean
+++ b/PolyFun/Control/Monad/Support.lean
@@ -7,6 +7,7 @@ module
 
 public import PolyFun.Control.Monad.Algebra
 public import Mathlib.Data.Set.Functor
+public import Mathlib.Control.Monad.Writer
 
 /-!
 # Exact Monadic Support
@@ -178,6 +179,26 @@ theorem noOutput_iff_forall_support (p : α → Prop) (x : m α) :
 theorem allOutputs_iff_forall_canReturn (p : α → Prop) (x : m α) :
     AllOutputs p x ↔ ∀ a, CanReturn x a → p a :=
   Iff.rfl
+
+/-- `support` is the *equality instance* of the angelic judgment: a value is a possible
+output exactly when "some output equals it" holds.
+
+The two presentations of the layer meet here. `support` is the `Set`-valued carrier and
+`AllOutputs`/`SomeOutput` are the demonic and angelic modalities over it; this equation
+says nothing is lost by reading the carrier off the modality instead. The modality is the
+more general of the two — it is `Prop`-valued and so survives settings where a `Set` of
+outputs is the wrong object, which is exactly what happens for `StateT` (see
+`mem_support_stateT_iff` and the indexed section). It is also what the weakest-precondition
+bridge consumes: `MonadAttach.toWP` is built from `AllOutputs`, not from `support`. -/
+theorem support_eq_setOf_someOutput (x : m α) :
+    support x = {a | SomeOutput (· = a) x} :=
+  Set.ext fun a => ⟨fun ha => ⟨a, ha, rfl⟩, fun ⟨_, hb, hba⟩ => hba ▸ hb⟩
+
+/-- The angelic judgment at an equality predicate is membership in the support. The
+pointwise form of `support_eq_setOf_someOutput`. -/
+theorem someOutput_eq_iff_mem_support (x : m α) (a : α) :
+    SomeOutput (· = a) x ↔ a ∈ support x :=
+  ⟨fun ⟨_, hb, hba⟩ => hba ▸ hb, fun ha => ⟨a, ha, rfl⟩⟩
 
 theorem not_someOutput_iff_noOutput (p : α → Prop) (x : m α) :
     ¬ SomeOutput p x ↔ NoOutput p x := by
@@ -434,6 +455,73 @@ instance instExactMonadAttachExceptT {ε : Type u} : ExactMonadAttach (ExceptT �
     rw [hrun]
     exact ExactMonadAttach.canReturn_bind (a := Except.ok a) h h'
 
+/-! ### The writer transformer
+
+`WriterT ω m` accumulates an output alongside the value, so the honest reading of its
+support is the one that keeps that output: a value is possible exactly when it is
+returned *together with some accumulator*. This is the same rule the measure semantics
+uses for the same transformer — a writer computation denotes the underlying `m (α × ω)`
+rather than discarding `ω` — and unlike `StateT` it costs nothing, because there is no
+*input* index to choose. Both introduction rules survive: `pure` writes the unit, and
+two composable outputs compose with their accumulators multiplied. -/
+
+section WriterT
+
+variable {ω : Type u} [Monoid ω]
+
+instance instMonadAttachWriterT : MonadAttach (WriterT ω m) where
+  CanReturn x a := ∃ w, CanReturn x.run (a, w)
+  attach x := WriterT.mk <|
+    (fun p => (⟨p.1.1, ⟨p.1.2, p.2⟩⟩, p.1.2)) <$> MonadAttach.attach x.run
+
+omit [LawfulMonad m] [ExactMonadAttach m] [Monoid ω] in
+theorem mem_support_writerT_iff {x : WriterT ω m α} {a : α} :
+    a ∈ support x ↔ ∃ w, (a, w) ∈ support x.run :=
+  Iff.rfl
+
+omit [LawfulMonad m] [ExactMonadAttach m] [Monoid ω] in
+theorem mem_support_of_run_writerT {x : WriterT ω m α} {a : α} {w : ω}
+    (h : (a, w) ∈ support x.run) : a ∈ support x :=
+  ⟨w, h⟩
+
+instance instWeaklyLawfulMonadAttachWriterT :
+    WeaklyLawfulMonadAttach (WriterT ω m) where
+  map_attach {α x} := by
+    refine WriterT.ext _ _ ?_
+    rw [WriterT.run_map]
+    have hrun : (MonadAttach.attach x : WriterT ω m (Subtype (CanReturn x))).run
+        = (fun p : Subtype (CanReturn x.run) =>
+            ((⟨p.1.1, ⟨p.1.2, p.2⟩⟩ : Subtype (CanReturn x)), p.1.2))
+          <$> MonadAttach.attach x.run := rfl
+    rw [hrun, Functor.map_map]
+    simpa [Function.comp_def] using WeaklyLawfulMonadAttach.map_attach (m := m) (x := x.run)
+
+instance instLawfulMonadAttachWriterT : LawfulMonadAttach (WriterT ω m) where
+  canReturn_map_imp {α P x a} h := by
+    obtain ⟨w, hw⟩ := h
+    rw [WriterT.run_map] at hw
+    obtain ⟨q, -, hqa⟩ := LawfulMonadAttach.canReturn_map_imp' hw
+    obtain ⟨⟨v, hv⟩, w'⟩ := q
+    cases hqa
+    exact hv
+
+/-- Both introduction rules hold: `pure` writes the unit accumulator, and composable
+outputs compose with their accumulators multiplied. This is what `StateT` cannot have —
+there is no input index to quantify over, so nothing is flattened away. -/
+instance instExactMonadAttachWriterT : ExactMonadAttach (WriterT ω m) where
+  canReturn_pure {α} a := ⟨1, ExactMonadAttach.canReturn_pure _⟩
+  canReturn_bind {α β x f a b} h h' := by
+    obtain ⟨w₁, hw₁⟩ := h
+    obtain ⟨w₂, hw₂⟩ := h'
+    refine ⟨w₁ * w₂, ?_⟩
+    change CanReturn (x.run >>= fun p => (fun q => (q.1, p.2 * q.2)) <$> (f p.1).run) (b, w₁ * w₂)
+    refine ExactMonadAttach.canReturn_bind (a := (a, w₁)) hw₁ ?_
+    have hmem : ((b, w₂) : β × ω) ∈ support (f a).run := hw₂
+    have himg := Set.mem_image_of_mem (fun q : β × ω => (q.1, w₁ * q.2)) hmem
+    rwa [← support_map] at himg
+
+end WriterT
+
 /-! ### Stateful monads
 
 `StateT` and `ReaderT` do have core `MonadAttach` instances, existentially quantified over
@@ -460,6 +548,185 @@ omit [LawfulMonad m] [ExactMonadAttach m] in
 theorem mem_support_of_run_readerT {ρ : Type u} {x : ReaderT ρ m α} {a : α} {r : ρ}
     (h : a ∈ support (x.run r)) : a ∈ support x :=
   ⟨r, h⟩
+
+/-! #### Indexed support
+
+The flattened support above is canonical but coarse: it quantifies the initial state
+existentially, and independently on each side of a `bind`, which is exactly why
+`ExactMonadAttach` fails. Indexing repairs that. `supportFrom s x` is the set of
+result/final-state pairs reachable *from `s`*, and its bind law is exact — the
+continuation is only ever run from states the prefix actually produced — needing no
+exactness on the transformer, because nothing is flattened away.
+
+This is the same move the probabilistic semantics makes for the same transformer:
+state-indexed computations denote a `Kernel σ (α × σ)` rather than a measure, because
+there is no canonical initial state to integrate over. Kernels are to measures as
+indexed support is to support. -/
+
+/-- The result/final-state pairs reachable by running `x` from the initial state `s`. -/
+def StateT.supportFrom {σ : Type u} (s : σ) (x : StateT σ m α) : Set (α × σ) :=
+  support (x.run s)
+
+/-- The outputs reachable by running `x` in the environment `r`. -/
+def ReaderT.supportAt {ρ : Type u} (r : ρ) (x : ReaderT ρ m α) : Set α :=
+  support (x.run r)
+
+omit [Monad m] [LawfulMonad m] [ExactMonadAttach m] in
+theorem StateT.mem_supportFrom_iff {σ : Type u} {s : σ} {x : StateT σ m α} {p : α × σ} :
+    p ∈ StateT.supportFrom s x ↔ p ∈ support (x.run s) :=
+  Iff.rfl
+
+omit [Monad m] [LawfulMonad m] [ExactMonadAttach m] in
+theorem ReaderT.mem_supportAt_iff {ρ : Type u} {r : ρ} {x : ReaderT ρ m α} {a : α} :
+    a ∈ ReaderT.supportAt r x ↔ a ∈ support (x.run r) :=
+  Iff.rfl
+
+omit [LawfulMonad m] [ExactMonadAttach m] in
+/-- The flattened support is the union of the indexed ones. Recovers
+`mem_support_stateT_iff` and pins that indexing loses nothing. -/
+theorem StateT.mem_support_iff_exists_supportFrom {σ : Type u} {x : StateT σ m α} {a : α} :
+    a ∈ support x ↔ ∃ s s', (a, s') ∈ StateT.supportFrom s x :=
+  Iff.rfl
+
+omit [LawfulMonad m] [ExactMonadAttach m] in
+theorem ReaderT.mem_support_iff_exists_supportAt {ρ : Type u} {x : ReaderT ρ m α} {a : α} :
+    a ∈ support x ↔ ∃ r, a ∈ ReaderT.supportAt r x :=
+  Iff.rfl
+
+@[simp]
+theorem StateT.supportFrom_pure {σ : Type u} (s : σ) (a : α) :
+    StateT.supportFrom s (pure a : StateT σ m α) = {(a, s)} := by
+  rw [StateT.supportFrom, StateT.run_pure, support_pure]
+
+@[simp]
+theorem ReaderT.supportAt_pure {ρ : Type u} (r : ρ) (a : α) :
+    ReaderT.supportAt r (pure a : ReaderT ρ m α) = {a} := by
+  rw [ReaderT.supportAt, ReaderT.run_pure, support_pure]
+
+/-- **The exact bind law.** Unlike the flattened `support`, this composes: the
+continuation is run only from states the prefix actually produces, so no witness is
+chosen independently on the two sides. Needs only `[ExactMonadAttach m]` on the base
+monad — `StateT σ m` itself is deliberately not `ExactMonadAttach`, and does not need
+to be. -/
+@[simp]
+theorem StateT.supportFrom_bind {σ : Type u} (s : σ) (x : StateT σ m α)
+    (f : α → StateT σ m β) :
+    StateT.supportFrom s (x >>= f)
+      = ⋃ p ∈ StateT.supportFrom s x, StateT.supportFrom p.2 (f p.1) := by
+  rw [StateT.supportFrom, StateT.run_bind, support_bind]
+  rfl
+
+/-- The environment version, where the same `r` is threaded to both sides. -/
+@[simp]
+theorem ReaderT.supportAt_bind {ρ : Type u} (r : ρ) (x : ReaderT ρ m α)
+    (f : α → ReaderT ρ m β) :
+    ReaderT.supportAt r (x >>= f)
+      = ⋃ a ∈ ReaderT.supportAt r x, ReaderT.supportAt r (f a) := by
+  rw [ReaderT.supportAt, ReaderT.run_bind, support_bind]
+  rfl
+
+@[simp]
+theorem StateT.supportFrom_map {σ : Type u} (s : σ) (g : α → β) (x : StateT σ m α) :
+    StateT.supportFrom s (g <$> x)
+      = (fun p => (g p.1, p.2)) '' StateT.supportFrom s x := by
+  rw [StateT.supportFrom, StateT.run_map, support_map]
+  rfl
+
+@[simp]
+theorem ReaderT.supportAt_map {ρ : Type u} (r : ρ) (g : α → β) (x : ReaderT ρ m α) :
+    ReaderT.supportAt r (g <$> x) = g '' ReaderT.supportAt r x := by
+  rw [ReaderT.supportAt, ReaderT.run_map, support_map]
+  rfl
+
+/-! #### Indexed judgments
+
+The modal pair, indexed. These are the primary indexed notions and `supportFrom` is
+their equality instance, exactly as `support` is `SomeOutput`'s in the unindexed case
+(`support_eq_setOf_someOutput`). The state-indexed predicate ranges over the *pair*: a
+`StateT` computation's outcome is a value together with a final state, and forgetting
+the state is what makes the flattened judgments fail to compose. -/
+
+/-- Every outcome reachable from `s` satisfies `p`. -/
+def StateT.AllOutputsFrom {σ : Type u} (s : σ) (p : α → σ → Prop) (x : StateT σ m α) : Prop :=
+  ∀ q ∈ StateT.supportFrom s x, p q.1 q.2
+
+/-- Some outcome reachable from `s` satisfies `p`. -/
+def StateT.SomeOutputFrom {σ : Type u} (s : σ) (p : α → σ → Prop) (x : StateT σ m α) : Prop :=
+  ∃ q ∈ StateT.supportFrom s x, p q.1 q.2
+
+/-- No outcome reachable from `s` satisfies `p`. -/
+def StateT.NoOutputFrom {σ : Type u} (s : σ) (p : α → σ → Prop) (x : StateT σ m α) : Prop :=
+  StateT.AllOutputsFrom s (fun a s' => ¬ p a s') x
+
+@[inherit_doc StateT.AllOutputsFrom]
+scoped notation:50 x:51 " ⊨ₐ[" s "] " p:51 => MonadAttach.StateT.AllOutputsFrom s p x
+
+@[inherit_doc StateT.SomeOutputFrom]
+scoped notation:50 x:51 " ⊨ₛ[" s "] " p:51 => MonadAttach.StateT.SomeOutputFrom s p x
+
+@[inherit_doc StateT.NoOutputFrom]
+scoped notation:50 x:51 " ⊭[" s "] " p:51 => MonadAttach.StateT.NoOutputFrom s p x
+
+omit [Monad m] [LawfulMonad m] [ExactMonadAttach m] in
+/-- `supportFrom` is the equality instance of the indexed angelic judgment — the indexed
+counterpart of `support_eq_setOf_someOutput`. -/
+theorem StateT.supportFrom_eq_setOf_someOutputFrom {σ : Type u} (s : σ) (x : StateT σ m α) :
+    StateT.supportFrom s x = {q | StateT.SomeOutputFrom s (fun a s' => (a, s') = q) x} :=
+  Set.ext fun q => ⟨fun hq => ⟨q, hq, rfl⟩, fun ⟨_, hb, hbq⟩ => hbq ▸ hb⟩
+
+@[simp]
+theorem StateT.allOutputsFrom_pure {σ : Type u} (s : σ) (p : α → σ → Prop) (a : α) :
+    StateT.AllOutputsFrom s p (pure a : StateT σ m α) ↔ p a s := by
+  simp [StateT.AllOutputsFrom]
+
+@[simp]
+theorem StateT.someOutputFrom_pure {σ : Type u} (s : σ) (p : α → σ → Prop) (a : α) :
+    StateT.SomeOutputFrom s p (pure a : StateT σ m α) ↔ p a s := by
+  simp [StateT.SomeOutputFrom]
+
+/-- The indexed demonic bind rule. This is the judgment-level form of
+`StateT.supportFrom_bind`, and like it needs no exactness on the transformer. -/
+@[simp]
+theorem StateT.allOutputsFrom_bind {σ : Type u} (s : σ) (p : β → σ → Prop)
+    (x : StateT σ m α) (f : α → StateT σ m β) :
+    StateT.AllOutputsFrom s p (x >>= f)
+      ↔ ∀ q ∈ StateT.supportFrom s x, StateT.AllOutputsFrom q.2 p (f q.1) := by
+  constructor
+  · intro h q hq a ha
+    exact h a (by rw [StateT.supportFrom_bind]; exact Set.mem_biUnion hq ha)
+  · intro h a ha
+    rw [StateT.supportFrom_bind] at ha
+    obtain ⟨q, hq, ha'⟩ := Set.mem_iUnion₂.mp ha
+    exact h q hq a ha'
+
+/-- The indexed angelic bind rule. -/
+@[simp]
+theorem StateT.someOutputFrom_bind {σ : Type u} (s : σ) (p : β → σ → Prop)
+    (x : StateT σ m α) (f : α → StateT σ m β) :
+    StateT.SomeOutputFrom s p (x >>= f)
+      ↔ ∃ q ∈ StateT.supportFrom s x, StateT.SomeOutputFrom q.2 p (f q.1) := by
+  simp only [StateT.SomeOutputFrom, StateT.supportFrom_bind, Set.mem_iUnion, exists_prop]
+  tauto
+
+omit [Monad m] [LawfulMonad m] [ExactMonadAttach m] in
+theorem StateT.not_someOutputFrom_iff_noOutputFrom {σ : Type u} (s : σ) (p : α → σ → Prop)
+    (x : StateT σ m α) :
+    ¬ StateT.SomeOutputFrom s p x ↔ StateT.NoOutputFrom s p x := by
+  simp [StateT.SomeOutputFrom, StateT.NoOutputFrom, StateT.AllOutputsFrom]
+
+omit [Monad m] [LawfulMonad m] [ExactMonadAttach m] in
+theorem StateT.allOutputsFrom_mono {σ : Type u} {s : σ} {p q : α → σ → Prop}
+    (h : ∀ a s', p a s' → q a s') {x : StateT σ m α}
+    (hx : StateT.AllOutputsFrom s p x) : StateT.AllOutputsFrom s q x :=
+  fun r hr => h r.1 r.2 (hx r hr)
+
+omit [LawfulMonad m] [ExactMonadAttach m] in
+/-- Indexed demonic implies flattened demonic: if `p` holds of every outcome from every
+initial state, it holds of every possible output. The converse fails, which is the
+content of the `StateT` counterexamples. -/
+theorem StateT.allOutputs_of_allOutputsFrom {σ : Type u} {p : α → Prop} {x : StateT σ m α}
+    (h : ∀ s, StateT.AllOutputsFrom s (fun a _ => p a) x) : AllOutputs p x :=
+  fun _ ⟨s, s', hs⟩ => h s (_, s') hs
 
 end Instances
 

--- a/PolyFun/Control/Monad/Support.lean
+++ b/PolyFun/Control/Monad/Support.lean
@@ -62,7 +62,7 @@ non-trivially. CPS encodings such as `PolyFun.Control.Monad.FreeContT` therefore
 
 @[expose] public section
 
-universe u v
+universe u v w
 
 /-- A monad whose `MonadAttach.CanReturn` predicate is *exact*: besides being the strongest
 postcondition (`LawfulMonadAttach`), it is closed under the monad's introduction rules, so
@@ -94,10 +94,60 @@ def support [MonadAttach m] (x : m α) : Set α :=
 
 Stated as a simp lemma because `Set.ofPred` and `Set.Mem` are `implicit_reducible`: `rfl`
 and `exact` see through them, but `simp`'s reducible-transparency discharge does not. -/
-@[simp]
+@[simp, grind =]
 theorem mem_support [MonadAttach m] {x : m α} {a : α} :
     a ∈ support x ↔ CanReturn x a :=
   Iff.rfl
+
+/-! ### Automation contract
+
+Two normal forms, one per layer, chosen so the two do not fight:
+
+* **Membership normalizes to `CanReturn`.** `mem_support` is `@[simp, grind =]`, so
+  `a ∈ support x` becomes the atomic reachability predicate, and the per-monad
+  `canReturn_iff` lemmas take it the rest of the way to a concrete equation. Those
+  lemmas key on `CanReturn`, not on membership, precisely so that they extend the
+  chain rather than race `mem_support` for the same left-hand side.
+* **Set-level laws produce `support` terms.** `support_pure`, `support_bind`,
+  `support_map` are `@[simp]`, so a structural goal is first decomposed at the set
+  level and only then unfolded pointwise.
+
+`grind` tags go on the *directed, single-variable* bridges only: membership
+unfoldings and the closed-form supports of `pure`/`none`/`error`. The
+characterizations that quantify over the support — `support_eq_empty_iff`,
+`support_nonempty_iff`, and the `AllOutputs`/`SomeOutput` iffs — stay `@[simp]`-only.
+Those are saturation hazards: `grind` case-splits the iff, Skolemizes the support
+quantifier into a fresh witness, and the always-tagged `bind` expansions turn that
+witness back into more `support` terms with no finite grounding. A proof that needs
+one re-supplies it locally, as `grind [allOutputs_iff_forall_support]`.
+
+### Emptiness and branching
+
+These need no exactness: they are about the shape of the `Set`, not about how the
+monad's operations act on it. -/
+
+theorem support_eq_empty_iff [MonadAttach m] {x : m α} :
+    support x = ∅ ↔ ∀ a, ¬ CanReturn x a := by
+  rw [Set.eq_empty_iff_forall_notMem]
+  exact Iff.rfl
+
+theorem support_nonempty_iff [MonadAttach m] {x : m α} :
+    (support x).Nonempty ↔ ∃ a, CanReturn x a :=
+  Iff.rfl
+
+theorem not_mem_support_iff [MonadAttach m] {x : m α} {a : α} :
+    a ∉ support x ↔ ¬ CanReturn x a :=
+  Iff.rfl
+
+@[simp]
+theorem support_ite [MonadAttach m] (c : Prop) [Decidable c] (x y : m α) :
+    support (if c then x else y) = if c then support x else support y := by
+  split <;> rfl
+
+@[simp]
+theorem support_dite [MonadAttach m] (c : Prop) [Decidable c] (x : c → m α) (y : ¬ c → m α) :
+    support (if h : c then x h else y h) = if h : c then support (x h) else support (y h) := by
+  split <;> rfl
 
 section Laws
 
@@ -132,6 +182,13 @@ theorem support_map (g : α → β) (x : m α) : support (g <$> x) = g '' suppor
   rw [← bind_pure_comp, support_bind]
   ext b
   simp [eq_comm]
+
+@[simp]
+theorem support_seq (f : m (α → β)) (x : m α) :
+    support (f <*> x) = ⋃ g ∈ support f, g '' support x := by
+  rw [seq_eq_bind_map, support_bind]
+  simp only [support_map]
+
 
 end Laws
 
@@ -220,6 +277,81 @@ theorem someOutput_mono {p q : α → Prop} (h : ∀ a, p a → q a) {x : m α}
 theorem noOutput_mono {p q : α → Prop} (h : ∀ a, q a → p a) {x : m α}
     (hx : NoOutput p x) : NoOutput q x :=
   fun a ha hqa => hx a ha (h a hqa)
+
+/-! #### Negation
+
+The pair is dual: the demonic judgment is the negation of the angelic one at the
+negated predicate, and conversely. Only one direction of this was available before. -/
+
+theorem not_allOutputs_iff (p : α → Prop) (x : m α) :
+    ¬ AllOutputs p x ↔ SomeOutput (fun a => ¬ p a) x := by
+  simp only [AllOutputs, SomeOutput, not_forall]
+  exact ⟨fun ⟨a, ha⟩ => ⟨a, by simpa using ha⟩, fun ⟨a, ha, hna⟩ => ⟨a, by simp [ha, hna]⟩⟩
+
+theorem not_noOutput_iff (p : α → Prop) (x : m α) :
+    ¬ NoOutput p x ↔ SomeOutput p x := by
+  rw [NoOutput, not_allOutputs_iff]
+  exact ⟨fun h => h.imp fun _ ⟨ha, hp⟩ => ⟨ha, not_not.mp hp⟩,
+    fun h => h.imp fun _ ⟨ha, hp⟩ => ⟨ha, not_not.mpr hp⟩⟩
+
+theorem someOutput_iff_not_noOutput (p : α → Prop) (x : m α) :
+    SomeOutput p x ↔ ¬ NoOutput p x :=
+  (not_noOutput_iff p x).symm
+
+theorem noOutput_iff_allOutputs_not (p : α → Prop) (x : m α) :
+    NoOutput p x ↔ AllOutputs (fun a => ¬ p a) x :=
+  Iff.rfl
+
+/-! #### Disjunction, conjunction, and monotonicity in the computation
+
+`allOutputs_and` was already available; these complete the square. Note the
+directions: the demonic judgment distributes over `∧` and only absorbs `∨`, and the
+angelic one is the mirror image. -/
+
+theorem someOutput_or (p q : α → Prop) (x : m α) :
+    SomeOutput (fun a => p a ∨ q a) x ↔ SomeOutput p x ∨ SomeOutput q x := by
+  constructor
+  · rintro ⟨a, ha, hp | hq⟩
+    · exact Or.inl ⟨a, ha, hp⟩
+    · exact Or.inr ⟨a, ha, hq⟩
+  · rintro (⟨a, ha, hp⟩ | ⟨a, ha, hq⟩)
+    · exact ⟨a, ha, Or.inl hp⟩
+    · exact ⟨a, ha, Or.inr hq⟩
+
+theorem allOutputs_or_of_left {p q : α → Prop} {x : m α} (h : AllOutputs p x) :
+    AllOutputs (fun a => p a ∨ q a) x :=
+  fun a ha => Or.inl (h a ha)
+
+theorem someOutput_and_left {p q : α → Prop} {x : m α}
+    (h : SomeOutput (fun a => p a ∧ q a) x) : SomeOutput p x :=
+  h.imp fun _ ⟨ha, hpq⟩ => ⟨ha, hpq.1⟩
+
+/-- Monotonicity in the *computation*, not the predicate: a demonic obligation
+transfers to anything with a smaller support. `allOutputs_mono` varies only the
+predicate. -/
+theorem allOutputs_of_support_subset {p : α → Prop} {x y : m α}
+    (hsub : support x ⊆ support y) (h : AllOutputs p y) : AllOutputs p x :=
+  fun a ha => h a (hsub ha)
+
+theorem someOutput_of_support_subset {p : α → Prop} {x y : m α}
+    (hsub : support x ⊆ support y) (h : SomeOutput p x) : SomeOutput p y :=
+  h.imp fun _ ⟨ha, hp⟩ => ⟨hsub ha, hp⟩
+
+@[simp]
+theorem allOutputs_true (x : m α) : AllOutputs (fun _ => True) x :=
+  fun _ _ => trivial
+
+@[simp]
+theorem someOutput_false_iff (x : m α) : SomeOutput (fun _ => False) x ↔ False := by
+  simp [SomeOutput]
+
+theorem allOutputs_congr {p q : α → Prop} (h : ∀ a, p a ↔ q a) (x : m α) :
+    AllOutputs p x ↔ AllOutputs q x :=
+  ⟨allOutputs_mono fun a => (h a).mp, allOutputs_mono fun a => (h a).mpr⟩
+
+theorem someOutput_congr {p q : α → Prop} (h : ∀ a, p a ↔ q a) (x : m α) :
+    SomeOutput p x ↔ SomeOutput q x :=
+  ⟨someOutput_mono fun a => (h a).mp, someOutput_mono fun a => (h a).mpr⟩
 
 end Judgments
 
@@ -335,6 +467,38 @@ def mAlgOrderedPropAngelic : MAlgOrdered m Prop where
     simp only [someOutput_bind]
     exact fun ⟨a, ha, h⟩ => ⟨a, ha, hfg a h⟩
 
+section Angelic
+
+attribute [local instance] mAlgOrderedPropAngelic
+
+/-- Support-based characterization of the angelic `Prop`-valued weakest precondition —
+the mirror of `wp_iff_forall_support`. -/
+theorem wp_angelic_iff_exists_support (x : m α) (post : α → Prop) :
+    MAlgOrdered.wp (l := Prop) x post ↔ ∃ a ∈ support x, post a := by
+  change SomeOutput id (x >>= fun a => pure (post a)) ↔ _
+  rw [someOutput_bind]
+  exact ⟨fun ⟨a, ha, h⟩ => ⟨a, ha, (someOutput_pure id (post a)).mp h⟩,
+    fun ⟨a, ha, h⟩ => ⟨a, ha, (someOutput_pure id (post a)).mpr h⟩⟩
+
+/-- The angelic `Prop`-valued weakest precondition is the "sometimes" judgment. -/
+theorem wp_angelic_iff_someOutput (x : m α) (post : α → Prop) :
+    MAlgOrdered.wp (l := Prop) x post ↔ SomeOutput post x :=
+  wp_angelic_iff_exists_support x post
+
+/-- The trivial-precondition angelic triple is exactly the "sometimes" judgment — the
+mirror of `triple_top_iff_allOutputs`. -/
+theorem triple_top_iff_someOutput (x : m α) (post : α → Prop) :
+    MAlgOrdered.Triple (l := Prop) ⊤ x post ↔ SomeOutput post x := by
+  rw [MAlgOrdered.Triple, top_le_iff, ← wp_angelic_iff_someOutput x post]
+  exact ⟨fun h => h ▸ trivial, fun h => eq_true h⟩
+
+/-- Against a negated postcondition the angelic triple is the negation of "never". -/
+theorem triple_top_not_iff_not_noOutput (x : m α) (post : α → Prop) :
+    MAlgOrdered.Triple (l := Prop) ⊤ x (fun a => ¬ post a) ↔ ¬ AllOutputs post x := by
+  rw [triple_top_iff_someOutput, ← not_allOutputs_iff]
+
+end Angelic
+
 end PropAlgebra
 
 /-! ## Recovering the `MonadLiftT` presentation
@@ -357,6 +521,50 @@ theorem toLawfulMonadLiftT (m : Type u → Type v) [Monad m] [LawfulMonad m] [Mo
   letI := toMonadLiftT m
   { monadLift_pure := fun a => support_pure a
     monadLift_bind := fun x f => support_bind x f }
+
+/-! ## Transport along a monad lift
+
+Core proves the elimination half — lifting cannot *create* possible outputs — so a
+lift can only shrink the support, and a demonic obligation therefore transfers along
+it for free.
+
+The introduction half is **not** available generically, and cannot be: nothing in
+`MonadLiftT` or its lawfulness class says the lift preserves reachability, and a lift
+into a monad whose `CanReturn` is uniformly `False` satisfies every law while losing
+every output. A caller that needs `support (liftM x) = support x` must supply that
+equation for its particular lift; `FreeM`'s powerset fold
+(`PFunctor.FreeM.support_eq_liftM_univ`) is the worked instance. -/
+
+section Transport
+
+variable {m : Type u → Type v} {n : Type u → Type w} {α : Type u}
+variable [Monad m] [LawfulMonad m] [MonadAttach m] [LawfulMonadAttach m]
+variable [Monad n] [LawfulMonad n] [MonadAttach n] [LawfulMonadAttach n]
+variable [MonadLiftT m n] [LawfulMonadLiftT m n]
+
+/-- Lifting cannot create possible outputs. The set form of core's
+`LawfulMonadAttach.canReturn_liftM_imp'`. -/
+theorem support_liftM_subset (x : m α) : support (liftM x : n α) ⊆ support x :=
+  fun _ h => LawfulMonadAttach.canReturn_liftM_imp' h
+
+/-- A demonic guarantee survives lifting: the lifted computation has no outputs the
+original did not have, so a property of all of the original's outputs holds of all of
+the lift's. -/
+theorem allOutputs_liftM {p : α → Prop} {x : m α} (h : AllOutputs p x) :
+    AllOutputs p (liftM x : n α) :=
+  fun a ha => h a (support_liftM_subset x ha)
+
+/-- Dually, an angelic fact about the lift transfers back to the original. -/
+theorem someOutput_of_someOutput_liftM {p : α → Prop} {x : m α}
+    (h : SomeOutput p (liftM x : n α)) : SomeOutput p x :=
+  h.imp fun _ ⟨ha, hp⟩ => ⟨support_liftM_subset x ha, hp⟩
+
+/-- And a "never" guarantee survives lifting. -/
+theorem noOutput_liftM {p : α → Prop} {x : m α} (h : NoOutput p x) :
+    NoOutput p (liftM x : n α) :=
+  fun a ha => h a (support_liftM_subset x ha)
+
+end Transport
 
 /-! ## Base instances
 
@@ -454,6 +662,82 @@ instance instExactMonadAttachExceptT {ε : Type u} : ExactMonadAttach (ExceptT �
         | Except.error e => pure (Except.error e) := rfl
     rw [hrun]
     exact ExactMonadAttach.canReturn_bind (a := Except.ok a) h h'
+
+/-! ### Per-monad unfoldings
+
+Each base monad's `CanReturn` is a concrete predicate, so membership in its support
+has a concrete spelling. Every one of these is `Iff.rfl`; naming them keeps callers
+from reaching through `support` and `CanReturn` with `change`. -/
+
+section Unfoldings
+
+variable {α : Type u}
+
+@[simp, grind =]
+theorem Id.canReturn_iff {x : Id α} {a : α} : CanReturn x a ↔ x.run = a :=
+  Iff.rfl
+
+@[simp]
+theorem Id.support_eq_singleton (x : Id α) : support x = {x.run} := by
+  ext a
+  rw [mem_support, Id.canReturn_iff, Set.mem_singleton_iff]
+  exact eq_comm
+
+@[simp, grind =]
+theorem Option.canReturn_iff {x : Option α} {a : α} : CanReturn x a ↔ x = some a :=
+  Iff.rfl
+
+@[simp, grind =]
+theorem Option.support_some (a : α) : support (some a) = {a} := by
+  ext b
+  rw [mem_support, Option.canReturn_iff, Set.mem_singleton_iff]
+  exact ⟨fun h => (Option.some.inj h).symm, fun h => by rw [h]⟩
+
+@[simp, grind =]
+theorem Option.support_none : support (none : Option α) = ∅ := by
+  ext b
+  rw [mem_support, Option.canReturn_iff]
+  simp
+
+@[simp, grind =]
+theorem Except.canReturn_iff {ε : Type u} {x : Except ε α} {a : α} :
+    CanReturn x a ↔ x = Except.ok a :=
+  Iff.rfl
+
+@[simp, grind =]
+theorem Except.support_ok {ε : Type u} (a : α) : support (Except.ok a : Except ε α) = {a} := by
+  ext b
+  rw [mem_support, Except.canReturn_iff, Set.mem_singleton_iff]
+  exact ⟨fun h => (Except.ok.inj h).symm, fun h => by rw [h]⟩
+
+@[simp, grind =]
+theorem Except.support_error {ε : Type u} (e : ε) :
+    support (Except.error e : Except ε α) = ∅ := by
+  ext b
+  rw [mem_support, Except.canReturn_iff]
+  simp
+
+@[simp, grind =]
+theorem SetM.canReturn_iff {x : SetM α} {a : α} : CanReturn x a ↔ a ∈ SetM.run x :=
+  Iff.rfl
+
+@[simp]
+theorem SetM.support_eq_run (x : SetM α) : support x = SetM.run x :=
+  Set.ext fun _ => Iff.rfl
+
+variable {m : Type u → Type v} [Monad m] [MonadAttach m]
+
+@[simp, grind =]
+theorem OptionT.canReturn_iff {x : OptionT m α} {a : α} :
+    CanReturn x a ↔ some a ∈ support x.run :=
+  Iff.rfl
+
+@[simp, grind =]
+theorem ExceptT.canReturn_iff {ε : Type u} {x : ExceptT ε m α} {a : α} :
+    CanReturn x a ↔ Except.ok a ∈ support x.run :=
+  Iff.rfl
+
+end Unfoldings
 
 /-! ### The writer transformer
 
@@ -593,12 +877,12 @@ theorem ReaderT.mem_support_iff_exists_supportAt {ρ : Type u} {x : ReaderT ρ m
     a ∈ support x ↔ ∃ r, a ∈ ReaderT.supportAt r x :=
   Iff.rfl
 
-@[simp]
+@[simp, grind =]
 theorem StateT.supportFrom_pure {σ : Type u} (s : σ) (a : α) :
     StateT.supportFrom s (pure a : StateT σ m α) = {(a, s)} := by
   rw [StateT.supportFrom, StateT.run_pure, support_pure]
 
-@[simp]
+@[simp, grind =]
 theorem ReaderT.supportAt_pure {ρ : Type u} (r : ρ) (a : α) :
     ReaderT.supportAt r (pure a : ReaderT ρ m α) = {a} := by
   rw [ReaderT.supportAt, ReaderT.run_pure, support_pure]

--- a/PolyFun/Control/Monad/Support.lean
+++ b/PolyFun/Control/Monad/Support.lean
@@ -173,6 +173,39 @@ theorem support_bind (x : m α) (f : α → m β) :
 theorem mem_support_pure {a b : α} : a ∈ support (pure b : m α) ↔ a = b := by
   simp
 
+/-! #### The structural laws on `CanReturn`
+
+The same three equations keyed on the reachability predicate rather than on set
+membership. `support_pure`/`support_bind`/`support_map` decompose a goal at the set
+level; these finish it pointwise, and they are what makes `CanReturn` a usable normal
+form rather than a dead end. Core supplies only the elimination halves
+(`eq_of_canReturn_pure`, `canReturn_bind_imp'`, `canReturn_map_imp'`); the
+introduction halves are exactly `ExactMonadAttach`'s two fields, so the equivalences
+need both classes.
+
+Their orientation matches the corresponding `mem_support_*` lemmas, so the two routes
+through the simp set — unfold membership first, or rewrite the set first — converge on
+the same normal form instead of racing. -/
+
+@[simp, grind =]
+theorem canReturn_pure_iff {a b : α} : CanReturn (pure b : m α) a ↔ a = b :=
+  ⟨fun h => (LawfulMonadAttach.eq_of_canReturn_pure h).symm,
+    fun h => by subst h; exact ExactMonadAttach.canReturn_pure _⟩
+
+@[simp, grind =]
+theorem canReturn_bind_iff {x : m α} {f : α → m β} {b : β} :
+    CanReturn (x >>= f) b ↔ ∃ a, CanReturn x a ∧ CanReturn (f a) b :=
+  ⟨LawfulMonadAttach.canReturn_bind_imp',
+    fun ⟨_, ha, hb⟩ => ExactMonadAttach.canReturn_bind ha hb⟩
+
+@[simp, grind =]
+theorem canReturn_map_iff {g : α → β} {x : m α} {b : β} :
+    CanReturn (g <$> x) b ↔ ∃ a, CanReturn x a ∧ g a = b :=
+  ⟨LawfulMonadAttach.canReturn_map_imp',
+    fun ⟨a, ha, hab⟩ => hab ▸ by
+      rw [← bind_pure_comp]
+      exact ExactMonadAttach.canReturn_bind ha (ExactMonadAttach.canReturn_pure _)⟩
+
 theorem mem_support_bind {x : m α} {f : α → m β} {b : β} :
     b ∈ support (x >>= f) ↔ ∃ a ∈ support x, b ∈ support (f a) := by
   simp
@@ -195,14 +228,20 @@ end Laws
 /-! ## Always / some / never output judgments -/
 
 /-- Every possible output of `x` satisfies `p` — the "always true" judgment.
-Definitionally the bounded quantifier `∀ a ∈ support x, p a`. -/
-def AllOutputs [MonadAttach m] (p : α → Prop) (x : m α) : Prop :=
-  ∀ a ∈ support x, p a
 
-/-- Some possible output of `x` satisfies `p`.
-Definitionally the bounded quantifier `∃ a ∈ support x, p a`. -/
+Stated over `CanReturn` rather than as a bounded quantifier over `support`, because the
+modality does not need a `Set`: it is `Prop`-valued and survives settings where the set
+of outputs is the wrong object, which is what happens for `StateT`. The two spellings
+are definitionally interchangeable — `allOutputs_iff_forall_support` and
+`allOutputs_iff_forall_canReturn` are both `Iff.rfl` — so nothing downstream has to
+choose. -/
+def AllOutputs [MonadAttach m] (p : α → Prop) (x : m α) : Prop :=
+  ∀ a, CanReturn x a → p a
+
+/-- Some possible output of `x` satisfies `p`. The angelic half of the pair; see
+`AllOutputs` for why it is stated over `CanReturn`. -/
 def SomeOutput [MonadAttach m] (p : α → Prop) (x : m α) : Prop :=
-  ∃ a ∈ support x, p a
+  ∃ a, CanReturn x a ∧ p a
 
 /-- No possible output of `x` satisfies `p` — the "never true" judgment. -/
 def NoOutput [MonadAttach m] (p : α → Prop) (x : m α) : Prop :=
@@ -503,8 +542,26 @@ end PropAlgebra
 
 /-! ## Recovering the `MonadLiftT` presentation
 
-Downstream libraries that phrase support as a monad lift into the powerset monad can
-register these; they are deliberately not instances, so that support reasoning does not
+`MonadAttach` is the canonical interface for reachability here: it is core's, it carries
+a lawfulness hierarchy, and core supplies instances for the transformers this library
+cares about. The `MonadLiftT m SetM` spelling below is a **compatibility shim for a
+downstream still phrased that way**, not the recommended API — register it locally when
+migrating, rather than building against it.
+
+Two things this does *not* say. `SetM` remains perfectly good as a **carrier**:
+`support : Set α` is unchanged, and `PFunctor.FreeM.support_eq_liftM_univ` — which
+genuinely folds into `SetM` as a monad — stays. What is being demoted is the lift as an
+*interface*. And unlike the probability layer's `PMF` retirement, there is no upstream
+force here: `SetM` is not being deprecated by Mathlib. This is a project standardizing
+on core's vocabulary, nothing more.
+
+One concrete argument for the direction, which is otherwise recorded nowhere:
+`support_eq_liftM_univ` is restricted to `{γ : Type uB}`, because `FreeM.liftM` pins the
+payload universe to the *direction* universe. `MonadAttach.support` on `FreeM P` carries
+no such restriction. The attach-based presentation is strictly more universe-polymorphic
+than the fold.
+
+The two declarations are deliberately not instances, so that support reasoning does not
 perturb monad-lift instance search. -/
 
 /-- The support map as a monad lift into `SetM`. Not an instance. -/

--- a/PolyFun/Control/Monad/Support.lean
+++ b/PolyFun/Control/Monad/Support.lean
@@ -48,8 +48,10 @@ Support is a *value*-level notion here. Core states the limitation directly: `Ca
 about how the state of the monad changes". Concretely, `StateT σ m` and `ReaderT ρ m` do
 have `MonadAttach` instances — quantifying existentially over the initial state — and those
 supports are canonical, so the elimination theory applies. But `ExactMonadAttach` is *false*
-for them: possible outputs do not compose along `bind` when the continuation may observe a
-state the prefix did not produce. Reason about those per run instead, via
+for them: flattened premises may choose unrelated initial indices on the two sides of a
+`bind`. For `StateT` this can let the continuation observe a state the prefix did not
+produce; for `ReaderT` it can let the two premises use different environments. Reason about
+those per run instead, via
 `mem_support_stateT_iff` / `mem_support_readerT_iff`; `PolyFunTest` pins the failure with a
 counterexample. Oracle- and state-relative supports belong at the specification layer
 (`PolyFun.PFunctor.Free.WP`), which indexes the notion by a per-operation answer assignment.
@@ -230,11 +232,11 @@ end Laws
 /-- Every possible output of `x` satisfies `p` — the "always true" judgment.
 
 Stated over `CanReturn` rather than as a bounded quantifier over `support`, because the
-modality does not need a `Set`: it is `Prop`-valued and survives settings where the set
-of outputs is the wrong object, which is what happens for `StateT`. The two spellings
-are definitionally interchangeable — `allOutputs_iff_forall_support` and
-`allOutputs_iff_forall_canReturn` are both `Iff.rfl` — so nothing downstream has to
-choose. -/
+modality does not need to expose a `Set` in its interface. This makes the same shape easy
+to index when a flattened set of values is too coarse, as for `StateT`; the indexed
+carrier there is still the honest set of value/final-state pairs. The two unindexed
+spellings are definitionally interchangeable — `allOutputs_iff_forall_support` and
+`allOutputs_iff_forall_canReturn` are both `Iff.rfl` — so nothing downstream has to choose. -/
 def AllOutputs [MonadAttach m] (p : α → Prop) (x : m α) : Prop :=
   ∀ a, CanReturn x a → p a
 
@@ -282,9 +284,8 @@ output exactly when "some output equals it" holds.
 The two presentations of the layer meet here. `support` is the `Set`-valued carrier and
 `AllOutputs`/`SomeOutput` are the demonic and angelic modalities over it; this equation
 says nothing is lost by reading the carrier off the modality instead. The modality is the
-more general of the two — it is `Prop`-valued and so survives settings where a `Set` of
-outputs is the wrong object, which is exactly what happens for `StateT` (see
-`mem_support_stateT_iff` and the indexed section). It is also what the weakest-precondition
+more flexible presentation: its shape can be indexed when a flattened set of values is
+too coarse, as in the `StateT` section below. It is also what the weakest-precondition
 bridge consumes: `MonadAttach.toWP` is built from `AllOutputs`, not from `support`. -/
 theorem support_eq_setOf_someOutput (x : m α) :
     support x = {a | SomeOutput (· = a) x} :=
@@ -319,8 +320,8 @@ theorem noOutput_mono {p q : α → Prop} (h : ∀ a, q a → p a) {x : m α}
 
 /-! #### Negation
 
-The pair is dual: the demonic judgment is the negation of the angelic one at the
-negated predicate, and conversely. Only one direction of this was available before. -/
+Classically, the pair is dual: the demonic judgment is the negation of the angelic one
+at the negated predicate, and conversely. Only one direction was available before. -/
 
 theorem not_allOutputs_iff (p : α → Prop) (x : m α) :
     ¬ AllOutputs p x ↔ SomeOutput (fun a => ¬ p a) x := by
@@ -531,8 +532,9 @@ theorem triple_top_iff_someOutput (x : m α) (post : α → Prop) :
   rw [MAlgOrdered.Triple, top_le_iff, ← wp_angelic_iff_someOutput x post]
   exact ⟨fun h => h ▸ trivial, fun h => eq_true h⟩
 
-/-- Against a negated postcondition the angelic triple is the negation of "never". -/
-theorem triple_top_not_iff_not_noOutput (x : m α) (post : α → Prop) :
+/-- Against a negated postcondition the angelic triple says that the demonic guarantee
+does not hold. -/
+theorem triple_top_not_iff_not_allOutputs (x : m α) (post : α → Prop) :
     MAlgOrdered.Triple (l := Prop) ⊤ x (fun a => ¬ post a) ↔ ¬ AllOutputs post x := by
   rw [triple_top_iff_someOutput, ← not_allOutputs_iff]
 
@@ -867,8 +869,8 @@ end WriterT
 
 `StateT` and `ReaderT` do have core `MonadAttach` instances, existentially quantified over
 the initial state or environment, and those supports are canonical. They are *not*
-`ExactMonadAttach`: possible outputs do not compose along `bind`, because the continuation
-may observe a state the prefix never produced. Reason per run instead. -/
+`ExactMonadAttach`: possible outputs do not compose along `bind`, because its flattened
+premises may be witnessed at different initial indices. Reason per run instead. -/
 
 omit [LawfulMonad m] [ExactMonadAttach m] in
 theorem mem_support_stateT_iff {σ : Type u} {x : StateT σ m α} {a : α} :
@@ -1062,12 +1064,27 @@ theorem StateT.allOutputsFrom_mono {σ : Type u} {s : σ} {p q : α → σ → P
   fun r hr => h r.1 r.2 (hx r hr)
 
 omit [LawfulMonad m] [ExactMonadAttach m] in
-/-- Indexed demonic implies flattened demonic: if `p` holds of every outcome from every
-initial state, it holds of every possible output. The converse fails, which is the
-content of the `StateT` counterexamples. -/
+/-- Indexed demonic implies flattened demonic: if a value-only `p` holds of every outcome
+from every initial state, it holds of every possible output. -/
 theorem StateT.allOutputs_of_allOutputsFrom {σ : Type u} {p : α → Prop} {x : StateT σ m α}
     (h : ∀ s, StateT.AllOutputsFrom s (fun a _ => p a) x) : AllOutputs p x :=
   fun _ ⟨s, s', hs⟩ => h s (_, s') hs
+
+omit [LawfulMonad m] [ExactMonadAttach m] in
+/-- A flattened value-only guarantee holds at every initial state. Flattening loses the
+ability to mention the final state, but it loses nothing for postconditions on values
+alone. -/
+theorem StateT.allOutputsFrom_of_allOutputs {σ : Type u} {p : α → Prop} {x : StateT σ m α}
+    (h : AllOutputs p x) (s : σ) : StateT.AllOutputsFrom s (fun a _ => p a) x :=
+  fun q hq => h q.1 ⟨s, q.2, hq⟩
+
+omit [LawfulMonad m] [ExactMonadAttach m] in
+/-- For value-only postconditions, flattened demonic support is exactly the universal
+closure of the indexed judgment. -/
+theorem StateT.allOutputs_iff_forall_allOutputsFrom {σ : Type u} {p : α → Prop}
+    {x : StateT σ m α} :
+    AllOutputs p x ↔ ∀ s, StateT.AllOutputsFrom s (fun a _ => p a) x :=
+  ⟨fun h s => StateT.allOutputsFrom_of_allOutputs h s, StateT.allOutputs_of_allOutputsFrom⟩
 
 end Instances
 

--- a/PolyFun/PFunctor/Free/Support.lean
+++ b/PolyFun/PFunctor/Free/Support.lean
@@ -142,8 +142,12 @@ theorem allOutputs_liftBind (p : α → Prop) (a : P.A) (r : P.B a → FreeM P �
 @[freeM_unfold]
 theorem someOutput_liftBind (p : α → Prop) (a : P.A) (r : P.B a → FreeM P α) :
     SomeOutput p (FreeM.liftBind a r) ↔ ∃ b, SomeOutput p (r b) := by
-  simp only [SomeOutput, support_liftBind, Set.mem_iUnion]
-  aesop
+  constructor
+  · rintro ⟨c, hc, hpc⟩
+    obtain ⟨b, hb⟩ := mem_support_liftBind.mp hc
+    exact ⟨b, c, hb, hpc⟩
+  · rintro ⟨b, c, hc, hpc⟩
+    exact ⟨c, mem_support_liftBind.mpr ⟨b, hc⟩, hpc⟩
 
 @[freeM_unfold]
 theorem noOutput_liftBind (p : α → Prop) (a : P.A) (r : P.B a → FreeM P α) :

--- a/PolyFun/PFunctor/Free/WP.lean
+++ b/PolyFun/PFunctor/Free/WP.lean
@@ -413,7 +413,9 @@ theorem allOutputs_liftM_of_wpFold {Φ : OpSpec Q Prop} (s : Handler n Q)
 
 /-- The demonic fold at the *canonical* spec already implies the interpreted guarantee,
 whenever the handler validates that spec. Specializes the previous theorem to
-`OpSpec.demonic`, whose hypothesis says the handler's every answer is possible. -/
+`OpSpec.demonic`: the handler must establish every postcondition that holds for all typed
+responses. This constrains its outputs to the operation's response type; it does not claim
+that the handler can produce every response. -/
 theorem allOutputs_liftM_of_allOutputs (s : Handler n Q)
     (h : ∀ (a : Q.A) (k : Q.B a → Prop), (∀ b, k b) → MAlgOrdered.wp (s a) k)
     (x : FreeM Q α) (post : α → Prop) (hx : AllOutputs post x) :

--- a/PolyFun/PFunctor/Free/WP.lean
+++ b/PolyFun/PFunctor/Free/WP.lean
@@ -369,6 +369,60 @@ theorem wpFold_demonic_not_iff_noOutput (x : FreeM P α) (post : α → Prop) :
 
 end Support
 
+/-! ## Coherence with the interpreted program's support
+
+The section above relates the syntactic fold to the support of the *free tree*. This one
+closes the other half: it relates the semantic `wpVia` to the support of the *interpreted*
+program, which is what a handler-specification consumer actually reasons about.
+
+The carrier is `Prop`, so these live at the ground direction universe: `MAlgOrdered m l`
+forces `l : Type uB`, and `Prop : Type 0`. -/
+
+section SemanticSupport
+
+open MonadAttach
+
+variable {Q : PFunctor.{uA, 0}} {n : Type → Type w}
+  [Monad n] [LawfulMonad n] [MonadAttach n] [ExactMonadAttach n] {α : Type}
+
+attribute [local instance] MonadAttach.mAlgOrderedPropDemonic
+
+/-- **The semantic keystone.** `wpVia` is by definition the algebra's `wp` of the
+interpreted program, so under the demonic `Prop` algebra it *is* the "always" judgment on
+that program. One rewrite, but it is the step that turns every statement about `wpVia`
+into a statement about which outputs the interpreted program can actually return. -/
+theorem wpVia_demonic_iff_allOutputs (s : Handler n Q) (x : FreeM Q α) (post : α → Prop) :
+    wpVia s x post ↔ AllOutputs post (x.liftM s) :=
+  wp_iff_allOutputs _ post
+
+/-- The angelic companion. -/
+theorem wpVia_angelic_iff_someOutput (s : Handler n Q) (x : FreeM Q α) (post : α → Prop) :
+    letI := MonadAttach.mAlgOrderedPropAngelic (m := n)
+    wpVia s x post ↔ SomeOutput post (x.liftM s) :=
+  wp_angelic_iff_someOutput _ post
+
+/-- **Specs discharge support facts about the interpreted program.** Composing the
+keystone with `wpFold_le_wpVia`: a per-operation spec that under-approximates the
+handler's `wp` turns a syntactic fold into a guarantee about every output the handler
+can actually produce. This is the shape a handler-specification layer consumes. -/
+theorem allOutputs_liftM_of_wpFold {Φ : OpSpec Q Prop} (s : Handler n Q)
+    (h : ∀ (a : Q.A) (k : Q.B a → Prop), Φ a k ≤ MAlgOrdered.wp (s a) k)
+    (x : FreeM Q α) (post : α → Prop) (hx : wpFold Φ x post) :
+    AllOutputs post (x.liftM s) :=
+  (wpVia_demonic_iff_allOutputs s x post).mp (wpFold_le_wpVia s h x post hx)
+
+/-- The demonic fold at the *canonical* spec already implies the interpreted guarantee,
+whenever the handler validates that spec. Specializes the previous theorem to
+`OpSpec.demonic`, whose hypothesis says the handler's every answer is possible. -/
+theorem allOutputs_liftM_of_allOutputs (s : Handler n Q)
+    (h : ∀ (a : Q.A) (k : Q.B a → Prop), (∀ b, k b) → MAlgOrdered.wp (s a) k)
+    (x : FreeM Q α) (post : α → Prop) (hx : AllOutputs post x) :
+    AllOutputs post (x.liftM s) :=
+  allOutputs_liftM_of_wpFold s h x post
+    ((wpFold_demonic_iff_allOutputs x post).mpr hx)
+
+end SemanticSupport
+
 end FreeM
 
 end PFunctor

--- a/PolyFunTest/Control/MonadAttach.lean
+++ b/PolyFunTest/Control/MonadAttach.lean
@@ -197,6 +197,94 @@ example {m : Type → Type v} [Monad m] [MonadAttach m] {σ α : Type} (x : Stat
     (a : α) : a ∈ support x ↔ ∃ s s', (a, s') ∈ support (x.run s) :=
   mem_support_stateT_iff
 
+/-! ### The indexed form repairs both failures
+
+The two failures above are failures of *flattening*, not of `StateT`: `CanReturn` picks an
+initial state existentially and picks it independently on each side of a `bind`. Indexing by
+the initial state removes that freedom, and both introduction rules come back. -/
+
+/-- The introduction rule the flattened support lacks. `StateT.supportFrom_bind` is an
+equation, so in particular the ⊇ direction holds: an outcome of the prefix followed by an
+outcome of the continuation *from the state the prefix produced* is an outcome of the bind.
+The flattened `canReturn_bind` above is exactly this with the two states decoupled. -/
+example {m : Type → Type v} [Monad m] [LawfulMonad m] [MonadAttach m] [ExactMonadAttach m]
+    {σ α β : Type} (s : σ) (x : StateT σ m α) (f : α → StateT σ m β)
+    {a : α} {s' : σ} {b : β} {s'' : σ}
+    (h : (a, s') ∈ StateT.supportFrom s x)
+    (h' : (b, s'') ∈ StateT.supportFrom s' (f a)) :
+    (b, s'') ∈ StateT.supportFrom s (x >>= f) := by
+  rw [StateT.supportFrom_bind]
+  exact Set.mem_biUnion h h'
+
+/-- On the very data that refutes `canReturn_bind`, the indexed law gives the right answer:
+the continuation is run only from `true`, the state the prefix actually produces, so the
+disagreeing value is not reachable. -/
+example : ((false, false) : Bool × Bool) ∉
+    StateT.supportFrom (m := Id) (σ := Bool) true (fun s => (s, s)) := fun h =>
+  Bool.noConfusion (congrArg Prod.fst (h : ((true, true) : Bool × Bool) = (false, false)))
+
+/-- The `pure` rule also comes back: there is no initial state to quantify over, because the
+initial state is an argument. Compare the `StateT Empty Id` failure above. -/
+example {m : Type → Type v} [Monad m] [LawfulMonad m] [MonadAttach m] [ExactMonadAttach m]
+    {σ α : Type} (s : σ) (a : α) :
+    StateT.supportFrom s (pure a : StateT σ m α) = {(a, s)} :=
+  StateT.supportFrom_pure s a
+
+/-! ### `ReaderT` fails for the same reason
+
+The `ReaderT` claim was previously asserted but not pinned. It fails only through the empty
+environment — with the same `r` threaded to both sides of a `bind`, the environment version
+of the composition rule is fine, which is why `ReaderT.supportAt_bind` needs no side
+condition. -/
+
+/-- `pure` has empty support over an empty environment: there is no environment to run in. -/
+example (a : Nat) : ¬ CanReturn (m := ReaderT Empty Id) (pure a) a := by
+  rintro ⟨r, -⟩
+  exact r.elim
+
+/-- Indexed by the environment, `pure` behaves. -/
+example {m : Type → Type v} [Monad m] [LawfulMonad m] [MonadAttach m] [ExactMonadAttach m]
+    {ρ α : Type} (r : ρ) (a : α) :
+    ReaderT.supportAt r (pure a : ReaderT ρ m α) = {a} :=
+  ReaderT.supportAt_pure r a
+
+/-! ### Why `ExactMonadAttach` has to exist
+
+`LawfulMonadAttach` bounds the support from one side only: every core law is an implication
+*out of* `CanReturn`, so a uniformly-`False` predicate satisfies all of them vacuously. The
+model below is the one the `ExactMonadAttach` docstring appeals to. Its mirror image is
+`MonadAttach.trivial`, whose `CanReturn` is uniformly `True` and which core itself documents
+as having no `LawfulMonadAttach` instance — so the two classes exclude the two degenerate
+models from opposite sides. -/
+
+/-- The constantly-`PUnit` monad, whose every law holds by `PUnit` eta. -/
+private def PUnitM (_ : Type) : Type := PUnit
+
+private instance : Monad PUnitM where
+  pure _ := PUnit.unit
+  bind _ _ := PUnit.unit
+
+private instance : LawfulMonad PUnitM :=
+  LawfulMonad.mk' _ (fun _ => rfl) (fun _ _ => rfl) (fun _ _ _ => rfl)
+
+/-- `CanReturn` uniformly `False` — no value is ever a possible output. -/
+private instance : MonadAttach PUnitM where
+  CanReturn _ _ := False
+  attach _ := PUnit.unit
+
+/-- And it is *lawful*: both fields are discharged without saying anything about outputs.
+This is why the introduction rules cannot be derived and must be assumed. -/
+private instance : LawfulMonadAttach PUnitM where
+  map_attach := rfl
+  canReturn_map_imp h := h.elim
+
+/-- The support of every computation in that model is empty, including `pure`. So
+`LawfulMonadAttach` alone does not pin the support: `ExactMonadAttach.canReturn_pure` is
+exactly what rules this out. -/
+example (a : Nat) : support (pure a : PUnitM Nat) = ∅ := rfl
+
+example (a : Nat) : ¬ CanReturn (pure a : PUnitM Nat) a := id
+
 end StatefulCounterexamples
 
 section TrivialTriple

--- a/PolyFunTest/Control/MonadAttach.lean
+++ b/PolyFunTest/Control/MonadAttach.lean
@@ -16,8 +16,9 @@ judgments must stay `Iff.rfl`-convertible both to their bounded-quantifier spell
 They also exercise the scoped `⊨ₐ` / `⊨ₛ` / `⊭` notation, the structural recursion of the
 judgments over free-monad trees, and `MonadAttach.pbind`.
 
-The `StateT` section is the executable justification for `StateT σ m` having a `MonadAttach`
-instance but *not* an `ExactMonadAttach` one: both introduction rules genuinely fail there.
+The stateful section is the executable justification for the canonical `MonadAttach`
+instances of `StateT` and `ReaderT` not being `ExactMonadAttach`: flattening their initial
+indices makes the bind introduction rule genuinely fail.
 -/
 
 @[expose] public section
@@ -232,10 +233,25 @@ example {m : Type → Type v} [Monad m] [LawfulMonad m] [MonadAttach m] [ExactMo
 
 /-! ### `ReaderT` fails for the same reason
 
-The `ReaderT` claim was previously asserted but not pinned. It fails only through the empty
-environment — with the same `r` threaded to both sides of a `bind`, the environment version
-of the composition rule is fine, which is why `ReaderT.supportAt_bind` needs no side
-condition. -/
+The flattened premises may choose different environments. The bind below has no `true`
+output: at `false` the prefix selects the `false` branch of the continuation, while at
+`true` it selects the `true` branch. Yet `false` is reachable from the prefix at one
+environment and `true` is reachable from its continuation at the other. Indexing fixes
+this by threading the same environment through both sides. -/
+
+/-- Possible outputs do not compose for flattened `ReaderT` support, even over a nonempty
+environment. -/
+example : ¬ (∀ {α β : Type} {x : ReaderT Bool Id α} {f : α → ReaderT Bool Id β}
+      {a : α} {b : β}, CanReturn x a → CanReturn (f a) b → CanReturn (x >>= f) b) := by
+  intro h
+  have hx : CanReturn (m := ReaderT Bool Id) (fun r => r) false := ⟨false, rfl⟩
+  have hf : CanReturn (m := ReaderT Bool Id) (fun r => !false && r) true := ⟨true, rfl⟩
+  obtain ⟨r, hr⟩ := h (x := fun r => r) (f := fun a r => !a && r) hx hf
+  cases r
+  · change (!false && false = true) at hr
+    contradiction
+  · change (!true && true = true) at hr
+    contradiction
 
 /-- `pure` has empty support over an empty environment: there is no environment to run in. -/
 example (a : Nat) : ¬ CanReturn (m := ReaderT Empty Id) (pure a) a := by
@@ -289,21 +305,19 @@ end StatefulCounterexamples
 
 section AutomationBattery
 
-/-! The living gate for the automation contract in `Control/Monad/Support.lean`. Each
-row is closed by a single terminal tactic, so a regression in either `simp` or `grind`
-surfaces here in isolation rather than inside a downstream proof. -/
+/-! A compact living gate for the automation contract in `Control/Monad/Support.lean`.
+Each distinct normalization path is closed by one terminal tactic; testing every goal
+twice with both tactics would add volume without distinguishing regressions. -/
 
 variable {m : Type → Type v} [Monad m] [LawfulMonad m] [MonadAttach m] [ExactMonadAttach m]
 
--- Membership normalizes to `CanReturn`, then to a concrete equation, under both tactics.
+-- Membership normalizes to `CanReturn`, then to a concrete equation.
 example (a b : Nat) : a ∈ support (pure b : Option Nat) ↔ a = b := by simp
-example (a b : Nat) : a ∈ support (pure b : Option Nat) ↔ a = b := by grind
 
-example (a : Nat) : support (some a) = {a} := by simp
+-- The directed closed-form rule is also available to `grind`.
 example (a : Nat) : support (some a) = {a} := by grind
 
 example : support (none : Option Nat) = ∅ := by simp
-example : support (none : Option Nat) = ∅ := by grind
 
 -- Set-level structure decomposes before pointwise unfolding.
 example (x : m Nat) (f : Nat → m Bool) :
@@ -314,9 +328,6 @@ example (g : Nat → Bool) (x : m Nat) : support (g <$> x) = g '' support x := b
 -- The indexed layer computes too.
 example {σ : Type} (s : σ) (a : Nat) :
     StateT.supportFrom s (pure a : StateT σ m Nat) = {(a, s)} := by simp
-
-example {σ : Type} (s : σ) (a : Nat) :
-    StateT.supportFrom s (pure a : StateT σ m Nat) = {(a, s)} := by grind
 
 -- The writer layer, which had no support at all before.
 example {ω : Type} [Monoid ω] (a : Nat) (w : ω) (x : WriterT ω m Nat)

--- a/PolyFunTest/Control/MonadAttach.lean
+++ b/PolyFunTest/Control/MonadAttach.lean
@@ -287,6 +287,53 @@ example (a : Nat) : ¬ CanReturn (pure a : PUnitM Nat) a := id
 
 end StatefulCounterexamples
 
+section AutomationBattery
+
+/-! The living gate for the automation contract in `Control/Monad/Support.lean`. Each
+row is closed by a single terminal tactic, so a regression in either `simp` or `grind`
+surfaces here in isolation rather than inside a downstream proof. -/
+
+variable {m : Type → Type v} [Monad m] [LawfulMonad m] [MonadAttach m] [ExactMonadAttach m]
+
+-- Membership normalizes to `CanReturn`, then to a concrete equation, under both tactics.
+example (a b : Nat) : a ∈ support (pure b : Option Nat) ↔ a = b := by simp
+example (a b : Nat) : a ∈ support (pure b : Option Nat) ↔ a = b := by grind
+
+example (a : Nat) : support (some a) = {a} := by simp
+example (a : Nat) : support (some a) = {a} := by grind
+
+example : support (none : Option Nat) = ∅ := by simp
+example : support (none : Option Nat) = ∅ := by grind
+
+-- Set-level structure decomposes before pointwise unfolding.
+example (x : m Nat) (f : Nat → m Bool) :
+    support (x >>= f) = ⋃ a ∈ support x, support (f a) := by simp
+
+example (g : Nat → Bool) (x : m Nat) : support (g <$> x) = g '' support x := by simp
+
+-- The indexed layer computes too.
+example {σ : Type} (s : σ) (a : Nat) :
+    StateT.supportFrom s (pure a : StateT σ m Nat) = {(a, s)} := by simp
+
+example {σ : Type} (s : σ) (a : Nat) :
+    StateT.supportFrom s (pure a : StateT σ m Nat) = {(a, s)} := by grind
+
+-- The writer layer, which had no support at all before.
+example {ω : Type} [Monoid ω] (a : Nat) (w : ω) (x : WriterT ω m Nat)
+    (h : (a, w) ∈ support x.run) : a ∈ support x := by grind [mem_support_writerT_iff]
+
+/-! The support-quantifier characterizations are deliberately kept out of `grind`'s
+default set, so a naive `grind` on a support goal fails fast rather than saturating.
+They remain available by explicit opt-in. -/
+
+example (p : Nat → Prop) (x : m Nat) (h : ∀ a ∈ support x, p a) : AllOutputs p x := by
+  grind [allOutputs_iff_forall_support]
+
+example (p : Nat → Prop) (x : m Nat) (h : SomeOutput p x) : ¬ NoOutput p x := by
+  grind [not_noOutput_iff]
+
+end AutomationBattery
+
 section TrivialTriple
 
 variable {m : Type → Type v} [Monad m] [LawfulMonad m] [MonadAttach m] [ExactMonadAttach m]

--- a/docs/reading/program-logic-landscape.md
+++ b/docs/reading/program-logic-landscape.md
@@ -127,3 +127,41 @@ implemented).
 - The ε-additive approximate-triple algebra (ArkLib's sequencing blocker).
 - Optional `MonadFinSupport` (Finset-valued support, generalizing VCVio's
   `HasEvalFinset`).
+
+## The `SetM` migration contract
+
+`MonadAttach` is the canonical interface for reachability; the `MonadLiftT m SetM`
+spelling is a compatibility shim for a downstream still phrased that way. This section
+records what such a downstream needs, so the migration does not have to be re-derived.
+
+**What already exists here.** `MonadAttach.toMonadLiftT` / `toLawfulMonadLiftT`
+(`Control/Monad/Support.lean`) are the shim itself — deliberately not instances.
+`MonadAttach.SetM.support_eq_run` and `SetM.canReturn_iff` are the carrier bridges.
+`support_liftM_subset` plus `allOutputs_liftM` / `someOutput_of_someOutput_liftM` /
+`noOutput_liftM` are the generically-true half of lift transport.
+`PFunctor.FreeM.support_eq_liftM_univ` is the worked *introduction* instance — the half
+that is not generic, since nothing in `MonadLiftT`'s lawfulness says a lift preserves
+reachability.
+
+**Two real obstructions, both outside this repo.**
+
+1. **`MonadAttach PMF` and `MonadAttach SPMF` do not exist anywhere** — not in the
+   pinned Mathlib, not here, not downstream. Any bridge from a probability-flavoured
+   support to the attach-based one goes through them, so they are the pivotal missing
+   piece rather than a rename. `SPMF := OptionT PMF`, so a `MonadAttach PMF` yields
+   `SPMF` for free through core's `OptionT` instance; the work is `attach`, for which
+   `PMF.bindOnSupport` is the nearest primitive.
+2. **A consumer pinning a PolyFun release predating `Control/Monad/Support.lean`
+   cannot see any of this.** The whole layer landed after the `v4.33.2` tag. A tag bump
+   is a hard prerequisite, not a detail.
+
+**What will not migrate.** An answer-set-indexed support — the `supportWhen` shape,
+where a per-oracle answer assignment is supplied — needs `SetM` as a genuine monad and
+is a different notion from `MonadAttach.support`. Its home here is the specification
+layer (`PFunctor/Free/WP.lean`), which indexes by a per-operation answer assignment.
+
+**No boundary guard is proposed.** The probability layer's `PMF` guard justifies itself
+from the pinned tree, where Mathlib is dismantling `PMF` construction by construction.
+`SetM` is not being retired upstream at all, and PolyFun's own `SetM` surface is 17
+occurrences across three files. The direction is set by documentation and by which API
+new code is written against, not by CI.

--- a/docs/wiki/program-logic.md
+++ b/docs/wiki/program-logic.md
@@ -68,9 +68,10 @@ the demonic/angelic `wpFold` (`wpFold_demonic_iff_allOutputs`).
 `StateT` and `ReaderT` do carry core's canonical support — the union over initial
 states — so the elimination theory applies to them, but they are deliberately
 *not* `ExactMonadAttach`: possible outputs do not compose along `bind` when the
-continuation may observe a state the prefix never produced. The test suite proves
-both introduction rules fail there. Reason per run instead, via
-`mem_support_stateT_iff`. Oracle- and state-relative supports belong at the
+flattened premises choose unrelated initial indices. For `StateT`, the continuation
+may observe a state the prefix never produced; for `ReaderT`, the two premises may use
+different environments. The test suite pins both failures. Reason per run instead, via
+`StateT.supportFrom` and `ReaderT.supportAt`. Oracle- and state-relative supports belong at the
 specification layer (`PFunctor/Free/WP.lean`), which indexes the notion by a
 per-operation answer assignment.
 

--- a/docs/wiki/program-logic.md
+++ b/docs/wiki/program-logic.md
@@ -52,7 +52,9 @@ the `FreeM P` instance.
 For `[MonadAttach m]` and `x : m α` (`open scoped MonadAttach`):
 
 - `x ⊨ₐ p` (`AllOutputs p x`): every possible output satisfies `p` —
-  definitionally `∀ a ∈ support x, p a`.
+  definitionally `∀ a, CanReturn x a → p a`, and equally
+  `∀ a ∈ support x, p a`: the two spellings are interchangeable by `Iff.rfl`
+  (`allOutputs_iff_forall_canReturn`, `allOutputs_iff_forall_support`).
 - `x ⊨ₛ p` (`SomeOutput p x`): some possible output satisfies `p`.
 - `x ⊭ p` (`NoOutput p x`): no possible output satisfies `p`.
 
@@ -78,6 +80,24 @@ support partial correctness distinct from the existing failure-as-`⊥`
 `OptionT`/`ExceptT` algebras and prevents inequivalent left/right transformer
 instance paths. Install the intended algebra locally at each verification
 boundary.
+
+## Support: which interface is canonical
+
+`MonadAttach` is the canonical interface for reachability — it is core's, it carries a
+lawfulness hierarchy, and core supplies the transformer instances. The
+`MonadLiftT m SetM` presentation (`MonadAttach.toMonadLiftT`, deliberately not an
+instance) is a **compatibility shim for a downstream still phrased that way**, not the
+recommended API.
+
+`SetM` is fine as a *carrier*: `support : Set α` is unchanged, and
+`PFunctor.FreeM.support_eq_liftM_univ` — a genuine fold into `SetM`-as-monad — stays.
+What is demoted is the lift as an interface. Note this is a project standardization,
+**not** an upstream retirement: unlike `PMF` in the probability layer, `SetM` is not
+being deprecated by Mathlib, so there is no boundary guard and none is proposed.
+
+The migration contract for a downstream — what bridges exist, and the two real
+obstructions — is in
+[`docs/reading/program-logic-landscape.md`](../reading/program-logic-landscape.md).
 
 ## The `Std.Do` quarantine
 


### PR DESCRIPTION
## Summary

This PR completes PolyFun's qualitative support layer around Lean core's `MonadAttach`.
It adds exact indexed support for stateful transformers, an honest `WriterT` instance,
a fuller structural and modal API, and the bridge from free-program weakest
preconditions to the support of interpreted programs.

The change is additive apart from documentation/proof cleanup: 7 files, 928 insertions,
26 deletions.

## What changes

### Exact and indexed support

- Adds structural equations and automation for `CanReturn` / `support`: pure, bind, map,
  sequence, branching, emptiness, and concrete base-monad unfoldings.
- Adds `StateT.supportFrom` and `ReaderT.supportAt`. Their bind laws keep the same initial
  index through the computation, so they compose exactly even though core's flattened
  transformer support does not.
- Adds state-indexed `AllOutputsFrom`, `SomeOutputFrom`, and `NoOutputFrom`, including
  pure/bind laws and the exact bridge back to flattened value-only guarantees.

### `WriterT`

- Adds `MonadAttach`, `WeaklyLawfulMonadAttach`, `LawfulMonadAttach`, and
  `ExactMonadAttach` for `WriterT`.
- Reachability retains an existential writer accumulator; bind combines witnessed
  accumulators in the transformer's actual multiplication order.

### Modal and WP bridges

- Completes the demonic/angelic `AllOutputs` / `SomeOutput` API, including support
  characterizations, classical duality laws, monotonicity, and the angelic ordered
  monad algebra.
- Adds support transport facts along monad lifts.
- Relates `FreeM.wpVia` to the support of the interpreted program and turns validated
  per-operation specs into `AllOutputs` facts about `liftM`.
- Lowers the assumptions of `ensures_of_allOutputs` and `toWPSound` to the weak
  `MonadAttach` law actually used.

### Tests and documentation

- Pins the `StateT` and `ReaderT` non-exactness boundaries, including a nonempty
  `ReaderT Bool` bind counterexample.
- Pins indexed recovery, the lawful-but-empty `CanReturn` model, WriterT behavior,
  definitional transfer, and a compact set of discriminating `simp` / `grind` canaries.
- Documents `MonadAttach` as the canonical reachability interface and the `SetM` lift
  as a compatibility bridge rather than a new global instance.

## Review follow-up

A full Lean-formalization review found and repaired four issues before merge:

1. The original explanation said `ReaderT` failed only for an empty environment. In
   fact flattened bind composition can fail over a nonempty environment because its two
   premises may choose different readers. The docs are corrected and a concrete
   `ReaderT Bool Id` counterexample now guards this boundary.
2. The indexed-to-flattened `StateT` bridge was described as strictly one-way. For
   postconditions that ignore final state it is an equivalence; both directions and the
   iff theorem are now exposed.
3. One `wpVia` comment incorrectly described a universal handler postcondition as saying
   every response is reachable. It now states the actual typed-output obligation.
4. A newly added angelic-triple theorem was named/documented as a negation of
   `NoOutput` while its statement correctly negated `AllOutputs`. The declaration now
   matches its theorem, and the classical status of the De Morgan laws is explicit.

Redundant duplicate automation examples were also removed; distinct normalization paths
remain covered.

## Validation

At commit `73de11dac10bf7e7fced6f71788c61fce5831d0a`:

- `./scripts/validate.sh --lint --test --axioms`
  - library build: 1,519 jobs
  - test library: 1,622 jobs
  - axiom sweep: 10,321 declarations across 259 modules
  - zero `sorry` taint and zero nonstandard-axiom taint
- `lake exe lint-style`
- `git diff --check`

All local checks pass.

## Scope

This does not add probability-specific support (`PMF` / `SPMF`), concrete downstream
handler specs, global `WP` instances for `FreeM`, or any CSLib changes.
