### PR TITLE
feat(itree): loop-invariant rule for `forInLoop`, and pin the angelic WP obstruction

### DIFF
--- a/PolyFun/Control/Do/Basic.lean
+++ b/PolyFun/Control/Do/Basic.lean
@@ -38,11 +38,30 @@ Downstream libraries choose where to register these (scoped or local); a global
 instance here would clash with registrations on reducible unfoldings of the same
 monads downstream.
 
+The demonic reading is the *only* one expressible here, and the reason is
+structural. `Std.Do.PredTrans` carries conjunctivity as a structure field, stated
+as a bi-entailment `t (Q₁ ∧ₚ Q₂) ⊣⊢ₛ t Q₁ ∧ t Q₂`. `AllOutputs` distributes over
+`∧` in both directions, so `toWP` can discharge it; `SomeOutput` distributes only
+left-to-right, since two different outputs may witness the two conjuncts
+separately. There is therefore no angelic `Std.Do.WP`, and the angelic reading
+stays at the `MAlgOrdered` level, whose `μ_bind_mono` asks only for monotonicity.
+`PolyFunTest/Control/MonadAttach.lean` pins both directions and the failure.
+
 This file depends on `Std.Do.Internal.Ensures` only through `WPSound`'s own field
 type. Reasoning here goes through `WPSound.of_wp_canReturn`, which lives in the
 stable `Std.Do` namespace; core's `Internal.MayReturn.canReturn_eq` (which proves
 `CanReturn` *is* the intrinsic strongest postcondition) is cited but not depended
 upon.
+
+Both of those are on a known clock. Upstream of this pin, core promotes its
+lattice-generic `Std.Internal.Do` tree to a public `Std.WP` (shipping in v4.35,
+not v4.34), replaces `WPSound` with `Std.WP.LawfulWPMonadAttach` — whose single
+field concludes from a `MonadAttach.CanReturn` witness directly, dropping the
+`Ensures` formulation — and deprecates `mvcgen` in favour of `vcgen`. That stack
+also drops conjunctivity from `PredTrans`, re-introducing it as the opt-in,
+one-directional `WPConjunctive`, which is what would unblock an angelic bridge.
+The elimination direction below is already stated against `CanReturn`, so it
+carries over as a rename.
 -/
 
 @[expose] public section

--- a/PolyFun/Control/Do/Basic.lean
+++ b/PolyFun/Control/Do/Basic.lean
@@ -58,8 +58,10 @@ lattice-generic `Std.Internal.Do` tree to a public `Std.WP` (shipping in v4.35,
 not v4.34), replaces `WPSound` with `Std.WP.LawfulWPMonadAttach` — whose single
 field concludes from a `MonadAttach.CanReturn` witness directly, dropping the
 `Ensures` formulation — and deprecates `mvcgen` in favour of `vcgen`. That stack
-also drops conjunctivity from `PredTrans`, re-introducing it as the opt-in,
-one-directional `WPConjunctive`, which is what would unblock an angelic bridge.
+also drops conjunctivity from `PredTrans`, re-introducing it as the opt-in
+`WPConjunctive`. Its one direction is exactly the direction angelic support fails;
+an angelic bridge becomes possible because the class is optional and would
+deliberately not be instantiated.
 The elimination direction below is already stated against `CanReturn`, so it
 carries over as a rename.
 -/

--- a/PolyFun/ITree/Do.lean
+++ b/PolyFun/ITree/Do.lean
@@ -86,13 +86,14 @@ what makes `iter_weakBisimRel`'s state relation `fun i j => i = j ∧ I i`
 inductive: the body hands back exactly the fact the next iteration needs.
 -/
 
-/-- Loop-invariant rule for `forInLoop`. If `I` holds of the initial state, and at
+/-- Invariant-scoped congruence for `forInLoop`. If `I` holds of the initial state, and at
 every state satisfying `I` the two bodies are weakly bisimilar under a relation
 that additionally re-establishes `I` on each `yield`, then the two loops are
 weakly bisimilar.
 
-With `body₂ := body₁` this reads as invariant preservation; with the two distinct
-it licenses replacing a body by a simplification valid only under `I`. -/
+This licenses replacing a body by a simplification valid only under `I`. Preservation
+of `I` is a hypothesis used to keep the relational argument inductive, not a separate
+postcondition established by the conclusion. -/
 theorem forInLoop_weakBisim_of_invariant {F : PFunctor.{uA, uB}} {β : Type uβ}
     (I : β → Prop) (loop : Lean.Loop) {init : β} (hinit : I init)
     {body₁ body₂ : Unit → β → ITree F (ForInStep β)}

--- a/PolyFun/ITree/Do.lean
+++ b/PolyFun/ITree/Do.lean
@@ -5,7 +5,7 @@ Authors: Quang Dao
 -/
 module
 
-public import PolyFun.ITree.Basic
+public import PolyFun.ITree.Bisim.Iter
 
 /-! # Productive `while` loops for interaction trees
 
@@ -70,5 +70,42 @@ Lean's generic `ForIn m Lean.Loop Unit` instance only while the scope is open. -
 scoped instance (priority := high) instForInLoop {F : PFunctor.{uA, uB}} :
     ForIn (ITree F) Lean.Loop Unit where
   forIn := forInLoop
+
+/-! ## Reasoning about the loop
+
+`ITree.iter` is lawful only up to weak bisimulation, and `ITree` carries no
+possible-output predicate for a postcondition to range over, so the loop rule is
+stated as a bisimulation congruence rather than as a weakest-precondition
+instance. What it supplies is the usual licence to *assume* an invariant inside
+the body: a body may be replaced by one that is only correct on the states the
+loop can actually reach.
+
+The invariant travels inside the relation rather than as a separate hypothesis.
+Relating a `ForInStep` to itself *together with* `I` on its `yield` payload is
+what makes `iter_weakBisimRel`'s state relation `fun i j => i = j ∧ I i`
+inductive: the body hands back exactly the fact the next iteration needs.
+-/
+
+/-- Loop-invariant rule for `forInLoop`. If `I` holds of the initial state, and at
+every state satisfying `I` the two bodies are weakly bisimilar under a relation
+that additionally re-establishes `I` on each `yield`, then the two loops are
+weakly bisimilar.
+
+With `body₂ := body₁` this reads as invariant preservation; with the two distinct
+it licenses replacing a body by a simplification valid only under `I`. -/
+theorem forInLoop_weakBisim_of_invariant {F : PFunctor.{uA, uB}} {β : Type uβ}
+    (I : β → Prop) (loop : Lean.Loop) {init : β} (hinit : I init)
+    {body₁ body₂ : Unit → β → ITree F (ForInStep β)}
+    (hbody : ∀ b, I b →
+      WeakBisimRel (fun s s' => s = s' ∧ ∀ n, s = ForInStep.yield n → I n)
+        (body₁ () b) (body₂ () b)) :
+    WeakBisim (forInLoop loop init body₁) (forInLoop loop init body₂) := by
+  refine iter_weakBisimRel (RI := fun i j => i = j ∧ I i) (RR := Eq) ?_ ⟨rfl, hinit⟩
+  rintro i j ⟨rfl, hI⟩
+  refine bind_weakBisimRel (hbody i hI) ?_
+  rintro s s' ⟨rfl, hs⟩
+  cases s with
+  | done result => exact WeakBisimRel.pure (.inr rfl)
+  | yield next => exact WeakBisimRel.pure (.inl ⟨rfl, hs next rfl⟩)
 
 end ITree

--- a/PolyFunTest/Control/MonadAttach.lean
+++ b/PolyFunTest/Control/MonadAttach.lean
@@ -391,3 +391,44 @@ example :
   exact fun _ _ => trivial
 
 end AlgebraSelection
+
+section AngelicNotConjunctive
+
+/-! ### Why there is no angelic `Std.Do.WP`
+
+`Std.Do.PredTrans` carries conjunctivity as a *structure field*, and as a bi-entailment:
+`t (Q₁ ∧ₚ Q₂) ⊣⊢ₛ t Q₁ ∧ t Q₂`. The demonic reading satisfies it in both directions, which
+is what lets `MonadAttach.toWP` build a `PredTrans` at all. The angelic reading satisfies
+only `→`: two *different* outputs may witness the two conjuncts separately, so nothing
+forces a single output to satisfy both.
+
+The consequence is structural rather than a gap in this development. The angelic
+interpretation cannot be a `Std.Do.WP`, so it stays at the `MAlgOrdered` level, whose
+`μ_bind_mono` asks only for monotonicity. Core's newer weakest-precondition stack drops
+conjunctivity from `PredTrans` and reintroduces it as an opt-in, one-directional
+`WPConjunctive`; the angelic reading is expressible against that stack. -/
+
+/-- The direction that does hold: an angelic conjunction splits. -/
+example {α : Type} (x : SetM α) (p q : α → Prop) (h : x ⊨ₛ fun a => p a ∧ q a) :
+    (x ⊨ₛ p) ∧ (x ⊨ₛ q) := by
+  obtain ⟨a, hcan, hp, hq⟩ := h
+  exact ⟨⟨a, hcan, hp⟩, ⟨a, hcan, hq⟩⟩
+
+/-- The direction that fails, and with it conjunctivity of the angelic transformer.
+Witness: `{0, 1}` has an output equal to `0` and an output equal to `1`, but none equal
+to both. -/
+example : ¬ (∀ {α : Type} (x : SetM α) (p q : α → Prop),
+    (x ⊨ₛ p) → (x ⊨ₛ q) → (x ⊨ₛ fun a => p a ∧ q a)) := by
+  intro h
+  obtain ⟨a, -, ha0, ha1⟩ :=
+    h (({0, 1} : Set ℕ) : SetM ℕ) (· = 0) (· = 1)
+      ⟨0, Or.inl rfl, rfl⟩ ⟨1, Or.inr rfl, rfl⟩
+  omega
+
+/-- The demonic reading, by contrast, distributes in both directions — this is the
+`conjunctiveRaw` field that `MonadAttach.toWP` discharges. -/
+example {α : Type} (x : SetM α) (p q : α → Prop) :
+    (x ⊨ₐ fun a => p a ∧ q a) ↔ (x ⊨ₐ p) ∧ (x ⊨ₐ q) :=
+  allOutputs_and p q x
+
+end AngelicNotConjunctive

--- a/PolyFunTest/Control/MonadAttach.lean
+++ b/PolyFunTest/Control/MonadAttach.lean
@@ -405,8 +405,9 @@ forces a single output to satisfy both.
 The consequence is structural rather than a gap in this development. The angelic
 interpretation cannot be a `Std.Do.WP`, so it stays at the `MAlgOrdered` level, whose
 `μ_bind_mono` asks only for monotonicity. Core's newer weakest-precondition stack drops
-conjunctivity from `PredTrans` and reintroduces it as an opt-in, one-directional
-`WPConjunctive`; the angelic reading is expressible against that stack. -/
+conjunctivity from `PredTrans` and reintroduces it as an opt-in `WPConjunctive`.
+That optional class asks for exactly the direction refuted below; the angelic reading
+is expressible against the newer base `WP` only without such an instance. -/
 
 /-- The direction that does hold: an angelic conjunction splits. -/
 example {α : Type} (x : SetM α) (p q : α → Prop) (h : x ⊨ₛ fun a => p a ∧ q a) :

--- a/PolyFunTest/ITree/LawfulIterationExamples.lean
+++ b/PolyFunTest/ITree/LawfulIterationExamples.lean
@@ -100,45 +100,42 @@ the productive `ITree.iter` implementation. -/
 example (body : Unit → Nat → ITree EmptySpec (ForInStep Nat)) (init : Nat) :=
   ITree.forInLoop_eq_iter (F := EmptySpec) Lean.Loop.mk init body
 
-/-! ## The loop-invariant rule
+/-! ## The invariant-scoped loop congruence
 
 `ITree.iter` is lawful only up to weak bisimulation, so the rule is a bisimulation
 congruence: it licenses assuming an invariant while reasoning about the loop body.
 -/
 
-/-- Invariant preservation: taking the two bodies to be the same one, the rule reduces
-to "every `yield` re-establishes `I`". -/
+private def guardedStep (n : Nat) : ForInStep Nat :=
+  if n < 100 then
+    if n < 3 then .yield (n + 1) else .done n
+  else .yield 0
+
+private def simplifiedStep (n : Nat) : ForInStep Nat :=
+  if n < 3 then .yield (n + 1) else .done n
+
+/-- The replacement below is genuinely conditional on the invariant. -/
+example : guardedStep 100 ≠ simplifiedStep 100 := by
+  simp [guardedStep, simplifiedStep]
+
+/-- Body replacement: once the loop maintains `n ≤ 3`, the outer `n < 100` branch is
+always taken, so the simplified body yields a weakly bisimilar loop. The invariant is
+essential: at `n = 100` the first body yields `0` while the second terminates with `100`. -/
 example (loop : Lean.Loop) :
     ITree.WeakBisim (F := EmptySpec)
       (ITree.forInLoop loop 0 fun _ n =>
-        ITree.pure (if n < 3 then .yield (n + 1) else .done n))
+        ITree.pure (guardedStep n))
       (ITree.forInLoop loop 0 fun _ n =>
-        ITree.pure (if n < 3 then .yield (n + 1) else .done n)) := by
+        ITree.pure (simplifiedStep n)) := by
   refine ITree.forInLoop_weakBisim_of_invariant (fun n => n ≤ 3) loop (by omega) ?_
   intro b hb
   refine ITree.WeakBisimRel.pure ?_
+  simp only [guardedStep, simplifiedStep]
+  rw [if_pos (by omega : b < 100)]
   by_cases h : b < 3
   · rw [if_pos h]
     exact ⟨rfl, fun n hn => by have := ForInStep.yield.inj hn; omega⟩
   · rw [if_neg h]
-    exact ⟨rfl, fun n hn => by simp at hn⟩
-
-/-- Body replacement: once the loop maintains `n ≤ 3`, the guard `n < 100` is dead, so
-the simplified body yields a weakly bisimilar loop. The invariant is what makes this
-step legitimate — the two bodies genuinely disagree at `n = 100`. -/
-example (loop : Lean.Loop) :
-    ITree.WeakBisim (F := EmptySpec)
-      (ITree.forInLoop loop 0 fun _ n =>
-        ITree.pure (if n < 3 ∧ n < 100 then .yield (n + 1) else .done n))
-      (ITree.forInLoop loop 0 fun _ n =>
-        ITree.pure (if n < 3 then .yield (n + 1) else .done n)) := by
-  refine ITree.forInLoop_weakBisim_of_invariant (fun n => n ≤ 3) loop (by omega) ?_
-  intro b hb
-  refine ITree.WeakBisimRel.pure ?_
-  by_cases h : b < 3
-  · rw [if_pos (⟨h, by omega⟩ : b < 3 ∧ b < 100), if_pos h]
-    exact ⟨rfl, fun n hn => by have := ForInStep.yield.inj hn; omega⟩
-  · rw [if_neg (fun hc => h hc.1), if_neg h]
     exact ⟨rfl, fun n hn => by simp at hn⟩
 
 end ITree.LawfulIterationExamples

--- a/PolyFunTest/ITree/LawfulIterationExamples.lean
+++ b/PolyFunTest/ITree/LawfulIterationExamples.lean
@@ -100,4 +100,45 @@ the productive `ITree.iter` implementation. -/
 example (body : Unit → Nat → ITree EmptySpec (ForInStep Nat)) (init : Nat) :=
   ITree.forInLoop_eq_iter (F := EmptySpec) Lean.Loop.mk init body
 
+/-! ## The loop-invariant rule
+
+`ITree.iter` is lawful only up to weak bisimulation, so the rule is a bisimulation
+congruence: it licenses assuming an invariant while reasoning about the loop body.
+-/
+
+/-- Invariant preservation: taking the two bodies to be the same one, the rule reduces
+to "every `yield` re-establishes `I`". -/
+example (loop : Lean.Loop) :
+    ITree.WeakBisim (F := EmptySpec)
+      (ITree.forInLoop loop 0 fun _ n =>
+        ITree.pure (if n < 3 then .yield (n + 1) else .done n))
+      (ITree.forInLoop loop 0 fun _ n =>
+        ITree.pure (if n < 3 then .yield (n + 1) else .done n)) := by
+  refine ITree.forInLoop_weakBisim_of_invariant (fun n => n ≤ 3) loop (by omega) ?_
+  intro b hb
+  refine ITree.WeakBisimRel.pure ?_
+  by_cases h : b < 3
+  · rw [if_pos h]
+    exact ⟨rfl, fun n hn => by have := ForInStep.yield.inj hn; omega⟩
+  · rw [if_neg h]
+    exact ⟨rfl, fun n hn => by simp at hn⟩
+
+/-- Body replacement: once the loop maintains `n ≤ 3`, the guard `n < 100` is dead, so
+the simplified body yields a weakly bisimilar loop. The invariant is what makes this
+step legitimate — the two bodies genuinely disagree at `n = 100`. -/
+example (loop : Lean.Loop) :
+    ITree.WeakBisim (F := EmptySpec)
+      (ITree.forInLoop loop 0 fun _ n =>
+        ITree.pure (if n < 3 ∧ n < 100 then .yield (n + 1) else .done n))
+      (ITree.forInLoop loop 0 fun _ n =>
+        ITree.pure (if n < 3 then .yield (n + 1) else .done n)) := by
+  refine ITree.forInLoop_weakBisim_of_invariant (fun n => n ≤ 3) loop (by omega) ?_
+  intro b hb
+  refine ITree.WeakBisimRel.pure ?_
+  by_cases h : b < 3
+  · rw [if_pos (⟨h, by omega⟩ : b < 3 ∧ b < 100), if_pos h]
+    exact ⟨rfl, fun n hn => by have := ForInStep.yield.inj hn; omega⟩
+  · rw [if_neg (fun hc => h hc.1), if_neg h]
+    exact ⟨rfl, fun n hn => by simp at hn⟩
+
 end ITree.LawfulIterationExamples

--- a/docs/reading/program-logic-landscape.md
+++ b/docs/reading/program-logic-landscape.md
@@ -122,8 +122,17 @@ implemented).
 - `Display`/wp adequacy: `Display.ofPredicates` sections versus `wpFold` of
   the induced spec — the intrinsic/extrinsic bridge (roadmap track D5).
 - ITree: no `WP` instance planned while `iter` is lawful only up to weak
-  bisimulation; the honest deliverables are wp-congruence under `WeakBisim`
-  and an invariant rule for the `ITree/Do.lean` `ForIn` loop.
+  bisimulation. The `ForIn` loop rule is now in place —
+  `ITree.forInLoop_weakBisim_of_invariant`, a bisimulation congruence carrying the
+  invariant inside the state relation, since `ITree` has no possible-output
+  predicate for a postcondition to range over. wp-congruence under `WeakBisim`
+  remains open.
+- The angelic WP bridge is **structurally blocked**, not merely unwritten.
+  `Std.Do.PredTrans` carries conjunctivity as a structure field, stated as a
+  bi-entailment; `AllOutputs` distributes over `∧` both ways but `SomeOutput` only
+  left-to-right, so there is no angelic `Std.Do.WP`. Core's newer stack makes
+  conjunctivity an opt-in, one-directional `WPConjunctive`, which would unblock it.
+  `PolyFunTest/Control/MonadAttach.lean` pins both directions and the failure.
 - The ε-additive approximate-triple algebra (ArkLib's sequencing blocker).
 - Optional `MonadFinSupport` (Finset-valued support, generalizing VCVio's
   `HasEvalFinset`).

--- a/docs/reading/program-logic-landscape.md
+++ b/docs/reading/program-logic-landscape.md
@@ -131,7 +131,8 @@ implemented).
   `Std.Do.PredTrans` carries conjunctivity as a structure field, stated as a
   bi-entailment; `AllOutputs` distributes over `∧` both ways but `SomeOutput` only
   left-to-right, so there is no angelic `Std.Do.WP`. Core's newer stack makes
-  conjunctivity an opt-in, one-directional `WPConjunctive`, which would unblock it.
+  conjunctivity an opt-in `WPConjunctive`. That class asks for the direction angelic
+  support fails; optionality unblocks the base WP bridge, which must omit the class.
   `PolyFunTest/Control/MonadAttach.lean` pins both directions and the failure.
 - The ε-additive approximate-triple algebra (ArkLib's sequencing blocker).
 - Optional `MonadFinSupport` (Finset-valued support, generalizing VCVio's

--- a/docs/wiki/program-logic.md
+++ b/docs/wiki/program-logic.md
@@ -16,6 +16,7 @@ migration sketch live in
 | `PolyFun/PFunctor/Free/Support.lean` | `MonadAttach`/`ExactMonadAttach` for `FreeM P` with a computable, axiom-free `attach`; structural equations by `rfl`; coherence with `Free/Path.lean` (`support_eq_range_output`) and with the powerset fold (`support_eq_liftM_univ`) |
 | `PolyFun/PFunctor/Free/WP.lean` | `OpSpec P l` per-operation specs; syntactic `FreeM.wpFold` (with `demonic`/`angelic`); `OpSpec.toMAlgOrdered`; semantic `FreeM.wpVia` through a `Handler`; soundness `wpFold_le_wpVia`/`wpFold_eq_wpVia` |
 | `PolyFun/Control/Do/Basic.lean` | Core-`Std.Do` transports: `MonadHom.transportWP(Monad)` along a monad morphism, `MonadAttach.toWP(Monad)` demonically at `.pure`, `toWPSound` for core-sense soundness, and `support_subset_of_wp`/`allOutputs_of_wp` turning any `WPSound` triple into a support fact |
+| `PolyFun/ITree/Do.lean` | Productive `while` for interaction trees: `forInLoop`, the scoped `ForIn` instance, and `forInLoop_weakBisim_of_invariant` — the loop-invariant rule, stated as a `WeakBisim` congruence because `iter` is lawful only up to weak bisimulation |
 | `PolyFun/PFunctor/Free/Do.lean` | Scoped demonic `WP (FreeM P) .pure` instances (`open scoped PFunctor.FreeM.DemonicWP`), `wpMonadOfHandler`, and the `Spec.lift` `@[spec]` lemma enabling `mvcgen` on free programs with uninterpreted operations |
 
 Worked examples: `PolyFunTest/Control/MonadAttach.lean` (judgments, notation,
@@ -109,6 +110,44 @@ everything they provide is a construction (`def`), not a global instance —
 global `WP` instances on `FreeM` would race downstream registrations on
 reducible unfoldings such as VCVio's `OracleComp`. The demonic instances are
 `scoped` under `PFunctor.FreeM.DemonicWP`.
+
+## The two upstream WP stacks
+
+Core ships **two** complete weakest-precondition stacks at the v4.33.1 pin, and PolyFun
+bridges the older one. Knowing which is which matters, because they differ on exactly the
+property that decides what PolyFun can express.
+
+| | `Std/Do/` (bridged here) | `Std/Internal/Do/` |
+|---|---|---|
+| Assertions | `SPred` / `PostShape` | any `Lean.Order.CompleteLattice` |
+| `WPMonad` bind law | equational (`wp_bind : … = …`) | inequational (`bind_le_wp_bind`) |
+| Conjunctivity | a **field of `PredTrans`**, bi-entailment | opt-in class `WPConjunctive`, one-directional |
+| Soundness | `WPSound`, via `Internal.Ensures` | — |
+| Also has | — | `WP.Frames`, `frameClosure`, `PreservesSup`, `RepeatInvariant` |
+| Visibility | public | `Internal` |
+
+**The conjunctivity field is why the WP bridge is demonic-only.** `Std.Do.PredTrans` requires
+`t (Q₁ ∧ₚ Q₂) ⊣⊢ₛ t Q₁ ∧ t Q₂`. `AllOutputs` distributes over `∧` in both directions, so
+`MonadAttach.toWP` discharges it. `SomeOutput` distributes only left-to-right — two different
+outputs may witness the two conjuncts separately — so there is no angelic `Std.Do.WP` at all.
+That is a structural obstruction, not an unwritten lemma;
+`PolyFunTest/Control/MonadAttach.lean` proves both directions and the failure. The angelic
+reading therefore lives at the `MAlgOrdered` level, whose `μ_bind_mono` asks only for
+monotonicity.
+
+**What changes upstream.** Beyond this pin, core promotes `Std.Internal.Do` verbatim to a
+public `Std.WP`, replaces `WPSound` with `Std.WP.LawfulWPMonadAttach` — whose one field
+concludes from a `MonadAttach.CanReturn` witness directly, dropping the `Ensures`
+formulation — and deprecates `mvcgen` in favour of `vcgen`. All three ship in **v4.35**, not
+v4.34. Two consequences for this layer: `support_subset_of_wp` / `allOutputs_of_wp` are
+already stated against `CanReturn`, so they carry over as a rename; and `WPConjunctive`
+being opt-in and one-directional is what would unblock an angelic bridge.
+
+`MAlgOrdered` is recognisably `Std.Internal.Do.WPMonad` minus exception postconditions — but
+over Mathlib's `CompleteLattice`, while every piece of core WP machinery is over
+`Lean.Order.CompleteLattice`, and the pinned Mathlib contains no bridge between the two
+hierarchies. Adopting core's stack means porting `MAlgOrdered` off Mathlib's order hierarchy.
+That cost is recorded here deliberately; it is not this layer's current direction.
 
 ## What stays downstream
 

--- a/docs/wiki/program-logic.md
+++ b/docs/wiki/program-logic.md
@@ -16,7 +16,7 @@ migration sketch live in
 | `PolyFun/PFunctor/Free/Support.lean` | `MonadAttach`/`ExactMonadAttach` for `FreeM P` with a computable, axiom-free `attach`; structural equations by `rfl`; coherence with `Free/Path.lean` (`support_eq_range_output`) and with the powerset fold (`support_eq_liftM_univ`) |
 | `PolyFun/PFunctor/Free/WP.lean` | `OpSpec P l` per-operation specs; syntactic `FreeM.wpFold` (with `demonic`/`angelic`); `OpSpec.toMAlgOrdered`; semantic `FreeM.wpVia` through a `Handler`; soundness `wpFold_le_wpVia`/`wpFold_eq_wpVia` |
 | `PolyFun/Control/Do/Basic.lean` | Core-`Std.Do` transports: `MonadHom.transportWP(Monad)` along a monad morphism, `MonadAttach.toWP(Monad)` demonically at `.pure`, `toWPSound` for core-sense soundness, and `support_subset_of_wp`/`allOutputs_of_wp` turning any `WPSound` triple into a support fact |
-| `PolyFun/ITree/Do.lean` | Productive `while` for interaction trees: `forInLoop`, the scoped `ForIn` instance, and `forInLoop_weakBisim_of_invariant` — the loop-invariant rule, stated as a `WeakBisim` congruence because `iter` is lawful only up to weak bisimulation |
+| `PolyFun/ITree/Do.lean` | Productive `while` for interaction trees: `forInLoop`, the scoped `ForIn` instance, and `forInLoop_weakBisim_of_invariant` — an invariant-scoped `WeakBisim` congruence because `iter` is lawful only up to weak bisimulation |
 | `PolyFun/PFunctor/Free/Do.lean` | Scoped demonic `WP (FreeM P) .pure` instances (`open scoped PFunctor.FreeM.DemonicWP`), `wpMonadOfHandler`, and the `Spec.lift` `@[spec]` lemma enabling `mvcgen` on free programs with uninterpreted operations |
 
 Worked examples: `PolyFunTest/Control/MonadAttach.lean` (judgments, notation,
@@ -141,7 +141,9 @@ concludes from a `MonadAttach.CanReturn` witness directly, dropping the `Ensures
 formulation — and deprecates `mvcgen` in favour of `vcgen`. All three ship in **v4.35**, not
 v4.34. Two consequences for this layer: `support_subset_of_wp` / `allOutputs_of_wp` are
 already stated against `CanReturn`, so they carry over as a rename; and `WPConjunctive`
-being opt-in and one-directional is what would unblock an angelic bridge.
+being opt-in is what would unblock an angelic bridge. Its one law is exactly the reverse
+conjunction direction refuted by the test, so that bridge would not provide the optional
+class.
 
 `MAlgOrdered` is recognisably `Std.Internal.Do.WPMonad` minus exception postconditions — but
 over Mathlib's `CompleteLattice`, while every piece of core WP machinery is over

--- a/docs/wiki/repo-map.md
+++ b/docs/wiki/repo-map.md
@@ -200,8 +200,8 @@ ITree/Resumption + PFunctor/{Dynamical/Trajectory, Resumption/Empty}
 ITree/Free + PFunctor/PatternRunsOnMatter/Dynamical
   -> ITree/PatternRunsOnMatter
 ITree/Bisim/Iter -> ITree/Do
-  (the scoped productive `ForIn` instance and its loop-invariant rule; the rule
-   is a `WeakBisim` congruence, so `Do` sits above the bisimulation layer)
+  (the scoped productive `ForIn` instance and its invariant-scoped `WeakBisim`
+   congruence, so `Do` sits above the bisimulation layer)
 
 PFunctor/Free + Control -> Interaction/Basic/{TypeTree, Node, Decoration,
                             Syntax, Shape, Interaction, Strategy,

--- a/docs/wiki/repo-map.md
+++ b/docs/wiki/repo-map.md
@@ -199,6 +199,9 @@ ITree/Resumption + PFunctor/{Dynamical/Trajectory, Resumption/Empty}
   -> ITree/Unfold
 ITree/Free + PFunctor/PatternRunsOnMatter/Dynamical
   -> ITree/PatternRunsOnMatter
+ITree/Bisim/Iter -> ITree/Do
+  (the scoped productive `ForIn` instance and its loop-invariant rule; the rule
+   is a `WeakBisim` congruence, so `Do` sits above the bisimulation layer)
 
 PFunctor/Free + Control -> Interaction/Basic/{TypeTree, Node, Decoration,
                             Syntax, Shape, Interaction, Strategy,


### PR DESCRIPTION
## Summary

This PR records the exact boundary of PolyFun's current `Std.Do` bridge and adds an
invariant-scoped congruence for productive `ITree` loops.

It is now cleanly restacked on current `main`: 7 files, 196 insertions, 3 deletions.

## Angelic weakest-precondition boundary

The public `Std.Do.PredTrans` used by PolyFun requires conjunctivity as a structure
field:

```text
t (Q₁ ∧ₚ Q₂) ⊣⊢ₛ t Q₁ ∧ t Q₂
```

`AllOutputs` satisfies both directions, so the existing demonic bridge is valid.
`SomeOutput` only splits an already-witnessed conjunction; two different reachable
outputs may witness its two sides separately, so the reverse direction fails. Therefore
there is no honest angelic `Std.Do.WP` against this public stack.

Three focused examples pin the boundary: the angelic direction that holds, a concrete
`SetM {0,1}` counterexample to the direction that fails, and the demonic equivalence.

Core's lattice-generic WP stack removes conjunctivity from the base predicate transformer
and makes it an optional `WPConjunctive` class. That optional class asks for exactly the
direction angelic support fails; an eventual angelic base-WP bridge would deliberately
omit the class.

## Invariant-scoped `ITree` loop congruence

`ITree.forInLoop_weakBisim_of_invariant` allows two loop bodies to be compared only on
states satisfying an invariant. Each yielded state must re-establish the invariant, so
`iter_weakBisimRel` can carry it through the recursive state relation. The result is a
`WeakBisim` between the two loops.

This is a body-replacement congruence, not a postcondition theorem: invariant preservation
is a premise used by the proof, not an independently observable conclusion.

The worked canary is discriminating. Its two bodies are formally unequal at `n = 100`,
but agree under `n ≤ 3`; the theorem proves the resulting loops weakly bisimilar from `0`.

## Upstream migration note

The documentation distinguishes the public `Std.Do` stack currently bridged by PolyFun
from the pinned `Std.Internal.Do` lattice-generic stack and its upstream promotion to
`Std.WP`. The future soundness bridge concludes directly from
`MonadAttach.CanReturn`; PolyFun's elimination lemmas already use that boundary.

## Review follow-up

The Lean review found and repaired two related issues:

1. The original same-body “invariant preservation” example had a reflexive conclusion
   and established no invariant property. It was removed, and the theorem/docs now state
   the actual invariant-scoped congruence contract.
2. The original replacement example's extra guard was globally redundant, so its bodies
   did not really disagree off the invariant. The new example proves the bodies unequal
   off-invariant before proving their loops equivalent under the invariant.

The WP documentation was also clarified: optionality of `WPConjunctive` enables a future
angelic base bridge; angelic support does not satisfy that optional class itself.

## Validation

At commit `038c3388762c1b950edc11dbef2e7b06b0865dff`:

- `./scripts/validate.sh --lint --test --axioms`
  - library build: 1,519 jobs
  - test library: 1,622 jobs
  - axiom sweep: 10,322 declarations across 259 modules
  - zero `sorry` taint and zero nonstandard-axiom taint
- `lake exe lint-style`
- `git diff --check`

All local checks pass.
