### PR TITLE
feat(control): fill the ordered-algebra coverage matrix and even out the hom APIs

### DIFF
--- a/PolyFun/Control/Coalgebra.lean
+++ b/PolyFun/Control/Coalgebra.lean
@@ -107,4 +107,18 @@ theorem id_apply (x : S₁) : (Coalg.Hom.id : Coalg.Hom F S₁ S₁) x = x := rf
 theorem comp_apply (g : Coalg.Hom F S₂ S₃) (f : Coalg.Hom F S₁ S₂) (x : S₁) :
     (Coalg.Hom.comp g f) x = g (f x) := rfl
 
+/-! Coalgebra morphisms form a category, on the nose. These mirror `MonadHom.comp`'s
+laws in `PolyFun/Control/Monad/Hom.lean`: the two hom types are structurally identical —
+a carrier map plus a commutation proof — so their composition APIs should agree. -/
+
+@[simp]
+theorem comp_id (f : Coalg.Hom F S₁ S₂) : f.comp Coalg.Hom.id = f := rfl
+
+@[simp]
+theorem id_comp (f : Coalg.Hom F S₁ S₂) : Coalg.Hom.id.comp f = f := rfl
+
+theorem comp_assoc {S₄ : Type u} [Coalg F S₄]
+    (h : Coalg.Hom F S₃ S₄) (g : Coalg.Hom F S₂ S₃) (f : Coalg.Hom F S₁ S₂) :
+    (h.comp g).comp f = h.comp (g.comp f) := rfl
+
 end Coalg.Hom

--- a/PolyFun/Control/Coalgebra.lean
+++ b/PolyFun/Control/Coalgebra.lean
@@ -108,8 +108,9 @@ theorem comp_apply (g : Coalg.Hom F S₂ S₃) (f : Coalg.Hom F S₁ S₂) (x : 
     (Coalg.Hom.comp g f) x = g (f x) := rfl
 
 /-! Coalgebra morphisms form a category, on the nose. These mirror `MonadHom.comp`'s
-laws in `PolyFun/Control/Monad/Hom.lean`: the two hom types are structurally identical —
-a carrier map plus a commutation proof — so their composition APIs should agree. -/
+laws in `PolyFun/Control/Monad/Hom.lean`: both hom types compose their carrier maps
+pointwise and package the corresponding preservation laws, so their composition APIs
+should agree. -/
 
 @[simp]
 theorem comp_id (f : Coalg.Hom F S₁ S₂) : f.comp Coalg.Hom.id = f := rfl

--- a/PolyFun/Control/Monad/Algebra.lean
+++ b/PolyFun/Control/Monad/Algebra.lean
@@ -6,6 +6,7 @@ Authors: Quang Dao
 module
 
 public import Mathlib.Order.CompleteLattice.Basic
+public import Mathlib.Control.Monad.Writer
 
 /-!
 # Monad algebras
@@ -160,7 +161,25 @@ theorem triple_bind [LawfulMonad m] {pre : l} {x : m α} {cut : α → l}
 
 end MAlgOrdered
 
-/-! ## Transformer lifting instances -/
+/-! ## Transformer lifting instances
+
+There is deliberately **no globally registered base instance**. The structure map
+`μ : m l → l` is a choice of semantics, not something a monad determines: on `FreeM P` it
+is a per-operation spec (`PFunctor.OpSpec.toMAlgOrdered` takes the spec and its
+monotonicity proof as arguments), and on a monad with exact support it is the demonic or
+the angelic reading. Nothing canonical exists to register.
+
+What is registered are the transformer *lifts* below. The intended pattern is to install
+the intended base algebra locally at a verification boundary and let the lifts compose
+above it; `PolyFunTest/Control/MonadAlgebra.lean` checks that each lift, and stacks of
+them, resolve by synthesis over one local base.
+
+The carriers follow the shape of what the transformer adds: `StateT`, `ReaderT`, and
+`WriterT` index the lattice by their state, environment, and accumulated log, while
+`ExceptT` and `OptionT` keep the base carrier and collapse failure to `⊥`. The collapsing
+pair loses the failure branch on purpose; `wpExc` / `wpOpt` below are the honest
+two-postcondition alternatives.
+-/
 
 namespace MAlgOrdered
 
@@ -267,6 +286,29 @@ attribute [instance] instExceptT
         x.run)
 
 attribute [instance] instOptionT
+
+/-- Lift an ordered monad algebra through `WriterT`, threading the accumulated log.
+
+The carrier is `ω → l` for the same reason `StateT`'s is `σ → l`: `bind` multiplies the
+prefix's log into the continuation's, so a postcondition that mentions the log has to be
+told what has already been written. Taking `ω → l` at the unit recovers the log-oblivious
+reading, so nothing is lost by indexing. -/
+@[implicit_reducible] noncomputable def instWriterT (ω : Type u) [Monoid ω] :
+    MAlgOrdered (WriterT ω m) (ω → l) where
+  μ x := fun w => MAlgOrdered.μ (x.run >>= fun p => pure (p.1 (w * p.2)))
+  μ_pure x := by
+    funext w
+    simp [MAlgOrdered.μ_pure]
+  μ_bind_mono f g hfg x := by
+    intro w
+    simp only [WriterT.run_bind, bind_assoc, map_eq_pure_bind, pure_bind]
+    exact MAlgOrdered.μ_bind_mono
+      (f := fun p => (f p.1).run >>= fun q => pure (q.1 (w * (p.2 * q.2))))
+      (g := fun p => (g p.1).run >>= fun q => pure (q.1 (w * (p.2 * q.2))))
+      (fun p => by simpa [mul_assoc] using (hfg p.1) (w * p.2))
+      x.run
+
+attribute [instance] instWriterT
 
 end MAlgOrdered
 

--- a/PolyFun/Control/Monad/Hom.lean
+++ b/PolyFun/Control/Monad/Hom.lean
@@ -207,3 +207,71 @@ omit [LawfulMonad m] [LawfulMonad n] in
     (StateT.mapHom φ x).run s = φ (x.run s) := rfl
 
 end StateT
+
+namespace ReaderT
+
+variable {m : Type u → Type v} {n : Type u → Type w} [Monad m] [Monad n]
+  [LawfulMonad m] [LawfulMonad n] {ρ α : Type u}
+
+/-- `ReaderT ρ` is functorial on monad morphisms, acting under the environment. -/
+def mapHom (φ : m →ᵐ n) : ReaderT ρ m →ᵐ ReaderT ρ n where
+  toFun _ x := ReaderT.mk fun r => φ (x.run r)
+  toFun_pure' a := by ext r; simp
+  toFun_bind' x y := by ext r; simp
+
+omit [LawfulMonad m] [LawfulMonad n] in
+@[simp] lemma run_mapHom (φ : m →ᵐ n) (x : ReaderT ρ m α) (r : ρ) :
+    (ReaderT.mapHom φ x).run r = φ (x.run r) := rfl
+
+end ReaderT
+
+namespace OptionT
+
+variable {m : Type u → Type v} {n : Type u → Type w} [Monad m] [Monad n]
+  [LawfulMonad m] [LawfulMonad n] {α : Type u}
+
+/-- `OptionT` is functorial on monad morphisms. The failure branch is preserved because a
+monad morphism commutes with `pure`, so `none` is carried to `none`. -/
+def mapHom (φ : m →ᵐ n) : OptionT m →ᵐ OptionT n where
+  toFun _ x := OptionT.mk (φ x.run)
+  toFun_pure' a := by
+    apply OptionT.ext
+    simp [OptionT.run_pure]
+  toFun_bind' x y := by
+    apply OptionT.ext
+    have h : ∀ a : Option _, φ (a.elim (pure none) fun b => (y b).run)
+        = a.elim (pure none) fun b => φ ((y b).run) := by
+      intro a; cases a <;> simp
+    simp only [OptionT.run_bind, OptionT.mk, Option.elimM, MonadHom.mmap_bind, h]
+    rfl
+
+omit [LawfulMonad m] [LawfulMonad n] in
+@[simp] lemma run_mapHom (φ : m →ᵐ n) (x : OptionT m α) :
+    (OptionT.mapHom φ x).run = φ x.run := rfl
+
+end OptionT
+
+namespace ExceptT
+
+variable {m : Type u → Type v} {n : Type u → Type w} [Monad m] [Monad n]
+  [LawfulMonad m] [LawfulMonad n] {ε α : Type u}
+
+/-- `ExceptT ε` is functorial on monad morphisms. As for `OptionT`, the error branch
+survives because a monad morphism preserves `pure`. -/
+def mapHom (φ : m →ᵐ n) : ExceptT ε m →ᵐ ExceptT ε n where
+  toFun _ x := ExceptT.mk (φ x.run)
+  toFun_pure' a := by
+    apply ExceptT.ext
+    simp [ExceptT.run_pure]
+  toFun_bind' x y := by
+    apply ExceptT.ext
+    simp only [ExceptT.run_bind, ExceptT.mk, MonadHom.mmap_bind]
+    exact bind_congr fun a => by cases a with
+      | error e => simp
+      | ok b => rfl
+
+omit [LawfulMonad m] [LawfulMonad n] in
+@[simp] lemma run_mapHom (φ : m →ᵐ n) (x : ExceptT ε m α) :
+    (ExceptT.mapHom φ x).run = φ x.run := rfl
+
+end ExceptT

--- a/PolyFun/Control/Monad/Hom.lean
+++ b/PolyFun/Control/Monad/Hom.lean
@@ -206,6 +206,23 @@ omit [LawfulMonad m] [LawfulMonad n] in
 @[simp] lemma run_mapHom (φ : m →ᵐ n) (x : StateT σ m α) (s : σ) :
     (StateT.mapHom φ x).run s = φ (x.run s) := rfl
 
+omit [LawfulMonad m] in
+@[simp] theorem mapHom_id :
+    StateT.mapHom (σ := σ) (MonadHom.id m) = MonadHom.id (StateT σ m) := by
+  apply MonadHom.ext'
+  intro α x
+  rfl
+
+variable {n' : Type u → Type x} [Monad n'] [LawfulMonad n']
+
+omit [LawfulMonad m] [LawfulMonad n] [LawfulMonad n'] in
+@[simp] theorem mapHom_comp (G : n →ᵐ n') (F : m →ᵐ n) :
+    StateT.mapHom (σ := σ) (G ∘ₘ F) =
+      StateT.mapHom (σ := σ) G ∘ₘ StateT.mapHom (σ := σ) F := by
+  apply MonadHom.ext'
+  intro α x
+  rfl
+
 end StateT
 
 namespace ReaderT
@@ -222,6 +239,23 @@ def mapHom (φ : m →ᵐ n) : ReaderT ρ m →ᵐ ReaderT ρ n where
 omit [LawfulMonad m] [LawfulMonad n] in
 @[simp] lemma run_mapHom (φ : m →ᵐ n) (x : ReaderT ρ m α) (r : ρ) :
     (ReaderT.mapHom φ x).run r = φ (x.run r) := rfl
+
+omit [LawfulMonad m] in
+@[simp] theorem mapHom_id :
+    ReaderT.mapHom (ρ := ρ) (MonadHom.id m) = MonadHom.id (ReaderT ρ m) := by
+  apply MonadHom.ext'
+  intro α x
+  rfl
+
+variable {n' : Type u → Type x} [Monad n'] [LawfulMonad n']
+
+omit [LawfulMonad m] [LawfulMonad n] [LawfulMonad n'] in
+@[simp] theorem mapHom_comp (G : n →ᵐ n') (F : m →ᵐ n) :
+    ReaderT.mapHom (ρ := ρ) (G ∘ₘ F) =
+      ReaderT.mapHom (ρ := ρ) G ∘ₘ ReaderT.mapHom (ρ := ρ) F := by
+  apply MonadHom.ext'
+  intro α x
+  rfl
 
 end ReaderT
 
@@ -249,6 +283,22 @@ omit [LawfulMonad m] [LawfulMonad n] in
 @[simp] lemma run_mapHom (φ : m →ᵐ n) (x : OptionT m α) :
     (OptionT.mapHom φ x).run = φ x.run := rfl
 
+omit [LawfulMonad m] in
+@[simp] theorem mapHom_id :
+    OptionT.mapHom (MonadHom.id m) = MonadHom.id (OptionT m) := by
+  apply MonadHom.ext'
+  intro α x
+  rfl
+
+variable {n' : Type u → Type x} [Monad n'] [LawfulMonad n']
+
+omit [LawfulMonad m] [LawfulMonad n] [LawfulMonad n'] in
+@[simp] theorem mapHom_comp (G : n →ᵐ n') (F : m →ᵐ n) :
+    OptionT.mapHom (G ∘ₘ F) = OptionT.mapHom G ∘ₘ OptionT.mapHom F := by
+  apply MonadHom.ext'
+  intro α x
+  rfl
+
 end OptionT
 
 namespace ExceptT
@@ -273,5 +323,22 @@ def mapHom (φ : m →ᵐ n) : ExceptT ε m →ᵐ ExceptT ε n where
 omit [LawfulMonad m] [LawfulMonad n] in
 @[simp] lemma run_mapHom (φ : m →ᵐ n) (x : ExceptT ε m α) :
     (ExceptT.mapHom φ x).run = φ x.run := rfl
+
+omit [LawfulMonad m] in
+@[simp] theorem mapHom_id :
+    ExceptT.mapHom (ε := ε) (MonadHom.id m) = MonadHom.id (ExceptT ε m) := by
+  apply MonadHom.ext'
+  intro α x
+  rfl
+
+variable {n' : Type u → Type x} [Monad n'] [LawfulMonad n']
+
+omit [LawfulMonad m] [LawfulMonad n] [LawfulMonad n'] in
+@[simp] theorem mapHom_comp (G : n →ᵐ n') (F : m →ᵐ n) :
+    ExceptT.mapHom (ε := ε) (G ∘ₘ F) =
+      ExceptT.mapHom (ε := ε) G ∘ₘ ExceptT.mapHom (ε := ε) F := by
+  apply MonadHom.ext'
+  intro α x
+  rfl
 
 end ExceptT

--- a/PolyFunTest/Control/MonadAlgebra.lean
+++ b/PolyFunTest/Control/MonadAlgebra.lean
@@ -1,0 +1,65 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+module
+
+public import PolyFun.Control.Monad.Algebra
+
+/-!
+# Coverage of the ordered monad algebra transformer lifts
+
+`MAlgOrdered` deliberately has no globally registered base instance: the structure map
+`μ : m l → l` is a *choice* of semantics, not something a monad determines. On `FreeM P`
+the choice is a per-operation spec (`PFunctor.OpSpec.toMAlgOrdered` takes the spec and its
+monotonicity proof as arguments), and on a supported monad it is the demonic or angelic
+reading. So there is nothing canonical to register.
+
+What the library does register are the transformer *lifts*. This file is their coverage
+check: with a single base algebra installed locally, every lift resolves by synthesis, and
+the lifts stack. That is the intended usage pattern — install the intended algebra at the
+verification boundary and let the transformers compose above it.
+-/
+
+@[expose] public section
+
+namespace PolyFunTest.MonadAlgebraCoverage
+
+open MAlgOrdered
+
+/-- The base choice. Everything below is synthesized above this one local instance. -/
+noncomputable local instance instIdProp : MAlgOrdered Id Prop where
+  μ x := x
+  μ_pure _ := rfl
+  μ_bind_mono _ _ h x := h x
+
+section Coverage
+
+variable {σ ρ ε ω : Type} [Monoid ω]
+
+noncomputable example : MAlgOrdered (StateT σ Id) (σ → Prop) := inferInstance
+noncomputable example : MAlgOrdered (ReaderT ρ Id) (ρ → Prop) := inferInstance
+noncomputable example : MAlgOrdered (ExceptT ε Id) Prop := inferInstance
+noncomputable example : MAlgOrdered (OptionT Id) Prop := inferInstance
+noncomputable example : MAlgOrdered (WriterT ω Id) (ω → Prop) := inferInstance
+
+/-! The lifts stack, which is what makes the "install one base" pattern worth having. -/
+
+noncomputable example : MAlgOrdered (StateT σ (OptionT Id)) (σ → Prop) := inferInstance
+noncomputable example : MAlgOrdered (ReaderT ρ (ExceptT ε Id)) (ρ → Prop) := inferInstance
+noncomputable example : MAlgOrdered (StateT σ (WriterT ω Id)) (σ → ω → Prop) := inferInstance
+
+end Coverage
+
+section Behaviour
+
+/-- `tell` shifts the log the postcondition is shown: this is the content of indexing the
+carrier by `ω`, and the analogue of `StateT`'s postcondition seeing the final state. -/
+example (ω : Type) [Monoid ω] (w₀ : ω) (post : PUnit → ω → Prop) :
+    wp (MonadWriter.tell w₀ : WriterT ω Id PUnit) post = fun w => post ⟨⟩ (w * w₀) :=
+  by simp only [wp, bind_pure_comp]; funext w; rfl
+
+end Behaviour
+
+end PolyFunTest.MonadAlgebraCoverage

--- a/PolyFunTest/Control/MonadHomExamples.lean
+++ b/PolyFunTest/Control/MonadHomExamples.lean
@@ -70,4 +70,30 @@ example {n : Type u → Type w} [Monad n] [LawfulMonad n] {α σ : Type u}
 
 end Structure
 
+section TransformerMaps
+
+/-- A nonidentity target effect makes it observable that each transformer map acts on
+the underlying monad rather than merely repackaging its source representation. -/
+def idToOption : Id →ᵐ Option := MonadHom.pure Option
+
+/-- The environment still selects the source value before the underlying morphism runs. -/
+def branchReader : ReaderT Bool Id Nat :=
+  ReaderT.mk fun flag => if flag then 7 else 11
+
+example : (ReaderT.mapHom idToOption branchReader).run true = some 7 := rfl
+example : (ReaderT.mapHom idToOption branchReader).run false = some 11 := rfl
+
+/-- Source-level `none` remains a successful target effect carrying `none`; it is not
+confused with failure in the target `Option` monad. -/
+def absent : OptionT Id Nat := OptionT.mk none
+
+example : (OptionT.mapHom idToOption absent).run = some none := rfl
+
+/-- Likewise, an `ExceptT` error remains data inside the successful target effect. -/
+def rejected : ExceptT String Id Nat := ExceptT.mk (.error "rejected")
+
+example : (ExceptT.mapHom idToOption rejected).run = some (.error "rejected") := rfl
+
+end TransformerMaps
+
 end Control.MonadHomExamples


### PR DESCRIPTION
Standardization pass from the upstream sweep. The two main classes of the control layer covered almost disjoint sets of transformers, and the gaps had no recorded reason. This closes the ones that were real and documents the one that was intentional.

|  | `Id` | `Option` | `Except` | `SetM` | `OptionT` | `ExceptT` | `StateT` | `ReaderT` | `WriterT` | `FreeM` |
|---|---|---|---|---|---|---|---|---|---|---|
| `ExactMonadAttach` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ provably | ✗ provably | ✓ | ✓ |
| `MAlgOrdered` lift | — | — | — | — | ✓ | ✓ | ✓ | ✓ | **✓ new** | ✓ |
| `MonadHom.mapHom` | — | — | — | — | **✓ new** | **✓ new** | ✓ | **✓ new** | — | — |

### `MAlgOrdered (WriterT ω m) (ω → l)`

The gap that was real: `WriterT` gained a full four-class attach stack but had no ordered algebra. The carrier is indexed by `ω` for the same reason `StateT`'s is indexed by `σ` — `bind` multiplies the prefix's log into the continuation's, so a postcondition that mentions the log has to be told what has already been written. Taking the unit recovers the log-oblivious reading, so nothing is lost by indexing.

### The "no base instance" gap is not one

It looked as though the four registered transformer lifts could never fire, since each requires an `MAlgOrdered m l` on the base and none is registered anywhere in the library. That is deliberate, and is now said so in the source. The structure map `μ : m l → l` is a *choice of semantics*, not something a monad determines: on `FreeM P` it is a per-operation spec (`OpSpec.toMAlgOrdered` takes the spec and its monotonicity proof as arguments), and on a monad with exact support it is the demonic or the angelic reading. There is nothing canonical to register.

What is registered are the *lifts*, which compose above whatever base is installed locally at a verification boundary. New file `PolyFunTest/Control/MonadAlgebra.lean` checks exactly that: over one local base algebra, every lift resolves by synthesis, three stacks of lifts resolve (`StateT ∘ OptionT`, `ReaderT ∘ ExceptT`, `StateT ∘ WriterT`), and `tell` is shown shifting the log the postcondition sees.

### Hom-API symmetry

`ReaderT`, `OptionT`, and `ExceptT` gain `mapHom`, joining `StateT`. Only `StateT` had one, which made `MonadHom.transportWP` usable at exactly one boundary. The failure branches survive because a monad morphism preserves `pure`.

`Coalg.Hom` gains `comp_id`, `id_comp`, and `comp_assoc`. `MonadHom.comp` has all three, and the two hom types are structurally identical — a carrier map plus a commutation proof — so their composition APIs should agree.

### Not in this PR

`ReaderT` side lifts for `MAlgRelOrdered` (the relational layer covers `StateT`/`ExceptT`/`OptionT` but not `ReaderT`), a `WriterT.mapHom` (would add a Mathlib `Writer` import to `Hom.lean`), and the simp/grind automation contract for `Algebra.lean` / `Relational.lean`.

### Validation

`./scripts/validate.sh --lint --test` — build, lint, and test all pass, with no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### Review follow-up

The formalization review completed the transformer-functor contract with identity and composition laws for `StateT`, `ReaderT`, `OptionT`, and `ExceptT`; added concrete branch/failure-preservation canaries; and corrected the coalgebra comparison wording. Full local validation, including the axiom sweep and text-style linter, passes on the repaired head.