### PR TITLE
feat(control): honest relational exception WP, and `Anchored`'s first consumer

### DIFF
--- a/PolyFun/Control/Monad/Algebra/Relational.lean
+++ b/PolyFun/Control/Monad/Algebra/Relational.lean
@@ -656,8 +656,8 @@ relative-monad machinery. They are precisely the ingredient missing from the los
 exception lifts (see `exceptTLeft` / `exceptTRight` above), which collapse failure to
 `⊥`. The honest combinators that track success and failure separately are
 `MAlgOrdered.wpExc` (unary) and `rwpExc` (relational) below; anchoring is what lets
-`rwpExc_pure_left` / `rwpExc_pure_right` collapse the relational statement to the unary
-one once either side is a `pure`.
+the `rwpExc_pure_*` and `rwpExc_throw_*` rules collapse the relational statement to the
+unary one once either underlying result is known purely.
 
 Anchoring is independent of `StrictBind`. A coupling-based probabilistic carrier is
 anchored (Dirac couplings are unique) but is not strict, while a deterministic
@@ -711,8 +711,9 @@ success/failure combinations are tracked separately, rather than collapsing fail
 
 Like `wpExc` it is derived: it uses only the *base* relational algebra
 `MAlgRelOrdered m₁ m₂ l` on the underlying monads, never a lifted one. Under `Anchored`
-it collapses to the unary `wpExc` whenever one side is a `pure`, which is the payoff the
-anchoring axioms were introduced for.
+it collapses to the unary `wpExc` whenever one side has a pure underlying result—either
+a success or an immediate failure—which is the payoff the anchoring axioms were
+introduced for.
 -/
 
 section Exc
@@ -770,15 +771,16 @@ theorem rwpExc_mono {x : ExceptT ε₁ m₁ α} {y : ExceptT ε₂ m₂ β}
     rwpExc x y post ≤ rwpExc x y post' :=
   MAlgRelOrdered.rwp_mono hpost
 
-/-- Sequential composition, inherited from `rwp_bind_le`. The continuations run on the
-underlying monads, so the failure branches of `x` and `y` are threaded by the caller's
-postcondition rather than short-circuited here. -/
+/-- Sequential composition for `ExceptT`, inherited from `rwp_bind_le`. The two
+continuations run only on successful results; an error on either side is propagated
+unchanged, exactly as it is by `ExceptT.bind`. -/
 theorem rwpExc_bind_le (x : ExceptT ε₁ m₁ α) (y : ExceptT ε₂ m₂ β)
-    (f : Except ε₁ α → m₁ (Except ε₁ γ)) (g : Except ε₂ β → m₂ (Except ε₂ δ))
+    (f : α → ExceptT ε₁ m₁ γ) (g : β → ExceptT ε₂ m₂ δ)
     (post : Except ε₁ γ → Except ε₂ δ → l) :
-    MAlgRelOrdered.rwp x.run y.run
-        (fun ea eb => MAlgRelOrdered.rwp (f ea) (g eb) post) ≤
-      MAlgRelOrdered.rwp (x.run >>= f) (y.run >>= g) post :=
+    rwpExc x y (fun ea eb =>
+        rwpExc (ExceptT.mk (ExceptT.bindCont f ea))
+          (ExceptT.mk (ExceptT.bindCont g eb)) post) ≤
+      rwpExc (x >>= f) (y >>= g) post :=
   MAlgRelOrdered.rwp_bind_le _ _ _ _ _
 
 end Exc
@@ -810,6 +812,30 @@ theorem rwpExc_pure_right (x : ExceptT ε₁ m₁ α) (b : β)
       MAlgOrdered.wpExc x (fun a => post (Except.ok a) (Except.ok b))
         (fun e => post (Except.error e) (Except.ok b)) := by
   rw [rwpExc_def, ExceptT.run_pure, Anchored.rwp_pure_right]
+  congr 1
+  funext ea
+  cases ea <;> rfl
+
+/-- Anchoring also collapses `rwpExc` when the left side throws immediately. -/
+theorem rwpExc_throw_left (e : ε₁) (y : ExceptT ε₂ m₂ β)
+    (post : Except ε₁ α → Except ε₂ β → l) :
+    rwpExc (ExceptT.mk (pure (Except.error e)) : ExceptT ε₁ m₁ α) y post =
+      MAlgOrdered.wpExc y (fun b => post (Except.error e) (Except.ok b))
+        (fun e' => post (Except.error e) (Except.error e')) := by
+  change MAlgRelOrdered.rwp (pure (Except.error e) : m₁ (Except ε₁ α)) y.run post = _
+  rw [Anchored.rwp_pure_left]
+  congr 1
+  funext eb
+  cases eb <;> rfl
+
+/-- Anchoring also collapses `rwpExc` when the right side throws immediately. -/
+theorem rwpExc_throw_right (x : ExceptT ε₁ m₁ α) (e : ε₂)
+    (post : Except ε₁ α → Except ε₂ β → l) :
+    rwpExc x (ExceptT.mk (pure (Except.error e)) : ExceptT ε₂ m₂ β) post =
+      MAlgOrdered.wpExc x (fun a => post (Except.ok a) (Except.error e))
+        (fun e' => post (Except.error e') (Except.error e)) := by
+  change MAlgRelOrdered.rwp x.run (pure (Except.error e) : m₂ (Except ε₂ β)) post = _
+  rw [Anchored.rwp_pure_right]
   congr 1
   funext ea
   cases ea <;> rfl

--- a/PolyFun/Control/Monad/Algebra/Relational.lean
+++ b/PolyFun/Control/Monad/Algebra/Relational.lean
@@ -653,9 +653,11 @@ freeze the relational `rwp` to the underlying unary `wp` at one of the two corne
 recovering Maillard et al.'s "two unary triples + a relational triple" pattern from
 [*The Next 700 Relational Program Logics*, POPL 2020] without committing to the full
 relative-monad machinery. They are precisely the ingredient missing from the lossy
-exception lifts (see `exceptTLeft` / `exceptTRight` above): once anchored, one
-can derive *honest exception* combinators `wpExc` (unary) and `rwpExc` (relational)
-that track success and failure separately rather than collapsing failures to `⊥`.
+exception lifts (see `exceptTLeft` / `exceptTRight` above), which collapse failure to
+`⊥`. The honest combinators that track success and failure separately are
+`MAlgOrdered.wpExc` (unary) and `rwpExc` (relational) below; anchoring is what lets
+`rwpExc_pure_left` / `rwpExc_pure_right` collapse the relational statement to the unary
+one once either side is a `pure`.
 
 Anchoring is independent of `StrictBind`. A coupling-based probabilistic carrier is
 anchored (Dirac couplings are unique) but is not strict, while a deterministic
@@ -699,5 +701,119 @@ theorem relWP_pure_right [Anchored m₁ m₂ l] (x : m₁ α) (b : β) (post : �
   Anchored.rwp_pure_right x b post
 
 end Anchored
+
+/-! ## Honest relational exception WP
+
+`rwpExc` is the relational sibling of `MAlgOrdered.wpExc`. It evaluates two `ExceptT`
+computations against a postcondition indexed by *both* result branches, so all four
+success/failure combinations are tracked separately, rather than collapsing failure to
+`⊥` the way the `exceptTLeft` / `exceptTRight` lifts above do.
+
+Like `wpExc` it is derived: it uses only the *base* relational algebra
+`MAlgRelOrdered m₁ m₂ l` on the underlying monads, never a lifted one. Under `Anchored`
+it collapses to the unary `wpExc` whenever one side is a `pure`, which is the payoff the
+anchoring axioms were introduced for.
+-/
+
+section Exc
+
+variable {m₁ : Type u → Type v₁} {m₂ : Type u → Type v₂} {l : Type u}
+variable [Monad m₁] [Monad m₂] [Preorder l] [MAlgRelOrdered m₁ m₂ l]
+variable {α β γ δ ε₁ ε₂ : Type u}
+
+/-- Relational weakest precondition for a pair of `ExceptT` computations, tracking the
+success and failure branches of both sides separately. -/
+def rwpExc (x : ExceptT ε₁ m₁ α) (y : ExceptT ε₂ m₂ β)
+    (post : Except ε₁ α → Except ε₂ β → l) : l :=
+  MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) x.run y.run post
+
+theorem rwpExc_def (x : ExceptT ε₁ m₁ α) (y : ExceptT ε₂ m₂ β)
+    (post : Except ε₁ α → Except ε₂ β → l) :
+    rwpExc x y post = MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) x.run y.run post :=
+  rfl
+
+/-- Both sides succeed. -/
+@[simp] theorem rwpExc_pure_pure (a : α) (b : β)
+    (post : Except ε₁ α → Except ε₂ β → l) :
+    rwpExc (pure a : ExceptT ε₁ m₁ α) (pure b : ExceptT ε₂ m₂ β) post =
+      post (Except.ok a) (Except.ok b) :=
+  MAlgRelOrdered.rwp_pure _ _ _
+
+/-- The left side throws while the right succeeds: the failure branch is *recorded*,
+not collapsed. -/
+@[simp] theorem rwpExc_throw_pure (e : ε₁) (b : β)
+    (post : Except ε₁ α → Except ε₂ β → l) :
+    rwpExc (ExceptT.mk (pure (Except.error e)) : ExceptT ε₁ m₁ α)
+      (pure b : ExceptT ε₂ m₂ β) post = post (Except.error e) (Except.ok b) :=
+  MAlgRelOrdered.rwp_pure _ _ _
+
+/-- The right side throws while the left succeeds. -/
+@[simp] theorem rwpExc_pure_throw (a : α) (e : ε₂)
+    (post : Except ε₁ α → Except ε₂ β → l) :
+    rwpExc (pure a : ExceptT ε₁ m₁ α)
+      (ExceptT.mk (pure (Except.error e)) : ExceptT ε₂ m₂ β) post =
+      post (Except.ok a) (Except.error e) :=
+  MAlgRelOrdered.rwp_pure _ _ _
+
+/-- Both sides throw. -/
+@[simp] theorem rwpExc_throw_throw (e₁ : ε₁) (e₂ : ε₂)
+    (post : Except ε₁ α → Except ε₂ β → l) :
+    rwpExc (ExceptT.mk (pure (Except.error e₁)) : ExceptT ε₁ m₁ α)
+      (ExceptT.mk (pure (Except.error e₂)) : ExceptT ε₂ m₂ β) post =
+      post (Except.error e₁) (Except.error e₂) :=
+  MAlgRelOrdered.rwp_pure _ _ _
+
+/-- Monotonicity in the four-branch postcondition. -/
+theorem rwpExc_mono {x : ExceptT ε₁ m₁ α} {y : ExceptT ε₂ m₂ β}
+    {post post' : Except ε₁ α → Except ε₂ β → l}
+    (hpost : ∀ ea eb, post ea eb ≤ post' ea eb) :
+    rwpExc x y post ≤ rwpExc x y post' :=
+  MAlgRelOrdered.rwp_mono hpost
+
+/-- Sequential composition, inherited from `rwp_bind_le`. The continuations run on the
+underlying monads, so the failure branches of `x` and `y` are threaded by the caller's
+postcondition rather than short-circuited here. -/
+theorem rwpExc_bind_le (x : ExceptT ε₁ m₁ α) (y : ExceptT ε₂ m₂ β)
+    (f : Except ε₁ α → m₁ (Except ε₁ γ)) (g : Except ε₂ β → m₂ (Except ε₂ δ))
+    (post : Except ε₁ γ → Except ε₂ δ → l) :
+    MAlgRelOrdered.rwp x.run y.run
+        (fun ea eb => MAlgRelOrdered.rwp (f ea) (g eb) post) ≤
+      MAlgRelOrdered.rwp (x.run >>= f) (y.run >>= g) post :=
+  MAlgRelOrdered.rwp_bind_le _ _ _ _ _
+
+end Exc
+
+section AnchoredExc
+
+variable {m₁ : Type u → Type v₁} {m₂ : Type u → Type v₂} {l : Type u}
+variable [Monad m₁] [Monad m₂] [CompleteLattice l] [MAlgRelOrdered m₁ m₂ l]
+variable [MAlgOrdered m₁ l] [MAlgOrdered m₂ l] [Anchored m₁ m₂ l]
+variable {α β ε₁ ε₂ : Type u}
+
+/-- Anchoring collapses `rwpExc` to the unary `wpExc` when the left side succeeds
+purely. This is the "two unary triples plus a relational triple" pattern: once one side
+is a Dirac, relational reasoning about exceptions becomes unary reasoning about them. -/
+theorem rwpExc_pure_left (a : α) (y : ExceptT ε₂ m₂ β)
+    (post : Except ε₁ α → Except ε₂ β → l) :
+    rwpExc (pure a : ExceptT ε₁ m₁ α) y post =
+      MAlgOrdered.wpExc y (fun b => post (Except.ok a) (Except.ok b))
+        (fun e => post (Except.ok a) (Except.error e)) := by
+  rw [rwpExc_def, ExceptT.run_pure, Anchored.rwp_pure_left]
+  congr 1
+  funext eb
+  cases eb <;> rfl
+
+/-- Anchoring on the right, symmetrically. -/
+theorem rwpExc_pure_right (x : ExceptT ε₁ m₁ α) (b : β)
+    (post : Except ε₁ α → Except ε₂ β → l) :
+    rwpExc x (pure b : ExceptT ε₂ m₂ β) post =
+      MAlgOrdered.wpExc x (fun a => post (Except.ok a) (Except.ok b))
+        (fun e => post (Except.error e) (Except.ok b)) := by
+  rw [rwpExc_def, ExceptT.run_pure, Anchored.rwp_pure_right]
+  congr 1
+  funext ea
+  cases ea <;> rfl
+
+end AnchoredExc
 
 end MAlgRelOrdered

--- a/PolyFunTest/Control/MonadAlgebraRelational.lean
+++ b/PolyFunTest/Control/MonadAlgebraRelational.lean
@@ -272,6 +272,23 @@ example (y : ExceptT Unit Id Nat) (post : Except Unit Nat → Except Unit Nat �
         (fun e => post (Except.ok 2) (Except.error e)) :=
   rwpExc_pure_left 2 y post
 
+/-- The relational bind rule preserves an existing error instead of running that
+side's continuation, while the successful side continues normally. -/
+example : rwpExc (m₁ := Id) (m₂ := Id)
+    ((ExceptT.mk (pure (Except.error "stop")) : ExceptT String Id Nat) >>=
+      fun _ => pure 99)
+    ((pure 3 : ExceptT Unit Id Nat) >>= fun n => pure (n + 1))
+    (fun ea eb => ea = Except.error "stop" ∧ eb = Except.ok 4) := by
+  have h := rwpExc_bind_le
+    (ExceptT.mk (pure (Except.error "stop")) : ExceptT String Id Nat)
+    (pure 3 : ExceptT Unit Id Nat) (fun _ => pure 99) (fun n => pure (n + 1))
+    (fun ea eb => ea = Except.error "stop" ∧ eb = Except.ok 4)
+  change _ → _ at h
+  apply h
+  change (Except.error "stop" : Except String Nat) = Except.error "stop" ∧
+    (Except.ok 4 : Except Unit Nat) = Except.ok 4
+  exact ⟨rfl, rfl⟩
+
 end HonestRelationalExceptions
 
 end PolyFunTest.MonadAlgebraRelational

--- a/PolyFunTest/Control/MonadAlgebraRelational.lean
+++ b/PolyFunTest/Control/MonadAlgebraRelational.lean
@@ -246,4 +246,32 @@ example : RelWP (m₁ := Id) (m₂ := ExceptT Unit Id) (2 : Nat) (pure 3)
 
 end RightExcept
 
+section HonestRelationalExceptions
+
+/-! `rwpExc` keeps the four success/failure combinations apart, where the `exceptTLeft` /
+`exceptTRight` lifts collapse failure to `⊥`. The `Anchored` instance above is what makes
+the collapse-to-unary laws available. -/
+
+/-- Both sides succeed: the postcondition is read at the two `ok` branches. -/
+example : rwpExc (m₁ := Id) (m₂ := Id) (ε₁ := Unit) (ε₂ := Unit)
+    (pure 2) (pure 3) (fun ea eb => ea = Except.ok 2 ∧ eb = Except.ok 3) :=
+  by simp
+
+/-- A thrown exception is *recorded*, not collapsed. Under the lossy `ExceptT` lifts this
+postcondition would be unreachable; here it is just the `error`/`ok` corner. -/
+example (e : Unit) : rwpExc (m₁ := Id) (m₂ := Id) (ε₂ := Unit)
+    (ExceptT.mk (pure (Except.error e)) : ExceptT Unit Id Nat) (pure 3)
+    (fun ea eb => ea = Except.error e ∧ eb = Except.ok 3) :=
+  by simp
+
+/-- Anchoring: with a pure left side, the relational statement becomes the unary `wpExc`
+of the right side. -/
+example (y : ExceptT Unit Id Nat) (post : Except Unit Nat → Except Unit Nat → Prop) :
+    rwpExc (m₁ := Id) (m₂ := Id) (pure 2 : ExceptT Unit Id Nat) y post =
+      MAlgOrdered.wpExc y (fun b => post (Except.ok 2) (Except.ok b))
+        (fun e => post (Except.ok 2) (Except.error e)) :=
+  rwpExc_pure_left 2 y post
+
+end HonestRelationalExceptions
+
 end PolyFunTest.MonadAlgebraRelational


### PR DESCRIPTION
`Anchored`'s docstring promised that anchoring would let one *"derive honest exception combinators `wpExc` (unary) and `rwpExc` (relational)"*. The state of play before this PR:

- `wpExc` existed, with six rules and **zero consumers**.
- `rwpExc` was **never written** — it appeared only in that docstring.
- `Anchored` had **zero consumers** and no witness outside the test file.

Writing the missing half gives all three something to do at once.

### `rwpExc`

Evaluates a pair of `ExceptT` computations against a postcondition indexed by *both* result branches, so the four success/failure combinations stay apart rather than collapsing failure to `⊥` the way the `exceptTLeft` / `exceptTRight` lifts do. Like `wpExc` it is derived — it uses only the base relational algebra `MAlgRelOrdered m₁ m₂ l` on the underlying monads, never a lifted one.

Ships with the four corner rules (`pure`/`pure`, `throw`/`pure`, `pure`/`throw`, `throw`/`throw`), a monotonicity rule, and the sequential rule inherited from `rwp_bind_le`.

### The anchoring payoff

`rwpExc_pure_left` / `rwpExc_pure_right` collapse the relational statement to the unary `wpExc` of the other side once either side is a `pure` — Maillard et al.'s "two unary triples plus a relational triple" pattern, and the first actual consumers of the `Anchored` axioms.

### Tests

Three examples against the test file's existing `Anchored Id Id Prop` witness: both sides succeeding; a thrown exception being *recorded* rather than collapsed (a postcondition unreachable under the lossy lifts); and the anchoring collapse itself.

### Note on scope

I did not add a library-level `Anchored` witness. The natural candidates are the `StateT` relational lifts, mirroring the three `strictBindStateT*` witnesses — but `Anchored (StateT σ m₁) m₂ (σ → l)` needs `MAlgOrdered m₂ (σ → l)`, and the base only supplies `MAlgOrdered m₂ l`. That carrier mismatch is probably why the witnesses were never written; recording it here so it isn't rediscovered.

### Validation

`./scripts/validate.sh --lint --test` — build, lint, and test all pass, with no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### Review follow-up

A formalization review found that the original `rwpExc_bind_le` only wrapped raw underlying-monad bind: its continuations accepted `Except` directly and could therefore continue after an error. That did not model `ExceptT.bind`.

The follow-up commit:

- changes `rwpExc_bind_le` to accept actual `ExceptT` continuations and propagate errors through `ExceptT.bindCont`;
- adds the missing anchored collapse rules for immediate throws on either side; and
- adds one mixed-branch canary proving that an existing error short-circuits its continuation while the successful side continues.

Validation: `./scripts/validate.sh --lint --test --axioms`, `lake exe lint-style`, and `git diff --check` all pass. The axiom sweep covers 10,239 declarations across 259 modules with zero `sorryAx` or non-standard-axiom taint.