### PR TITLE
feat(control): give the algebra layers an automation contract and the simp set to match

### DIFF
--- a/PolyFun/Control/Monad/Algebra.lean
+++ b/PolyFun/Control/Monad/Algebra.lean
@@ -57,8 +57,8 @@ attribute [simp] monadAlg_pure monadAlg_bind
 The `@[simp]` set here drives `wp` *inwards* through program structure until it meets a
 leaf, mirroring the way core's monad simp set drives `bind` towards right-nested normal
 form. Four lemmas carry it — `wp_pure`, `wp_bind`, `wp_map`, `wp_seq` — and each strictly
-decreases the syntactic size of the program argument, so the set is terminating and
-confluent on the fragment built from `pure`, `>>=`, `<$>`, and `<*>`.
+decreases the program argument to proper subprograms. Together they normalize the
+fragment built from `pure`, `>>=`, `<$>`, and `<*>`.
 
 Deliberately untagged: `wp_mono` and every `Triple` rule. They are not equations, and the
 `Triple` rules are directed reasoning steps a user chooses, not normalizations. `wpExc` /

--- a/PolyFun/Control/Monad/Algebra.lean
+++ b/PolyFun/Control/Monad/Algebra.lean
@@ -50,7 +50,26 @@ export LawfulMonadAlgebra (monadAlg_pure monadAlg_bind)
 
 attribute [simp] monadAlg_pure monadAlg_bind
 
-/-! ## Loom-style ordered monad algebras -/
+/-! ## Loom-style ordered monad algebras
+
+### Automation contract
+
+The `@[simp]` set here drives `wp` *inwards* through program structure until it meets a
+leaf, mirroring the way core's monad simp set drives `bind` towards right-nested normal
+form. Four lemmas carry it — `wp_pure`, `wp_bind`, `wp_map`, `wp_seq` — and each strictly
+decreases the syntactic size of the program argument, so the set is terminating and
+confluent on the fragment built from `pure`, `>>=`, `<$>`, and `<*>`.
+
+Deliberately untagged: `wp_mono` and every `Triple` rule. They are not equations, and the
+`Triple` rules are directed reasoning steps a user chooses, not normalizations. `wpExc` /
+`wpOpt` keep their own leaf rules tagged but not their `_def` unfoldings, so goals stated
+in terms of the honest two-postcondition combinators are not silently collapsed back into
+the lossy `⊥`-based ones.
+
+No `grind` annotations. `wp_bind` introduces a fresh higher-order argument
+(`fun a => wp (f a) post`) on its right-hand side, which is exactly the shape that makes
+`grind` saturate; `simp`'s inside-out rewriting handles it without that risk.
+-/
 
 /-- Ordered monad algebra interface used for quantitative WP/triple reasoning. -/
 class MAlgOrdered (m : Type u → Type v) (l : Type u) [Monad m] [CompleteLattice l] where
@@ -85,6 +104,7 @@ theorem wp_pure [LawfulMonad m] (x : α) (post : α → l) :
     wp (pure x : m α) post = post x := by
   simp [wp, MAlgOrdered.μ_pure]
 
+@[simp]
 theorem wp_bind [LawfulMonad m] (x : m α) (f : α → m β) (post : β → l) :
     wp (x >>= f) post = wp x (fun a => wp (f a) post) := by
   unfold wp
@@ -108,12 +128,14 @@ theorem wp_mono (x : m α) {post post' : α → l} (h : ∀ a, post a ≤ post' 
     x
 
 /-- `wp` is functorial in the program return value. -/
+@[simp]
 theorem wp_map [LawfulMonad m] (f : α → β) (x : m α) (post : β → l) :
     wp (f <$> x) post = wp x (fun a => post (f a)) := by
   simpa [Functor.map, bind_pure_comp] using
     (wp_bind (m := m) (l := l) x (fun a => pure (f a)) post)
 
 /-- `wp` preserves applicative sequencing. -/
+@[simp]
 theorem wp_seq [LawfulMonad m] (f : m (α → β)) (x : m α) (post : β → l) :
     wp (f <*> x) post = wp f (fun g => wp x (fun a => post (g a))) := by
   rw [seq_eq_bind_map, wp_bind]

--- a/PolyFun/Control/Monad/Algebra/Relational.lean
+++ b/PolyFun/Control/Monad/Algebra/Relational.lean
@@ -55,10 +55,10 @@ composition axiom is `rwp_bind_le`, an inequality, so the derived structural rul
 `bind` would be a strictly stronger assumption — which is precisely what `StrictBind`
 adds, and `relWP_bind` is tagged because under that class the law *is* an equation.
 
-So the equational content is: `relWP_pure` at the leaf, `relWP_bind` under `StrictBind`,
-and the four `rwpExc` corner rules. Everything else is a directed reasoning step the user
-chooses. Reaching for `simp` on a bare `RelWP` goal and finding nothing happens is the
-expected behaviour, not a missing lemma.
+The deliberately tagged relational equations are `relWP_pure` at the leaf, `relWP_bind`
+under `StrictBind`, and the four `rwpExc` corner rules. The remaining structural rules are
+directed reasoning steps the user chooses. Reaching for `simp` on a bare `RelWP` goal and
+finding nothing happens is the expected behaviour, not a missing lemma.
 
 No `grind` annotations, for the same reason as the unary layer: the bind rules introduce
 fresh higher-order arguments on the larger side.

--- a/PolyFun/Control/Monad/Algebra/Relational.lean
+++ b/PolyFun/Control/Monad/Algebra/Relational.lean
@@ -44,6 +44,26 @@ Attribution:
 
 universe u v₁ v₂
 
+/-! ### Automation contract
+
+The `@[simp]` set here is deliberately much thinner than the unary one in
+`PolyFun/Control/Monad/Algebra.lean`, and the reason is structural rather than an
+oversight: **the relational layer is inequational by design.** `MAlgRelOrdered`'s
+composition axiom is `rwp_bind_le`, an inequality, so the derived structural rules
+(`relWP_map_left`, `relWP_map_right`, `relWP_bind_left_le`, `relWP_bind_right_le`) are
+`≤` facts and cannot be rewrite rules at all. A relational logic that were equational at
+`bind` would be a strictly stronger assumption — which is precisely what `StrictBind`
+adds, and `relWP_bind` is tagged because under that class the law *is* an equation.
+
+So the equational content is: `relWP_pure` at the leaf, `relWP_bind` under `StrictBind`,
+and the four `rwpExc` corner rules. Everything else is a directed reasoning step the user
+chooses. Reaching for `simp` on a bare `RelWP` goal and finding nothing happens is the
+expected behaviour, not a missing lemma.
+
+No `grind` annotations, for the same reason as the unary layer: the bind rules introduce
+fresh higher-order arguments on the larger side.
+-/
+
 /-- Ordered relational monad algebra between two monads. -/
 class MAlgRelOrdered (m₁ : Type u → Type v₁) (m₂ : Type u → Type v₂) (l : Type u)
     [Monad m₁] [Monad m₂] [Preorder l] where
@@ -581,6 +601,7 @@ variable {α β γ δ : Type u}
 /-- Strict version of `relWP_bind_le`: under `StrictBind` the bind law is an
 equality, so the relational WP of a sequenced computation can be rewritten in
 either direction. -/
+@[simp]
 theorem relWP_bind [StrictBind m₁ m₂ l]
     (x : m₁ α) (y : m₂ β) (f : α → m₁ γ) (g : β → m₂ δ) (post : γ → δ → l) :
     RelWP x y (fun a b => RelWP (f a) (g b) post) = RelWP (x >>= f) (y >>= g) post :=

--- a/PolyFunTest/Control/MonadAlgebra.lean
+++ b/PolyFunTest/Control/MonadAlgebra.lean
@@ -62,4 +62,24 @@ example (ω : Type) [Monoid ω] (w₀ : ω) (post : PUnit → ω → Prop) :
 
 end Behaviour
 
+section Automation
+
+/-! The `@[simp]` set drives `wp` inwards through program structure until it reaches
+leaves. These are the checks behind the automation contract in
+`PolyFun/Control/Monad/Algebra.lean`. -/
+
+/-- A compound `do` block normalizes down to the one leaf that is not a `pure`. -/
+example (g : Nat → Id Nat) (f : Nat → Nat) (post : Nat → Prop) :
+    wp (do let a ← (pure 1 : Id Nat); let b ← g a; pure (f b)) post =
+      wp (g 1) (fun b => post (f b)) := by
+  simp
+
+/-- `<$>` and `<*>` are eliminated too, so the fragment closed under `pure`, `>>=`,
+`<$>`, and `<*>` normalizes completely. -/
+example (x : Id Nat) (h : Id (Nat → Nat)) (post : Nat → Prop) :
+    wp (h <*> x) post = wp h (fun g => wp x (fun a => post (g a))) := by
+  simp
+
+end Automation
+
 end PolyFunTest.MonadAlgebraCoverage

--- a/PolyFunTest/Control/MonadAlgebra.lean
+++ b/PolyFunTest/Control/MonadAlgebra.lean
@@ -65,19 +65,17 @@ end Behaviour
 section Automation
 
 /-! The `@[simp]` set drives `wp` inwards through program structure until it reaches
-leaves. These are the checks behind the automation contract in
+leaves. This is the canary behind the automation contract in
 `PolyFun/Control/Monad/Algebra.lean`. -/
 
-/-- A compound `do` block normalizes down to the one leaf that is not a `pure`. -/
-example (g : Nat → Id Nat) (f : Nat → Nat) (post : Nat → Prop) :
-    wp (do let a ← (pure 1 : Id Nat); let b ← g a; pure (f b)) post =
-      wp (g 1) (fun b => post (f b)) := by
-  simp
-
-/-- `<$>` and `<*>` are eliminated too, so the fragment closed under `pure`, `>>=`,
-`<$>`, and `<*>` normalizes completely. -/
-example (x : Id Nat) (h : Id (Nat → Nat)) (post : Nat → Prop) :
-    wp (h <*> x) post = wp h (fun g => wp x (fun a => post (g a))) := by
+/-- On an abstract monad, one `simp` call must use `wp_map`, `wp_bind`, and `wp_seq` to
+reach the three opaque computation leaves; no definitional `Id` reduction can bypass the
+new attributes. -/
+example {m : Type → Type} [Monad m] [LawfulMonad m] [MAlgOrdered m Prop]
+    {α β γ δ : Type} (mf : m (α → β)) (x : m α) (k : β → m γ) (h : γ → δ)
+    (post : δ → Prop) :
+    wp (h <$> ((mf <*> x) >>= k)) post =
+      wp mf (fun f => wp x (fun a => wp (k (f a)) (fun c => post (h c)))) := by
   simp
 
 end Automation

--- a/PolyFunTest/Control/MonadAlgebraRelational.lean
+++ b/PolyFunTest/Control/MonadAlgebraRelational.lean
@@ -294,19 +294,17 @@ end HonestRelationalExceptions
 section Automation
 
 /-! The relational simp set is thin by design: `MAlgRelOrdered`'s composition axiom is
-an *inequality*, so the derived structural rules cannot be rewrite rules. What is
-equational is the leaf, the `StrictBind` bind law, and the `rwpExc` corners. -/
+an *inequality*, so the derived structural rules cannot be rewrite rules. `StrictBind`
+is precisely what makes bind an equation that `simp` can use. -/
 
-/-- The leaf rule fires. -/
-example (post : Nat → Nat → Prop) (h : post 1 2) :
-    RelWP (m₁ := Id) (m₂ := Id) (pure 1) (pure 2) post := by
-  simpa using h
-
-/-- Under `StrictBind` the bind law is an equation, so `simp` decomposes a sequenced
-relational goal — which it cannot do without that class. -/
-example (f : Nat → Id Nat) (g : Nat → Id Nat) (post : Nat → Nat → Prop) :
-    RelWP (m₁ := Id) (m₂ := Id) ((pure 1 : Id Nat) >>= f) ((pure 2 : Id Nat) >>= g) post =
-      RelWP (f 1) (g 2) post := by
+/-- Abstract computations force this proof to use the new `relWP_bind` simp attribute;
+core's `pure_bind` rule cannot solve the goal first. -/
+example {m₁ m₂ : Type → Type} {l : Type} [Monad m₁] [Monad m₂] [Preorder l]
+    [MAlgRelOrdered m₁ m₂ l] [StrictBind m₁ m₂ l]
+    {α β γ δ : Type} (x : m₁ α) (y : m₂ β) (f : α → m₁ γ) (g : β → m₂ δ)
+    (post : γ → δ → l) :
+    RelWP (x >>= f) (y >>= g) post =
+      RelWP x y (fun a b => RelWP (f a) (g b) post) := by
   simp
 
 end Automation

--- a/PolyFunTest/Control/MonadAlgebraRelational.lean
+++ b/PolyFunTest/Control/MonadAlgebraRelational.lean
@@ -291,4 +291,24 @@ example : rwpExc (m₁ := Id) (m₂ := Id)
 
 end HonestRelationalExceptions
 
+section Automation
+
+/-! The relational simp set is thin by design: `MAlgRelOrdered`'s composition axiom is
+an *inequality*, so the derived structural rules cannot be rewrite rules. What is
+equational is the leaf, the `StrictBind` bind law, and the `rwpExc` corners. -/
+
+/-- The leaf rule fires. -/
+example (post : Nat → Nat → Prop) (h : post 1 2) :
+    RelWP (m₁ := Id) (m₂ := Id) (pure 1) (pure 2) post := by
+  simpa using h
+
+/-- Under `StrictBind` the bind law is an equation, so `simp` decomposes a sequenced
+relational goal — which it cannot do without that class. -/
+example (f : Nat → Id Nat) (g : Nat → Id Nat) (post : Nat → Nat → Prop) :
+    RelWP (m₁ := Id) (m₂ := Id) ((pure 1 : Id Nat) >>= f) ((pure 2 : Id Nat) >>= g) post =
+      RelWP (f 1) (g 2) post := by
+  simp
+
+end Automation
+
 end PolyFunTest.MonadAlgebraRelational


### PR DESCRIPTION
The audit that opened this cycle flagged the two algebra files as having essentially no simp set: one `@[simp]` in each, across 21 and 22 theorems respectively. One of those turned out to be a real gap and the other a design consequence, and the difference is worth recording so the second one isn't "fixed" later.

### The unary layer had a real gap

`wp_pure` was tagged; `wp_bind`, `wp_map`, and `wp_seq` were not — so a compound `wp` goal could not be normalized at all. All three are now `@[simp]`. Each reduces the program argument to proper subprograms. Together they normalize the fragment built from `pure`, `>>=`, `<$>`, and `<*>`. The effect is that `wp` is driven *inwards* through program structure until it reaches a leaf, mirroring how core's monad simp set drives `bind` toward right-nested normal form.

Deliberately untagged, and now recorded as such: `wp_mono` and every `Triple` rule (not equations, and the `Triple` rules are directed reasoning steps a user chooses); and the `wpExc` / `wpOpt` `_def` unfoldings, so a goal stated with the honest two-postcondition combinators is not silently collapsed back into the lossy `⊥`-based ones.

No `grind` annotations, with the reason stated: `wp_bind` introduces a fresh higher-order argument (`fun a => wp (f a) post`) on its right-hand side, which is exactly the shape that makes `grind` saturate. `simp`'s inside-out rewriting handles it without that risk.

### The relational layer's thin simp set is not a gap

`MAlgRelOrdered`'s composition axiom is `rwp_bind_le` — an **inequality**. So the derived structural rules (`relWP_map_left`, `relWP_map_right`, `relWP_bind_left_le`, `relWP_bind_right_le`) are `≤` facts and cannot be rewrite rules at all. A relational logic that were equational at `bind` would be a strictly stronger assumption, which is exactly what `StrictBind` adds — so `relWP_bind` is now tagged, since under that class the law *is* an equation.

The deliberately tagged relational equations are `relWP_pure` at the leaf, `relWP_bind` under `StrictBind`, and the four `rwpExc` corner rules from #167. Reaching for `simp` on a bare `RelWP` goal and finding nothing happen is the expected behaviour, and the file now says so rather than leaving it to be rediscovered as a defect.

### Checks, not assertions

Two abstract-monad canaries now exercise the attributes without allowing `Id` reduction or core `pure_bind` simplification to bypass them: one jointly covers `wp_map`, `wp_bind`, and `wp_seq`; the other forces the `StrictBind.relWP_bind` rewrite on opaque computations.

### Validation

`./scripts/validate.sh --lint --test` — build, lint (environment linters, so `simpNF` included), and test all pass, with no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### Review follow-up

A formalization review confirmed that the four simp rules are sound, terminating on the stated program fragment, and oriented in the intended direction. It found that the original four examples were not discriminating: their use of `Id` and `pure >>= ...` allowed definitional/core simplification to solve the goals without necessarily exercising the new attributes.

The follow-up commit replaces those four examples with two stronger abstract-monad canaries, covering all newly tagged rules while reducing test count. It also removes the unproved `confluent` claim and narrows the relational documentation from all equational content to the equations deliberately tagged for simp.

Validation: `./scripts/validate.sh --lint --test --axioms`, `lake exe lint-style`, and `git diff --check` all pass. The axiom sweep covers 10,239 declarations across 259 modules with zero `sorryAx` or non-standard-axiom taint.