### PR TITLE
feat(realizability): add generic polynomial resource contracts

### DIFF
--- a/PolyFun.lean
+++ b/PolyFun.lean
@@ -253,6 +253,7 @@ public import PolyFun.Realizability.Quantitative
 public import PolyFun.Realizability.Quantitative.BoundedClosure
 public import PolyFun.Realizability.Quantitative.Closure
 public import PolyFun.Realizability.Quantitative.Polynomial
+public import PolyFun.Realizability.Quantitative.Resource
 public import PolyFun.Realizability.Quantitative.WordClass
 public import PolyFun.Realizability.Representation
 public import PolyFun.Realizability.StepClass

--- a/PolyFun/Realizability/Basic.lean
+++ b/PolyFun/Realizability/Basic.lean
@@ -97,9 +97,29 @@ structure Boundary (C : StepClass.{u, v}) (p : PFunctor.{u, u}) (α β : Type u)
   /-- Representation of the interface's index space `Idx p = Σ a, p.B a`. -/
   idx : C.Str p.Idx
 
+/-- The interface portion of a realizability boundary, independent of a program's input and
+returned-value representations.
+
+This projection is useful when several programs share one response policy or resource contract.
+The position and index representations remain independent because a step class need not construct
+dependent-sum representations. -/
+structure InterfaceBoundary (C : StepClass.{u, v}) (p : PFunctor.{u, u}) : Type v where
+  /-- Representation of the interface's query positions. -/
+  pos : C.Str p.A
+  /-- Representation of the interface's dependent position-response index. -/
+  idx : C.Str p.Idx
+
 namespace Boundary
 
 variable {C : StepClass.{u, v}}
+
+/-- Forget a boundary's input and returned-value representations. -/
+def interface (bd : Boundary C p α β) : InterfaceBoundary C p :=
+  ⟨bd.pos, bd.idx⟩
+
+@[simp] theorem interface_pos (bd : Boundary C p α β) : bd.interface.pos = bd.pos := rfl
+
+@[simp] theorem interface_idx (bd : Boundary C p α β) : bd.interface.idx = bd.idx := rfl
 
 /-- The representation of a machine's one-step readout `β ⊕ p.A`, assembled from
 the result and position representations. -/

--- a/PolyFun/Realizability/Basic.lean
+++ b/PolyFun/Realizability/Basic.lean
@@ -114,6 +114,7 @@ namespace Boundary
 variable {C : StepClass.{u, v}}
 
 /-- Forget a boundary's input and returned-value representations. -/
+@[implicit_reducible]
 def interface (bd : Boundary C p α β) : InterfaceBoundary C p :=
   ⟨bd.pos, bd.idx⟩
 
@@ -134,12 +135,14 @@ def stateIdx [P : C.HasProd] (bd : Boundary C p α β) {S : Type u}
 
 /-- Replace the input representation of a boundary, keeping the result and
 interface representations. -/
+@[implicit_reducible]
 def withInput {γ : Type u} (bd : Boundary C p α β) (inputRep : C.Str γ) :
     Boundary C p γ β :=
   ⟨inputRep, bd.out, bd.pos, bd.idx⟩
 
 /-- Replace the result representation of a boundary, keeping the input and
 interface representations. -/
+@[implicit_reducible]
 def withOut {γ : Type u} (bd : Boundary C p α β) (outRep : C.Str γ) :
     Boundary C p α γ :=
   ⟨bd.input, outRep, bd.pos, bd.idx⟩
@@ -164,6 +167,7 @@ equality between two boundaries would force `subst` transport at every use site;
 deriving the middle boundary makes every compatibility fact hold by `rfl`. The
 composite boundary of a sequential composition is then simply
 `bd.withOut outRep`. -/
+@[implicit_reducible]
 def mid {γ : Type u} (bd : Boundary C p α β) (outRep : C.Str γ) :
     Boundary C p β γ :=
   (bd.withOut outRep).withInput bd.out

--- a/PolyFun/Realizability/Quantitative/Resource.lean
+++ b/PolyFun/Realizability/Quantitative/Resource.lean
@@ -333,6 +333,13 @@ def bound (certificate : PolynomialRunBound R contract) (model : contract.Model)
     input → ExecutionCost :=
   fun value ↦ certificate.polynomial.eval model.modulus (Q.size bd.input value)
 
+@[simp]
+theorem bound_apply (certificate : PolynomialRunBound R contract) (model : contract.Model)
+    (value : input) :
+    certificate.bound model value =
+      certificate.polynomial.eval model.modulus (Q.size bd.input value) := by
+  simp [bound]
+
 /-- Restate the certificate's pathwise theorem through its named input-indexed bound. -/
 theorem runsWithin_bound (certificate : PolynomialRunBound R contract)
     (model : contract.Model) :
@@ -573,12 +580,14 @@ end PureResourceCertificate
 namespace RankedResource
 
 /-- Cost of observing a state as the final state of an execution prefix. -/
+@[expose]
 def terminalCost (R : QuantitativeRealization Q bd) (state : R.machine.State) :
     ExecutionCost :=
   ExecutionCost.ofWork (Q.cost R.headCode state) +
     ExecutionCost.observe (Q.size R.state state) (Q.size bd.head (R.machine.head state))
 
 /-- Cost contributed by one enabled position-response transition. -/
+@[expose]
 def queryStepCost (R : QuantitativeRealization Q bd) (state : R.machine.State)
     (position : p.A) (direction : p.B position) : ExecutionCost :=
   ExecutionCost.ofWork (Q.cost R.headCode state) +
@@ -807,6 +816,7 @@ variable {program₁ : input → FreeM p output} {program₂ : output → FreeM 
 
 /-- Compose program witnesses along `FreeM.bind`, keeping semantic implementation separate from
 the resource decomposition certificates needed by the two execution phases. -/
+@[expose]
 def bind (first : PolynomialProgramWitness Q bd contract program₁)
     (second : PolynomialProgramWitness Q (bd.mid middleOut) contract program₂)
     (handoff : PolynomialSeqCompHandoffBound first.realization second.realization contract

--- a/PolyFun/Realizability/Quantitative/Resource.lean
+++ b/PolyFun/Realizability/Quantitative/Resource.lean
@@ -1,0 +1,830 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+
+module
+
+public import PolyFun.Realizability.Quantitative.BoundedClosure
+public import PolyFun.Realizability.Quantitative.Polynomial
+
+/-!
+# Resource contracts for quantitative realizations
+
+This module gives `ExecutionCost` an inspectable second-order polynomial bound and describes the
+response-size environments under which an open quantitative realization runs. The definitions are
+generic in a polynomial-functor interface and a quantitative backend. They do not select a machine
+model or assert a complexity class.
+
+`PolynomialRunBound` concerns one already chosen realization and is deliberately independent of
+semantic `FreeM` syntax. `PolynomialProgramWitness` adds implementation and returned-output
+recovery as a separate layer. Local pure, ranked-potential, and sequential-composition
+certificates construct these bounds without replacing backend costs by an asserted meter.
+-/
+
+public section
+
+universe u v w x y
+
+namespace PFunctor
+
+/-! ## Execution-cost polynomials -/
+
+/-- A second-order polynomial upper bound for every component of `ExecutionCost`. -/
+structure ExecutionCostPolynomial (label : Type x) where
+  /-- Backend-relative local work. -/
+  work : _root_.Complexity.SecondOrderPolynomial label
+  /-- Number of visible interactions. -/
+  queries : _root_.Complexity.SecondOrderPolynomial label
+  /-- Total encoded position-response traffic. -/
+  traffic : _root_.Complexity.SecondOrderPolynomial label
+  /-- Peak encoded hidden-state size. -/
+  peakStateSize : _root_.Complexity.SecondOrderPolynomial label
+  /-- Peak encoded one-step readout size. -/
+  peakHeadSize : _root_.Complexity.SecondOrderPolynomial label
+  deriving DecidableEq, Repr
+
+namespace ExecutionCostPolynomial
+
+variable {label : Type x}
+
+/-- Regard a first-order polynomial as one which does not inspect its length environment. -/
+def ofFirstOrder (bound : _root_.Complexity.FirstOrderPolynomial) :
+    _root_.Complexity.SecondOrderPolynomial label :=
+  bound.reindex PEmpty.elim
+
+@[simp]
+theorem eval_ofFirstOrder (bound : _root_.Complexity.FirstOrderPolynomial)
+    (length : label → ℕ → ℕ) (inputSize : ℕ) :
+    (ofFirstOrder bound : _root_.Complexity.SecondOrderPolynomial label).eval length inputSize =
+      bound.eval inputSize := by
+  unfold ofFirstOrder
+  rw [_root_.Complexity.SecondOrderPolynomial.eval_reindex]
+  change _ = _root_.Complexity.SecondOrderPolynomial.eval PEmpty.elim inputSize bound
+  congr 1
+  funext interface
+  exact interface.elim
+
+/-- Evaluate every resource component at an input size and length environment. -/
+def eval (bound : ExecutionCostPolynomial label) (length : label → ℕ → ℕ)
+    (inputSize : ℕ) : ExecutionCost where
+  work := bound.work.eval length inputSize
+  queries := bound.queries.eval length inputSize
+  traffic := bound.traffic.eval length inputSize
+  peakStateSize := bound.peakStateSize.eval length inputSize
+  peakHeadSize := bound.peakHeadSize.eval length inputSize
+
+@[simp] theorem eval_work (bound : ExecutionCostPolynomial label) (length : label → ℕ → ℕ)
+    (inputSize : ℕ) : (bound.eval length inputSize).work = bound.work.eval length inputSize := by
+  simp [eval]
+
+@[simp] theorem eval_queries (bound : ExecutionCostPolynomial label)
+    (length : label → ℕ → ℕ) (inputSize : ℕ) :
+    (bound.eval length inputSize).queries = bound.queries.eval length inputSize := by
+  simp [eval]
+
+@[simp] theorem eval_traffic (bound : ExecutionCostPolynomial label)
+    (length : label → ℕ → ℕ) (inputSize : ℕ) :
+    (bound.eval length inputSize).traffic = bound.traffic.eval length inputSize := by
+  simp [eval]
+
+@[simp] theorem eval_peakStateSize (bound : ExecutionCostPolynomial label)
+    (length : label → ℕ → ℕ) (inputSize : ℕ) :
+    (bound.eval length inputSize).peakStateSize =
+      bound.peakStateSize.eval length inputSize := by
+  simp [eval]
+
+@[simp] theorem eval_peakHeadSize (bound : ExecutionCostPolynomial label)
+    (length : label → ℕ → ℕ) (inputSize : ℕ) :
+    (bound.eval length inputSize).peakHeadSize =
+      bound.peakHeadSize.eval length inputSize := by
+  simp [eval]
+
+/-- A constant execution-cost bound. -/
+def const (cost : ExecutionCost) : ExecutionCostPolynomial label where
+  work := .const cost.work
+  queries := .const cost.queries
+  traffic := .const cost.traffic
+  peakStateSize := .const cost.peakStateSize
+  peakHeadSize := .const cost.peakHeadSize
+
+/-- A conservative sequential sum of two execution-cost bounds.
+
+The additive components add exactly. Polynomial addition upper-bounds the `max` used by the two
+peak components. -/
+def add (left right : ExecutionCostPolynomial label) : ExecutionCostPolynomial label where
+  work := .add left.work right.work
+  queries := .add left.queries right.queries
+  traffic := .add left.traffic right.traffic
+  peakStateSize := .add left.peakStateSize right.peakStateSize
+  peakHeadSize := .add left.peakHeadSize right.peakHeadSize
+
+instance : Add (ExecutionCostPolynomial label) := ⟨add⟩
+
+/-- Replace the base input-size variable in every component. -/
+def comp (bound : ExecutionCostPolynomial label)
+    (inputBound : _root_.Complexity.SecondOrderPolynomial label) :
+    ExecutionCostPolynomial label where
+  work := bound.work.comp inputBound
+  queries := bound.queries.comp inputBound
+  traffic := bound.traffic.comp inputBound
+  peakStateSize := bound.peakStateSize.comp inputBound
+  peakHeadSize := bound.peakHeadSize.comp inputBound
+
+/-- Relabel every length-function symbol in an execution-cost bound. -/
+def reindex {target : Type y} (bound : ExecutionCostPolynomial label) (map : label → target) :
+    ExecutionCostPolynomial target where
+  work := bound.work.reindex map
+  queries := bound.queries.reindex map
+  traffic := bound.traffic.reindex map
+  peakStateSize := bound.peakStateSize.reindex map
+  peakHeadSize := bound.peakHeadSize.reindex map
+
+/-- Substitute a second-order transformer for every source length-function symbol. -/
+def subst {target : Type y} (bound : ExecutionCostPolynomial label)
+    (replacement : label → _root_.Complexity.SecondOrderPolynomial target) :
+    ExecutionCostPolynomial target where
+  work := bound.work.subst replacement
+  queries := bound.queries.subst replacement
+  traffic := bound.traffic.subst replacement
+  peakStateSize := bound.peakStateSize.subst replacement
+  peakHeadSize := bound.peakHeadSize.subst replacement
+
+@[simp]
+theorem eval_const (cost : ExecutionCost) (length : label → ℕ → ℕ) (inputSize : ℕ) :
+    (const cost : ExecutionCostPolynomial label).eval length inputSize = cost :=
+  by
+    ext <;> simp [const, eval]
+
+@[simp]
+theorem eval_comp (bound : ExecutionCostPolynomial label)
+    (inputBound : _root_.Complexity.SecondOrderPolynomial label)
+    (length : label → ℕ → ℕ) (inputSize : ℕ) :
+    (bound.comp inputBound).eval length inputSize =
+      bound.eval length (inputBound.eval length inputSize) := by
+  ext <;> simp [eval, comp]
+
+@[simp]
+theorem eval_reindex {target : Type y} (bound : ExecutionCostPolynomial label)
+    (map : label → target) (length : target → ℕ → ℕ) (inputSize : ℕ) :
+    (bound.reindex map).eval length inputSize =
+      bound.eval (fun symbol ↦ length (map symbol)) inputSize := by
+  ext <;> simp [eval, reindex]
+
+@[simp]
+theorem eval_subst {target : Type y} (bound : ExecutionCostPolynomial label)
+    (replacement : label → _root_.Complexity.SecondOrderPolynomial target)
+    (length : target → ℕ → ℕ) (inputSize : ℕ) :
+    (bound.subst replacement).eval length inputSize =
+      bound.eval (fun symbol size ↦ (replacement symbol).eval length size) inputSize := by
+  ext <;> simp [eval, subst]
+
+/-- Sequentially accumulated costs fit the conservative polynomial sum. -/
+theorem add_eval_le_eval_add (left right : ExecutionCostPolynomial label)
+    (length : label → ℕ → ℕ) (inputSize : ℕ) :
+    left.eval length inputSize + right.eval length inputSize ≤
+      (left + right).eval length inputSize := by
+  rw [ExecutionCost.le_iff]
+  exact ⟨le_rfl, le_rfl, le_rfl, max_le (Nat.le_add_right _ _) (Nat.le_add_left _ _),
+    max_le (Nat.le_add_right _ _) (Nat.le_add_left _ _)⟩
+
+/-- Evaluation is monotone in encoded input size when every length function is monotone. -/
+theorem eval_mono_input (bound : ExecutionCostPolynomial label) {length : label → ℕ → ℕ}
+    (hLength : _root_.Complexity.SecondOrderPolynomial.MonotoneLengths length)
+    {smaller larger : ℕ} (hle : smaller ≤ larger) :
+    bound.eval length smaller ≤ bound.eval length larger := by
+  rw [ExecutionCost.le_iff]
+  exact ⟨bound.work.eval_monotone hLength hle, bound.queries.eval_monotone hLength hle,
+    bound.traffic.eval_monotone hLength hle, bound.peakStateSize.eval_monotone hLength hle,
+    bound.peakHeadSize.eval_monotone hLength hle⟩
+
+/-- Evaluation is monotone under pointwise enlargement of monotone length functions. -/
+theorem eval_mono_lengths (bound : ExecutionCostPolynomial label)
+    {smaller larger : label → ℕ → ℕ}
+    (hLarger : _root_.Complexity.SecondOrderPolynomial.MonotoneLengths larger)
+    (hle : ∀ symbol size, smaller symbol size ≤ larger symbol size) (inputSize : ℕ) :
+    bound.eval smaller inputSize ≤ bound.eval larger inputSize := by
+  rw [ExecutionCost.le_iff]
+  exact ⟨bound.work.eval_mono_lengths hLarger hle inputSize,
+    bound.queries.eval_mono_lengths hLarger hle inputSize,
+    bound.traffic.eval_mono_lengths hLarger hle inputSize,
+    bound.peakStateSize.eval_mono_lengths hLarger hle inputSize,
+    bound.peakHeadSize.eval_mono_lengths hLarger hle inputSize⟩
+
+end ExecutionCostPolynomial
+
+namespace DynSystem.DynComputation
+
+/-! ## Response-size environments -/
+
+variable {p : PFunctor.{u, u}} {C : StepClass.{u, v}}
+  {Q : QuantitativeStepClass.{u, v, w} C} {label : Type x}
+
+/-- The response-length function exposed for each labelled interface. -/
+inductive ResponseModulus (label : Type x) where
+  /-- Encoded dependent-response length as a function of encoded position length. -/
+  | responseSize (interface : label)
+  deriving DecidableEq, Repr
+
+/-- One family of admitted responses and monotone encoded-response size envelopes. -/
+structure ResponseResourceModel (Q : QuantitativeStepClass.{u, v, w} C)
+    (interface : InterfaceBoundary C p) (labelOf : p.A → label) where
+  /-- Replies admitted at each typed position. -/
+  allows : ∀ position : p.A, p.B position → Prop
+  /-- Encoded response length for each labelled interface. -/
+  responseSize : label → ℕ → ℕ
+  /-- Every response-size envelope is monotone in encoded position size. -/
+  responseSize_monotone : ∀ interface, Monotone (responseSize interface)
+  /-- Every admitted dependent response fits its selected envelope. -/
+  responseSize_le : ∀ (position : p.A) (answer : p.B position), allows position answer →
+    Q.size interface.idx ⟨position, answer⟩ ≤
+      responseSize (labelOf position) (Q.size interface.pos position)
+
+namespace ResponseResourceModel
+
+variable {interface : InterfaceBoundary C p} {labelOf : p.A → label}
+  (model : ResponseResourceModel Q interface labelOf)
+
+/-- Expose a response model as the length environment of a second-order polynomial. -/
+def modulus : ResponseModulus label → ℕ → ℕ
+  | .responseSize interface => model.responseSize interface
+
+@[simp]
+theorem modulus_responseSize (interface : label) (size : ℕ) :
+    model.modulus (.responseSize interface) size = model.responseSize interface size := by
+  simp [modulus]
+
+/-- Every length function exposed by a response model is monotone. -/
+theorem modulus_monotone :
+    _root_.Complexity.SecondOrderPolynomial.MonotoneLengths model.modulus := by
+  intro symbol
+  cases symbol with
+  | responseSize interface => exact model.responseSize_monotone interface
+
+end ResponseResourceModel
+
+/-- A pinned position labelling and a nonempty collection of admissible response models. -/
+structure ResponseResourceContract (Q : QuantitativeStepClass.{u, v, w} C)
+    (interface : InterfaceBoundary C p) (label : Type x) where
+  /-- Label assigned to each interface position. -/
+  labelOf : p.A → label
+  /-- Response environments admitted by the contract. -/
+  admissible : ResponseResourceModel Q interface labelOf → Prop
+  /-- At least one global finite response envelope satisfies the contract. -/
+  model_nonempty : ∃ model, admissible model
+
+namespace ResponseResourceContract
+
+variable {interface : InterfaceBoundary C p}
+  (contract : ResponseResourceContract Q interface label)
+
+/-- Response environments carrying evidence that they satisfy a contract. -/
+abbrev Model := { model : ResponseResourceModel Q interface contract.labelOf //
+  contract.admissible model }
+
+namespace Model
+
+variable {contract : ResponseResourceContract Q interface label}
+
+/-- Forget contract admissibility evidence. -/
+abbrev resourceModel (model : contract.Model) :
+    ResponseResourceModel Q interface contract.labelOf :=
+  model.1
+
+/-- The second-order length environment supplied by a compatible response model. -/
+abbrev modulus (model : contract.Model) : ResponseModulus label → ℕ → ℕ :=
+  model.resourceModel.modulus
+
+/-- Every compatible response model supplies monotone length functions. -/
+theorem modulus_monotone (model : contract.Model) :
+    _root_.Complexity.SecondOrderPolynomial.MonotoneLengths model.modulus :=
+  model.resourceModel.modulus_monotone
+
+end Model
+
+end ResponseResourceContract
+
+/-! ## Polynomial run and program witnesses -/
+
+variable [C.HasProd] [C.HasSum] [C.HasOption] [DecidableEq p.A]
+  {input output : Type u} {bd : Boundary C p input output}
+
+/-- A second-order polynomial bound on one already selected quantitative realization.
+
+This structure contains no semantic `FreeM` program and no output-recovery policy. It can therefore
+be reused when the same realization is related to syntax in more than one way. -/
+structure PolynomialRunBound (R : QuantitativeRealization Q bd)
+    (contract : ResponseResourceContract Q bd.interface label) where
+  /-- One bound shared by every response model admitted by the contract. -/
+  polynomial : ExecutionCostPolynomial (ResponseModulus label)
+  /-- Every conforming finite prefix satisfies the shared bound. -/
+  runsWithin : ∀ model : contract.Model,
+    R.RunsWithinUnder model.resourceModel.allows fun value ↦
+      polynomial.eval model.modulus (Q.size bd.input value)
+
+namespace PolynomialRunBound
+
+variable {R : QuantitativeRealization Q bd}
+  {contract : ResponseResourceContract Q bd.interface label}
+
+/-- The input-indexed execution bound selected by one compatible response model. -/
+def bound (certificate : PolynomialRunBound R contract) (model : contract.Model) :
+    input → ExecutionCost :=
+  fun value ↦ certificate.polynomial.eval model.modulus (Q.size bd.input value)
+
+/-- Restate the certificate's pathwise theorem through its named input-indexed bound. -/
+theorem runsWithin_bound (certificate : PolynomialRunBound R contract)
+    (model : contract.Model) :
+    R.RunsWithinUnder model.resourceModel.allows (certificate.bound model) :=
+  certificate.runsWithin model
+
+end PolynomialRunBound
+
+/-- A polynomially resource-bounded realization together with its semantic program witness.
+
+The run bound remains a separate field so closure constructions can operate on it without
+reproving implementation or returned-output recovery. -/
+structure PolynomialProgramWitness (Q : QuantitativeStepClass.{u, v, w} C)
+    (bd : Boundary C p input output)
+    (contract : ResponseResourceContract Q bd.interface label)
+    (program : input → FreeM p output) where
+  /-- The selected executable realization. -/
+  realization : QuantitativeRealization Q bd
+  /-- Semantic agreement with the free interaction syntax. -/
+  implements : realization.machine.Implements program
+  /-- Returned payload size is recoverable from the charged tagged readout size. -/
+  outputRecovery : Q.PolyOutputSizeRecovery bd
+  /-- The realization's response-relative execution bound. -/
+  runBound : PolynomialRunBound realization contract
+
+namespace PolynomialProgramWitness
+
+variable {contract : ResponseResourceContract Q bd.interface label}
+  {program : input → FreeM p output}
+
+/-- A second-order polynomial bounding returned payload size through the charged peak readout. -/
+def outputSizePolynomial (witness : PolynomialProgramWitness Q bd contract program) :
+    _root_.Complexity.SecondOrderPolynomial (ResponseModulus label) :=
+  (ExecutionCostPolynomial.ofFirstOrder witness.outputRecovery.polynomial).comp
+    witness.runBound.polynomial.peakHeadSize
+
+@[simp]
+theorem eval_outputSizePolynomial (witness : PolynomialProgramWitness Q bd contract program)
+    (model : contract.Model) (value : input) :
+    witness.outputSizePolynomial.eval model.modulus (Q.size bd.input value) =
+      witness.outputRecovery.polynomial.eval
+        (witness.runBound.bound model value).peakHeadSize := by
+  simp [outputSizePolynomial, PolynomialRunBound.bound, ExecutionCostPolynomial.eval]
+
+/-- Every return reached by a conforming execution has polynomially bounded encoded payload
+size. -/
+theorem returnedSize_le (witness : PolynomialProgramWitness Q bd contract program)
+    (model : contract.Model) (value : input) {finish : witness.realization.machine.State}
+    (trace : witness.realization.ExecutionTrace
+      (witness.realization.machine.init value) finish)
+    (htrace : trace.Conforms model.resourceModel.allows) (result : output)
+    (view_eq : witness.realization.machine.view finish = Sum.inl result) :
+    Q.size bd.out result ≤
+      witness.outputSizePolynomial.eval model.modulus (Q.size bd.input value) := by
+  have hreturned := witness.realization.returnedSize_le_peakHeadSize
+    witness.outputRecovery.toOutputSizeRecovery value trace result view_eq
+  have hcost := (witness.runBound.runsWithin_bound model).cost_le value trace htrace
+  rw [witness.eval_outputSizePolynomial model value]
+  exact hreturned.trans (witness.outputRecovery.polynomial.eval_monotone hcost.2.2.2.2)
+
+/-- Transport a program witness across extensional equality of whole program families. -/
+def congrProgram {program' : input → FreeM p output}
+    (witness : PolynomialProgramWitness Q bd contract program)
+    (hprogram : program = program') : PolynomialProgramWitness Q bd contract program' :=
+  hprogram ▸ witness
+
+/-- A program witness retains ordinary quantitative realizability. -/
+theorem isQuantitativelyRealizableBy
+    (witness : PolynomialProgramWitness Q bd contract program) :
+    IsQuantitativelyRealizableBy Q bd program :=
+  ⟨witness.realization, witness.implements⟩
+
+/-- A program witness supplies the corresponding exact bound under each compatible model. -/
+theorem isQuantitativelyRealizableWithinUnder
+    (witness : PolynomialProgramWitness Q bd contract program) (model : contract.Model) :
+    IsQuantitativelyRealizableWithinUnder Q bd model.resourceModel.allows program
+      (witness.runBound.bound model) :=
+  ⟨witness.realization, witness.implements, witness.runBound.runsWithin_bound model⟩
+
+/-- If a response model admits every typed reply, the query component bounds the full free
+syntax. -/
+theorem isTotalRollBound (witness : PolynomialProgramWitness Q bd contract program)
+    (model : contract.Model)
+    (hAllows : ∀ position answer, model.resourceModel.allows position answer)
+    (value : input) :
+    (program value).IsTotalRollBound (witness.runBound.bound model value).queries := by
+  have hAllowsEq : model.resourceModel.allows = fun _ _ ↦ True := by
+    funext position answer
+    apply propext
+    exact ⟨fun _ ↦ trivial, fun _ ↦ hAllows position answer⟩
+  have hRuns : witness.realization.RunsWithin (witness.runBound.bound model) := by
+    change witness.realization.RunsWithinUnder (fun _ _ ↦ True) _
+    rw [← hAllowsEq]
+    exact witness.runBound.runsWithin_bound model
+  exact hRuns.isTotalRollBound witness.implements value
+
+end PolynomialProgramWitness
+
+/-! ## Immediately returning programs -/
+
+/-- Executable polynomial data for an immediately returning function.
+
+The partial update realizer is required for a complete realization but needs no resource bound:
+an immediately returning machine never invokes it. -/
+structure PureResourceCertificate
+    (Q : QuantitativeStepClass.{u, v, w} C) (bd : Boundary C p input output)
+    (function : input → output) where
+  /-- Executable result computation with polynomial work and output growth. -/
+  result : Q.PolyRealizer bd.input bd.out function
+  /-- Executable resolved-state readout, including its sum tag. -/
+  head : Q.PolyRealizer bd.out bd.head (Sum.inl : output → output ⊕ p.A)
+  /-- Returned payload recovery from the tagged readout representation. -/
+  outputRecovery : Q.PolyOutputSizeRecovery bd
+  /-- Executable evidence for the unreachable partial update. -/
+  update : Q.Realizer (bd.stateIdx bd.out) (StepClass.HasOption.option bd.out)
+    (DynComputation.ofFn (p := p) function).update?
+
+namespace PureResourceCertificate
+
+variable {function : input → output}
+
+/-- Construct pure-program data from one result realizer and an explicit polynomial model. -/
+def ofPolyRealizer (model : Q.PolynomialModel)
+    (result : Q.PolyRealizer bd.input bd.out function) :
+    letI := model.kernel.cProd
+    letI := model.kernel.cSum
+    letI := model.kernel.cOption
+    PureResourceCertificate Q bd function := by
+  letI := model.category
+  letI := model.kernel.cProd
+  letI := model.kernel.cSum
+  letI := model.kernel.cOption
+  exact
+    { result := result
+      head := model.structural.inl bd.out bd.pos
+      outputRecovery := model.structural.polyOutputSizeRecovery bd
+      update :=
+        (model.structural.optionNone (bd.stateIdx bd.out) bd.out).code.castFunction (by
+          funext step
+          exact (DynComputation.update?_of_view_return
+            (DynComputation.ofFn (p := p) function)
+            (DynComputation.view_ofFn function step.1) step.2).symm) }
+
+/-- Assemble the quantitative realization of an immediately returning function. -/
+def realization (certificate : PureResourceCertificate Q bd function) :
+    QuantitativeRealization Q bd where
+  machine := DynComputation.ofFn (p := p) function
+  state := bd.out
+  initCode := certificate.result.code
+  headCode := certificate.head.code
+  updateCode := certificate.update
+
+/-- The first-order work and size certificates lifted into all execution-cost components. -/
+def polynomial {resourceLabel : Type x}
+    (certificate : PureResourceCertificate Q bd function) :
+    ExecutionCostPolynomial resourceLabel where
+  work := ExecutionCostPolynomial.ofFirstOrder <|
+    _root_.Complexity.FirstOrderPolynomial.add certificate.result.work <|
+      _root_.Complexity.FirstOrderPolynomial.comp certificate.head.work
+        certificate.result.outputSize
+  queries := .const 0
+  traffic := .const 0
+  peakStateSize := ExecutionCostPolynomial.ofFirstOrder certificate.result.outputSize
+  peakHeadSize := ExecutionCostPolynomial.ofFirstOrder <|
+    _root_.Complexity.FirstOrderPolynomial.comp certificate.head.outputSize
+      certificate.result.outputSize
+
+/-- The assembled realization implements the corresponding pure `FreeM` program. -/
+theorem implements (certificate : PureResourceCertificate Q bd function) :
+    certificate.realization.machine.Implements fun input ↦ FreeM.pure (function input) := by
+  change (DynComputation.ofFn (p := p) function).Implements _
+  intro input
+  rw [denote_ofFn]
+  simp
+
+/-- Every finite prefix of the pure realization satisfies its derived polynomial bound. -/
+theorem runsWithin {resourceLabel : Type x}
+    (certificate : PureResourceCertificate Q bd function)
+    (allows : ∀ position, p.B position → Prop)
+    (length : resourceLabel → ℕ → ℕ) :
+    certificate.realization.RunsWithinUnder allows fun input ↦
+      (certificate.polynomial (resourceLabel := resourceLabel)).eval length
+        (Q.size bd.input input) := by
+  refine ⟨?_, ?_, ?_⟩
+  · intro input finish trace _
+    cases trace with
+    | nil state =>
+        rw [ExecutionCost.le_iff]
+        simp only [QuantitativeRealization.executionCost,
+          QuantitativeRealization.ExecutionTrace.cost,
+          realization, polynomial, ExecutionCostPolynomial.eval,
+          ExecutionCostPolynomial.eval_ofFirstOrder,
+          _root_.Complexity.FirstOrderPolynomial.eval_add,
+          _root_.Complexity.FirstOrderPolynomial.eval_comp,
+          ExecutionCost.ofWork, ExecutionCost.observe, ExecutionCost.work_add,
+          ExecutionCost.queries_add, ExecutionCost.traffic_add,
+          ExecutionCost.peakStateSize_add, ExecutionCost.peakHeadSize_add,
+          add_zero, Nat.max_zero, Nat.zero_max]
+        refine ⟨?_, le_rfl, le_rfl, ?_, ?_⟩
+        · exact Nat.add_le_add (certificate.result.work_le input) <|
+            (certificate.head.work_le (function input)).trans <|
+              certificate.head.work.eval_monotone (certificate.result.outputSize_le input)
+        · exact certificate.result.outputSize_le input
+        · exact (certificate.head.outputSize_le (function input)).trans <|
+            certificate.head.outputSize.eval_monotone
+              (certificate.result.outputSize_le input)
+    | query view_eq direction tail =>
+        change Sum.inl _ = Sum.inr _ at view_eq
+        exact nomatch view_eq
+  · intro input
+    exact resolvesInUnder_return _ _ 0 _ _ (view_ofFn function (function input))
+  · intro input state trace _ position next view_eq
+    change Sum.inl state =
+      Sum.inr (⟨position, next⟩ : p.Obj certificate.realization.machine.State)
+      at view_eq
+    exact nomatch view_eq
+
+/-- Package a pure certificate as a run-only polynomial bound under any response contract. -/
+def runBound (certificate : PureResourceCertificate Q bd function)
+    (contract : ResponseResourceContract Q bd.interface label) :
+    PolynomialRunBound certificate.realization contract where
+  polynomial := certificate.polynomial
+  runsWithin model := certificate.runsWithin model.resourceModel.allows model.modulus
+
+/-- Package a pure certificate together with its semantic program witness. -/
+def programWitness (certificate : PureResourceCertificate Q bd function)
+    (contract : ResponseResourceContract Q bd.interface label) :
+    PolynomialProgramWitness Q bd contract fun input ↦ FreeM.pure (function input) where
+  realization := certificate.realization
+  implements := certificate.implements
+  outputRecovery := certificate.outputRecovery
+  runBound := certificate.runBound contract
+
+end PureResourceCertificate
+
+/-! ## Ranked resource potentials -/
+
+namespace RankedResource
+
+/-- Cost of observing a state as the final state of an execution prefix. -/
+def terminalCost (R : QuantitativeRealization Q bd) (state : R.machine.State) :
+    ExecutionCost :=
+  ExecutionCost.ofWork (Q.cost R.headCode state) +
+    ExecutionCost.observe (Q.size R.state state) (Q.size bd.head (R.machine.head state))
+
+/-- Cost contributed by one enabled position-response transition. -/
+def queryStepCost (R : QuantitativeRealization Q bd) (state : R.machine.State)
+    (position : p.A) (direction : p.B position) : ExecutionCost :=
+  ExecutionCost.ofWork (Q.cost R.headCode state) +
+    ExecutionCost.ofWork (Q.cost R.updateCode (state, ⟨position, direction⟩)) +
+    ExecutionCost.observe (Q.size R.state state) (Q.size bd.head (R.machine.head state)) +
+    ExecutionCost.query (Q.size bd.pos position) (Q.size bd.idx ⟨position, direction⟩)
+
+@[simp]
+theorem executionTrace_cost_query {R : QuantitativeRealization Q bd}
+    {state : R.machine.State} {position : p.A} {next : p.B position → R.machine.State}
+    {finish : R.machine.State}
+    (view_eq : R.machine.view state = Sum.inr ⟨position, next⟩)
+    (direction : p.B position) (tail : R.ExecutionTrace (next direction) finish) :
+    (QuantitativeRealization.ExecutionTrace.query (R := R) view_eq direction tail).cost =
+      queryStepCost R state position direction + tail.cost :=
+  by
+    simp [QuantitativeRealization.ExecutionTrace.cost, queryStepCost]
+
+/-- Split prefix cost into initialization, transition cost, and the final observation. -/
+theorem executionCost_eq_init_add_trace_add_terminal
+    (R : QuantitativeRealization Q bd) (value : input) {finish : R.machine.State}
+    (trace : R.ExecutionTrace (R.machine.init value) finish) :
+    R.executionCost value trace =
+      ExecutionCost.ofWork (Q.cost R.initCode value) + (trace.cost + terminalCost R finish) := by
+  simp [QuantitativeRealization.executionCost, terminalCost, add_assoc]
+
+/-- Local resource potentials combined with a decreasing, progress-bearing query rank. -/
+structure PotentialCertificate (R : QuantitativeRealization Q bd)
+    (allows : ∀ position, p.B position → Prop) (bound : input → ExecutionCost) where
+  /-- Backend-independent termination and non-vacuous progress evidence. -/
+  toRankedRunCertificate : RankedRunCertificate R allows
+  /-- Resource potential available at each hidden state. -/
+  potential : R.machine.State → ExecutionCost
+  /-- Stopping a prefix at any state fits that state's potential. -/
+  terminal_le : ∀ state, terminalCost R state ≤ potential state
+  /-- One admitted transition and the successor potential fit the source potential. -/
+  query_le : ∀ {state : R.machine.State} {position : p.A}
+    {next : p.B position → R.machine.State},
+    R.machine.view state = Sum.inr ⟨position, next⟩ →
+      ∀ direction, allows position direction →
+        queryStepCost R state position direction + potential (next direction) ≤ potential state
+  /-- Initialization work and the initial potential fit the advertised bound. -/
+  init_le : ∀ value,
+    ExecutionCost.ofWork (Q.cost R.initCode value) + potential (R.machine.init value) ≤
+      bound value
+  /-- The query component of the advertised bound dominates the initial rank. -/
+  rank_init_le : ∀ value,
+    toRankedRunCertificate.rank (R.machine.init value) ≤ (bound value).queries
+
+namespace PotentialCertificate
+
+variable {R : QuantitativeRealization Q bd}
+  {allows : ∀ position, p.B position → Prop} {bound : input → ExecutionCost}
+
+/-- Transition cost plus the final observation of a conforming trace fits its start potential. -/
+theorem traceCost_add_terminal_le (certificate : PotentialCertificate R allows bound)
+    {start finish : R.machine.State} (trace : R.ExecutionTrace start finish)
+    (htrace : trace.Conforms allows) :
+    trace.cost + terminalCost R finish ≤ certificate.potential start := by
+  induction trace with
+  | nil state =>
+      simpa only [QuantitativeRealization.ExecutionTrace.cost, zero_add] using
+        certificate.terminal_le state
+  | @query state position next finish view_eq direction tail ih =>
+      calc
+        (QuantitativeRealization.ExecutionTrace.query (R := R) view_eq direction tail).cost +
+            terminalCost R finish =
+            queryStepCost R state position direction +
+              (tail.cost + terminalCost R finish) := by
+          simp only [QuantitativeRealization.ExecutionTrace.cost, queryStepCost, add_assoc]
+        _ ≤ queryStepCost R state position direction + certificate.potential (next direction) :=
+          ExecutionCost.add_le_add le_rfl (ih htrace.2)
+        _ ≤ certificate.potential state := certificate.query_le view_eq direction htrace.1
+
+/-- The decreasing rank gives branchwise resolution from every hidden state. -/
+theorem resolvesInUnder (certificate : PotentialCertificate R allows bound)
+    (state : R.machine.State) :
+    R.machine.ResolvesInUnder allows (certificate.toRankedRunCertificate.rank state) state :=
+  certificate.toRankedRunCertificate.resolvesInUnder state
+
+/-- A ranked local potential supplies the complete non-vacuous pathwise run bound. -/
+theorem runsWithinUnder (certificate : PotentialCertificate R allows bound) :
+    R.RunsWithinUnder allows bound := by
+  apply certificate.toRankedRunCertificate.runsWithinUnder bound
+  · intro value finish trace htrace
+    rw [executionCost_eq_init_add_trace_add_terminal R value trace]
+    exact (ExecutionCost.add_le_add le_rfl
+      (certificate.traceCost_add_terminal_le trace htrace)).trans (certificate.init_le value)
+  · exact certificate.rank_init_le
+
+end PotentialCertificate
+
+end RankedResource
+
+/-! ## Ranked polynomial program certificates -/
+
+/-- A polynomial program witness presented through model-relative ranked local potentials. -/
+structure RankedResourceCertificate
+    (Q : QuantitativeStepClass.{u, v, w} C) (bd : Boundary C p input output)
+    (contract : ResponseResourceContract Q bd.interface label)
+    (program : input → FreeM p output) where
+  /-- The selected executable realization. -/
+  realization : QuantitativeRealization Q bd
+  /-- Semantic agreement with the free interaction syntax. -/
+  implements : realization.machine.Implements program
+  /-- Returned payload recovery from the charged tagged readout. -/
+  outputRecovery : Q.PolyOutputSizeRecovery bd
+  /-- One polynomial shared by every compatible response model. -/
+  polynomial : ExecutionCostPolynomial (ResponseModulus label)
+  /-- Local ranked evidence specialized to each compatible model. -/
+  resourcePotential : ∀ model : contract.Model,
+    RankedResource.PotentialCertificate realization model.resourceModel.allows fun value ↦
+      polynomial.eval model.modulus (Q.size bd.input value)
+
+namespace RankedResourceCertificate
+
+variable {contract : ResponseResourceContract Q bd.interface label}
+  {program : input → FreeM p output}
+
+/-- Forget local ranked evidence to the realization-only polynomial run bound. -/
+def runBound (certificate : RankedResourceCertificate Q bd contract program) :
+    PolynomialRunBound certificate.realization contract where
+  polynomial := certificate.polynomial
+  runsWithin model := (certificate.resourcePotential model).runsWithinUnder
+
+/-- Forget local ranked evidence to the standard polynomial program witness. -/
+def programWitness (certificate : RankedResourceCertificate Q bd contract program) :
+    PolynomialProgramWitness Q bd contract program where
+  realization := certificate.realization
+  implements := certificate.implements
+  outputRecovery := certificate.outputRecovery
+  runBound := certificate.runBound
+
+end RankedResourceCertificate
+
+/-! ## Polynomial sequential-composition certificates -/
+
+section SeqComp
+
+variable [Q.HasCategory] [Q.HasProd] [Q.HasSum] [Q.HasOption] [Q.IsDistributive]
+  {final : Type u} {middleOut : C.Str final}
+  {R₁ : QuantitativeRealization Q bd}
+  {R₂ : QuantitativeRealization Q (bd.mid middleOut)}
+  {contract : ResponseResourceContract Q bd.interface label}
+
+/-- A response-model-uniform polynomial envelope for every reachable second-phase run. -/
+structure PolynomialSeqCompHandoffBound
+    (R₁ : QuantitativeRealization Q bd)
+    (R₂ : QuantitativeRealization Q (bd.mid middleOut))
+    (contract : ResponseResourceContract Q bd.interface label)
+    (second : PolynomialRunBound R₂ contract) where
+  /-- Shared polynomial envelope for the reached second phase. -/
+  polynomial : ExecutionCostPolynomial (ResponseModulus label)
+  /-- The exact handoff certificate under each compatible response model. -/
+  certificate : ∀ model : contract.Model,
+    SeqCompHandoffBound R₁ model.resourceModel.allows (second.bound model)
+  /-- Every model-specific handoff envelope fits the shared polynomial. -/
+  bound_le : ∀ (model : contract.Model) input,
+    (certificate model).bound input ≤
+      polynomial.eval model.modulus (Q.size bd.input input)
+
+/-- A response-model-uniform polynomial allowance for structural composition overhead. -/
+structure PolynomialSeqCompCostCertificate
+    (R₁ : QuantitativeRealization Q bd)
+    (R₂ : QuantitativeRealization Q (bd.mid middleOut))
+    (contract : ResponseResourceContract Q bd.interface label) where
+  /-- Shared polynomial envelope for structural wiring and phase switching. -/
+  polynomial : ExecutionCostPolynomial (ResponseModulus label)
+  /-- The exact composite/source cost comparison under each compatible response model. -/
+  certificate : ∀ model : contract.Model,
+    SeqCompCostCertificate R₁ R₂ model.resourceModel.allows
+  /-- Every model-specific structural allowance fits the shared polynomial. -/
+  overhead_le : ∀ (model : contract.Model) input,
+    (certificate model).overhead input ≤
+      polynomial.eval model.modulus (Q.size bd.input input)
+
+namespace PolynomialRunBound
+
+/-- Polynomial run bounds compose using the exact phase decomposition from bounded closure.
+
+The first-phase, handoff, and structural bounds are accumulated conservatively. The two peak
+components may therefore be loose, but remain sound because `ExecutionCost` combines peaks by
+`max`. -/
+def seqComp (first : PolynomialRunBound R₁ contract)
+    (second : PolynomialRunBound R₂ contract)
+    (handoff : PolynomialSeqCompHandoffBound R₁ R₂ contract second)
+    (cost : PolynomialSeqCompCostCertificate R₁ R₂ contract) :
+    PolynomialRunBound (R₁.seqComp R₂) contract where
+  polynomial := first.polynomial + handoff.polynomial + cost.polynomial
+  runsWithin model := by
+    have assembled := (first.runsWithin_bound model).seqComp
+      (second.runsWithin_bound model) (handoff.certificate model) (cost.certificate model)
+    apply assembled.mono
+    intro input
+    let size := Q.size bd.input input
+    let length := model.modulus
+    have h₁ :
+        first.polynomial.eval length size + handoff.polynomial.eval length size ≤
+          (first.polynomial + handoff.polynomial).eval length size :=
+      ExecutionCostPolynomial.add_eval_le_eval_add _ _ _ _
+    have h₂ :
+        (first.polynomial + handoff.polynomial).eval length size +
+            cost.polynomial.eval length size ≤
+          (first.polynomial + handoff.polynomial + cost.polynomial).eval length size :=
+      ExecutionCostPolynomial.add_eval_le_eval_add _ _ _ _
+    change first.polynomial.eval length size + (handoff.certificate model).bound input +
+        (cost.certificate model).overhead input ≤ _
+    calc
+      first.polynomial.eval length size + (handoff.certificate model).bound input +
+          (cost.certificate model).overhead input ≤
+          (first.polynomial.eval length size + handoff.polynomial.eval length size) +
+            cost.polynomial.eval length size :=
+        ExecutionCost.add_le_add
+          (ExecutionCost.add_le_add le_rfl (handoff.bound_le model input))
+          (cost.overhead_le model input)
+      _ ≤ (first.polynomial + handoff.polynomial).eval length size +
+          cost.polynomial.eval length size :=
+        ExecutionCost.add_le_add h₁ le_rfl
+      _ ≤ (first.polynomial + handoff.polynomial + cost.polynomial).eval length size := h₂
+
+end PolynomialRunBound
+
+namespace PolynomialProgramWitness
+
+variable {program₁ : input → FreeM p output} {program₂ : output → FreeM p final}
+
+/-- Compose program witnesses along `FreeM.bind`, keeping semantic implementation separate from
+the resource decomposition certificates needed by the two execution phases. -/
+def bind (first : PolynomialProgramWitness Q bd contract program₁)
+    (second : PolynomialProgramWitness Q (bd.mid middleOut) contract program₂)
+    (handoff : PolynomialSeqCompHandoffBound first.realization second.realization contract
+      second.runBound)
+    (cost : PolynomialSeqCompCostCertificate first.realization second.realization contract) :
+    PolynomialProgramWitness Q (bd.withOut middleOut) contract
+      (fun input ↦ FreeM.bind (program₁ input) program₂) where
+  realization := first.realization.seqComp second.realization
+  implements := first.implements.seqComp second.implements
+  outputRecovery :=
+    { polynomial := second.outputRecovery.polynomial
+      output_le := second.outputRecovery.output_le }
+  runBound := first.runBound.seqComp second.runBound handoff cost
+
+end PolynomialProgramWitness
+
+end SeqComp
+
+end DynSystem.DynComputation
+
+end PFunctor

--- a/PolyFunTest/Realizability/QuantitativeBoundedClosure.lean
+++ b/PolyFunTest/Realizability/QuantitativeBoundedClosure.lean
@@ -298,9 +298,11 @@ def secondQueryRealization :
   updateCode := PUnit.unit
 
 /-- Exact envelope for either one-query phase under `unitCostBackend`. -/
+@[expose]
 def oneQueryBound : ExecutionCost := ⟨4, 1, 2, 1, 1⟩
 
 /-- Exact envelope for the two-query composite under `unitCostBackend`. -/
+@[expose]
 def twoQueryBound : ExecutionCost := ⟨6, 2, 4, 1, 1⟩
 
 /-- A concrete first-phase trace carrying an arbitrary typed Boolean answer. -/
@@ -344,6 +346,7 @@ example :
       (queryCrossingTrace true false) = twoQueryBound := rfl
 
 /-- Every well-typed Boolean response is admitted by the querying fixtures. -/
+@[expose]
 def allowsBool : ∀ position, boolResponse.B position → Prop := fun _ _ ↦ True
 
 /-- Transition work is exactly two units per typed query in `unitCostBackend`. -/
@@ -513,6 +516,7 @@ theorem secondQueryRunsWithin :
     exact ⟨false, trivial⟩
 
 /-- Every reached first-phase answer fits the uniform one-query envelope of phase two. -/
+@[expose]
 def queryHandoffBound :
     SeqCompHandoffBound firstQueryRealization allowsBool (fun _ ↦ oneQueryBound) where
   bound _ := oneQueryBound
@@ -526,6 +530,7 @@ The exact unit-cost formula and exact phase-source query accounting show that th
 already dominate the composite in all five resource components. A two-phase source pays for one
 additional initialization and final readout, while its query count and encoded traffic agree
 exactly with the composite prefix. -/
+@[expose]
 def querySeqCompCost :
     SeqCompCostCertificate firstQueryRealization secondQueryRealization allowsBool where
   overhead _ := 0

--- a/PolyFunTest/Realizability/QuantitativeResource.lean
+++ b/PolyFunTest/Realizability/QuantitativeResource.lean
@@ -7,6 +7,8 @@ Authors: Devon Tuma
 module
 
 public import PolyFun.Realizability.Quantitative.Resource
+public import PolyFun.PFunctor.Dynamical.DynComputation.Termination
+public import PolyFunTest.Realizability.QuantitativeBoundedClosure
 public import PolyFunTest.Realizability.QuantitativePolynomial
 
 /-!
@@ -24,6 +26,80 @@ namespace PFunctor.QuantitativeResourceTest
 open Complexity
 open DynSystem.DynComputation
 open QuantitativePolynomialTest
+
+/-! ## Genuinely dependent response sizes -/
+
+/-- A representation is its concrete encoded-size function. -/
+def measuredClass : StepClass.{0, 0} where
+  Str α := α → ℕ
+  Hom _ _ _ := True
+  id_mem _ := trivial
+  comp_mem _ _ := trivial
+
+/-- A cost-free backend which reads the nonconstant sizes pinned by `measuredClass`. -/
+def measuredBackend : QuantitativeStepClass.{0, 0, 0} measuredClass where
+  Realizer _ _ _ := PUnit
+  size representation value := representation value
+  cost _ _ := 0
+  admissible _ := trivial
+
+/-- Two positions with genuinely different dependent answer types. -/
+def dependentResponse : PFunctor.{0, 0} where
+  A := Bool
+  B
+    | false => Bool
+    | true => Fin 3
+
+/-- Nonconstant position encoding used as the modulus argument. -/
+def dependentPositionSize : Bool → ℕ
+  | false => 2
+  | true => 5
+
+/-- Nonconstant dependent response encoding, including the position tag. -/
+def dependentIndexSize : dependentResponse.Idx → ℕ
+  | ⟨false, false⟩ => 4
+  | ⟨false, true⟩ => 7
+  | ⟨true, answer⟩ => 10 + answer.val
+
+/-- Pinned interface representations for the dependent response model. -/
+def dependentInterface : InterfaceBoundary measuredClass dependentResponse :=
+  ⟨dependentPositionSize, dependentIndexSize⟩
+
+/-- Distinct monotone envelopes for the two positions. -/
+def dependentModel :
+    ResponseResourceModel measuredBackend dependentInterface id where
+  allows _ _ := True
+  responseSize
+    | false => fun size ↦ size + 5
+    | true => fun size ↦ 2 * size + 3
+  responseSize_monotone
+    | false => fun _ _ hle ↦ Nat.add_le_add_right hle 5
+    | true => fun _ _ hle ↦ Nat.add_le_add_right (Nat.mul_le_mul_left 2 hle) 3
+  responseSize_le
+    | false, false, _ => by change 4 ≤ 7; omega
+    | false, true, _ => by change 7 ≤ 7; omega
+    | true, answer, _ => by
+        change 10 + answer.val ≤ 13
+        omega
+
+/-- The two dependent answers at the first position have distinguishable encodings. -/
+example : measuredBackend.size dependentInterface.idx ⟨false, false⟩ = 4 := rfl
+example : measuredBackend.size dependentInterface.idx ⟨false, true⟩ = 7 := rfl
+
+/-- The second position uses a different answer type and a nonconstant three-point encoding. -/
+example : measuredBackend.size dependentInterface.idx
+    ⟨true, (⟨2, by omega⟩ : Fin 3)⟩ = 12 := rfl
+
+/-- `responseSize_le` is exercised directly at both dependent fibers. -/
+example : measuredBackend.size dependentInterface.idx ⟨false, true⟩ ≤
+    dependentModel.responseSize false
+      (measuredBackend.size dependentInterface.pos false) :=
+  dependentModel.responseSize_le false true trivial
+
+example : measuredBackend.size dependentInterface.idx ⟨true, (⟨2, by omega⟩ : Fin 3)⟩ ≤
+    dependentModel.responseSize true
+      (measuredBackend.size dependentInterface.pos true) :=
+  dependentModel.responseSize_le true ⟨2, by omega⟩ trivial
 
 /-- A concrete response-size environment for the empty-response test interface. -/
 def emptyModel :
@@ -46,7 +122,7 @@ example : emptyModel.modulus (.responseSize true) 4 = 5 := by
 /-- A component-distinguishing polynomial used to guard evaluation and composition. -/
 def samplePolynomial : ExecutionCostPolynomial (ResponseModulus Bool) where
   work := .oracle (.responseSize true) (.add .input (.const 1))
-  queries := .input
+  queries := .oracle (.responseSize false) .input
   traffic := .mul .input (.const 3)
   peakStateSize := .const 5
   peakHeadSize := .const 7
@@ -57,13 +133,13 @@ def doubleModulus : ResponseModulus Bool → ℕ → ℕ
 
 /-- Evaluation preserves all five fields and applies the response modulus at the nested argument. -/
 example : samplePolynomial.eval doubleModulus 3 =
-    { work := 8, queries := 3, traffic := 9, peakStateSize := 5, peakHeadSize := 7 } :=
+    { work := 8, queries := 6, traffic := 9, peakStateSize := 5, peakHeadSize := 7 } :=
   by
     ext <;> simp [samplePolynomial, doubleModulus]
 
 /-- Input composition changes the argument seen by both ordinary and response-length terms. -/
 example : (samplePolynomial.comp (.add .input (.const 2))).eval doubleModulus 3 =
-    { work := 12, queries := 5, traffic := 15, peakStateSize := 5, peakHeadSize := 7 } :=
+    { work := 12, queries := 10, traffic := 15, peakStateSize := 5, peakHeadSize := 7 } :=
   by
     rw [ExecutionCostPolynomial.eval_comp]
     ext <;> simp [samplePolynomial, doubleModulus]
@@ -72,10 +148,25 @@ example : (samplePolynomial.comp (.add .input (.const 2))).eval doubleModulus 3 
 example :
     (samplePolynomial.subst (target := PEmpty)
       (fun _ ↦ .mul .input (.const 3))).eval PEmpty.elim 2 =
-      { work := 9, queries := 2, traffic := 6, peakStateSize := 5, peakHeadSize := 7 } :=
+      { work := 9, queries := 6, traffic := 6, peakStateSize := 5, peakHeadSize := 7 } :=
   by
     rw [ExecutionCostPolynomial.eval_subst]
     ext <;> simp [samplePolynomial]
+
+/-- Swap the two response labels rather than merely changing their result type. -/
+def swapResponseLabel : ResponseModulus Bool → ResponseModulus Bool
+  | .responseSize label => .responseSize (!label)
+
+/-- A modulus which makes the two labels observably different. -/
+def splitModulus : ResponseModulus Bool → ℕ → ℕ
+  | .responseSize false => fun size ↦ size + 10
+  | .responseSize true => fun size ↦ 3 * size
+
+/-- Reindexing swaps both distinct symbols: work moves to `false`, queries move to `true`. -/
+example : (samplePolynomial.reindex swapResponseLabel).eval splitModulus 3 =
+    { work := 14, queries := 9, traffic := 9, peakStateSize := 5, peakHeadSize := 7 } := by
+  rw [ExecutionCostPolynomial.eval_reindex]
+  ext <;> simp [samplePolynomial, swapResponseLabel, splitModulus]
 
 /-- Conservative polynomial addition dominates `ExecutionCost`'s additive and peak combination. -/
 example : samplePolynomial.eval doubleModulus 3 + samplePolynomial.eval doubleModulus 4 ≤
@@ -112,5 +203,291 @@ example :=
 /-- Every admitted response model receives the exact input-indexed bound from the same witness. -/
 example (model : emptyContract.Model) :=
   pureWitness.isQuantitativelyRealizableWithinUnder model
+
+/-! ## Query-bearing ranked and bind certificates -/
+
+private abbrev queryBackend := QuantitativeBoundedClosureTest.unitCostBackend
+private abbrev queryBoundary := QuantitativeBoundedClosureTest.firstQueryBoundary
+private abbrev queryFinalRep := QuantitativeBoundedClosureTest.natOutputRep
+private abbrev queryFirst := QuantitativeBoundedClosureTest.firstQueryRealization
+private abbrev querySecond := QuantitativeBoundedClosureTest.secondQueryRealization
+
+/-- The single concrete response model used by the query-bearing certificate canary. -/
+private def queryResponseModel :
+    ResponseResourceModel queryBackend queryBoundary.interface (fun _ ↦ false) where
+  allows := QuantitativeBoundedClosureTest.allowsBool
+  responseSize _ _ := 1
+  responseSize_monotone _ _ _ _ := le_rfl
+  responseSize_le _ _ _ := le_rfl
+
+/-- Pin the query fixture to one response policy, preventing model variation from hiding a cast. -/
+private abbrev queryContract :
+    ResponseResourceContract queryBackend queryBoundary.interface Bool where
+  labelOf _ := false
+  admissible model := model = queryResponseModel
+  model_nonempty := ⟨queryResponseModel, rfl⟩
+
+private abbrev queryModel : queryContract.Model := ⟨queryResponseModel, rfl⟩
+
+/-- The existing all-response bound gives ordinary well-founded termination of phase one. -/
+private theorem firstTerminates (input : PUnit) :
+    queryFirst.machine.TerminatesFrom (queryFirst.machine.init input) := by
+  have hAll := QuantitativeBoundedClosureTest.firstQueryRunsWithin.resolvesIn input
+  change queryFirst.machine.ResolvesInUnder (fun _ _ ↦ True) 1
+    (queryFirst.machine.init input) at hAll
+  exact DynSystem.DynComputation.ResolvesIn.terminatesFrom <|
+    (queryFirst.machine.resolvesInUnder_all_iff 1 _).mp hAll
+
+/-- The existing all-response bound gives ordinary well-founded termination of phase two. -/
+private theorem secondTerminates (input : Bool) :
+    querySecond.machine.TerminatesFrom (querySecond.machine.init input) := by
+  have hAll := QuantitativeBoundedClosureTest.secondQueryRunsWithin.resolvesIn input
+  change querySecond.machine.ResolvesInUnder (fun _ _ ↦ True) 1
+    (querySecond.machine.init input) at hAll
+  exact DynSystem.DynComputation.ResolvesIn.terminatesFrom <|
+    (querySecond.machine.resolvesInUnder_all_iff 1 _).mp hAll
+
+/-- The extracted first-phase program retains the concrete query-bearing machine semantics. -/
+private noncomputable def firstProgram :
+    PUnit → FreeM QuantitativeBoundedClosureTest.boolResponse Bool :=
+  queryFirst.machine.toFreeM firstTerminates
+
+/-- The extracted second-phase program retains the answer-dependent concrete machine semantics. -/
+private noncomputable def secondProgram :
+    Bool → FreeM QuantitativeBoundedClosureTest.boolResponse Nat :=
+  querySecond.machine.toFreeM secondTerminates
+
+private theorem firstImplements : queryFirst.machine.Implements firstProgram :=
+  queryFirst.machine.implements_toFreeM firstTerminates
+
+private theorem secondImplements : querySecond.machine.Implements secondProgram :=
+  querySecond.machine.implements_toFreeM secondTerminates
+
+/-- Rank one before the query and rank zero after receiving its typed answer. -/
+private noncomputable def firstRanked :
+    RankedRunCertificate queryFirst QuantitativeBoundedClosureTest.allowsBool where
+  rank
+    | none => 1
+    | some _ => 0
+  returns_of_rank_zero
+    | none, h => by simp at h
+    | some answer, _ => ⟨answer, rfl⟩
+  decreases := by
+    intro state position next view_eq direction _
+    cases state with
+    | none =>
+        cases position
+        cases view_eq
+        change 0 < 1
+        omega
+    | some answer =>
+        change Sum.inl answer = Sum.inr _ at view_eq
+        contradiction
+  progress := by
+    intro state position next view_eq
+    exact ⟨false, trivial⟩
+
+/-- Remaining positive cost after initialization, separated before and after the query. -/
+private def firstPotential : Option Bool → ExecutionCost
+  | none => ⟨3, 1, 2, 1, 1⟩
+  | some _ => ⟨1, 0, 0, 1, 1⟩
+
+/-- The final readout charges one work unit but no update or query. -/
+private example : RankedResource.terminalCost queryFirst (some true) =
+    ⟨1, 0, 0, 1, 1⟩ := rfl
+
+/-- A pending transition charges both readout and update work plus typed boundary traffic. -/
+private example : RankedResource.queryStepCost queryFirst none PUnit.unit true =
+    ⟨2, 1, 2, 1, 1⟩ := rfl
+
+/-- A genuinely query-bearing ranked local-potential producer. -/
+private noncomputable def firstPotentialCertificate :
+    RankedResource.PotentialCertificate queryFirst
+      QuantitativeBoundedClosureTest.allowsBool
+      (fun _ ↦ QuantitativeBoundedClosureTest.oneQueryBound) where
+  toRankedRunCertificate := firstRanked
+  potential := firstPotential
+  terminal_le := by
+    intro state
+    cases state <;>
+      simp [RankedResource.terminalCost, firstPotential, queryFirst,
+        QuantitativeBoundedClosureTest.firstQueryRealization,
+        QuantitativeBoundedClosureTest.unitCostBackend, ExecutionCost.le_iff,
+        ExecutionCost.ofWork]
+  query_le := by
+    intro state position next view_eq direction _
+    cases state with
+    | none =>
+        cases position
+        cases view_eq
+        change (⟨2, 1, 2, 1, 1⟩ : ExecutionCost) + ⟨1, 0, 0, 1, 1⟩ ≤
+          ⟨3, 1, 2, 1, 1⟩
+        rw [ExecutionCost.le_iff]
+        decide
+    | some answer =>
+        change Sum.inl answer = Sum.inr _ at view_eq
+        contradiction
+  init_le := by
+    intro input
+    cases input
+    change ExecutionCost.ofWork 1 + ⟨3, 1, 2, 1, 1⟩ ≤
+      QuantitativeBoundedClosureTest.oneQueryBound
+    rw [ExecutionCost.le_iff]
+    decide
+  rank_init_le := by
+    intro input
+    cases input
+    change 1 ≤ QuantitativeBoundedClosureTest.oneQueryBound.queries
+    decide
+
+/-- Consuming the local potential yields the same pathwise one-query run bound. -/
+private example := firstPotentialCertificate.runsWithinUnder
+
+/-- The ranked producer pins the exact one-query and terminal zero-query boundaries. -/
+private example : firstPotentialCertificate.toRankedRunCertificate.rank none = 1 := rfl
+private example : firstPotentialCertificate.toRankedRunCertificate.rank (some true) = 0 := rfl
+
+private def firstOutputRecovery : queryBackend.PolyOutputSizeRecovery queryBoundary where
+  polynomial := FirstOrderPolynomial.input
+  output_le _ := le_rfl
+
+private def oneQueryPolynomial : ExecutionCostPolynomial (ResponseModulus Bool) :=
+  .const QuantitativeBoundedClosureTest.oneQueryBound
+
+/-- Ranked evidence packages directly into the standard split program-witness surface. -/
+private noncomputable def firstRankedCertificate :
+    RankedResourceCertificate queryBackend queryBoundary queryContract firstProgram where
+  realization := queryFirst
+  implements := firstImplements
+  outputRecovery := firstOutputRecovery
+  polynomial := oneQueryPolynomial
+  resourcePotential := by
+    intro model
+    rcases model with ⟨model, hmodel⟩
+    change model = queryResponseModel at hmodel
+    subst model
+    simpa [oneQueryPolynomial, queryResponseModel] using firstPotentialCertificate
+
+/-- Forgetting ranked evidence yields a usable semantic witness, not only a run-only package. -/
+private example :=
+  firstRankedCertificate.programWitness.isQuantitativelyRealizableWithinUnder queryModel
+
+private noncomputable def firstWitness :
+    PolynomialProgramWitness queryBackend queryBoundary queryContract firstProgram where
+  realization := queryFirst
+  implements := firstImplements
+  outputRecovery := firstOutputRecovery
+  runBound := firstRankedCertificate.runBound
+
+/-- The public bound equation exposes exactly the polynomial evaluation expected downstream. -/
+private example (input : PUnit) :
+    firstWitness.runBound.bound queryModel input =
+      firstWitness.runBound.polynomial.eval queryModel.modulus
+        (queryBackend.size queryBoundary.input input) := by
+  simp
+
+private def secondRunBound : PolynomialRunBound querySecond queryContract where
+  polynomial := oneQueryPolynomial
+  runsWithin := by
+    intro model
+    rcases model with ⟨model, hmodel⟩
+    change model = queryResponseModel at hmodel
+    subst model
+    simpa [oneQueryPolynomial, queryResponseModel] using
+      QuantitativeBoundedClosureTest.secondQueryRunsWithin
+
+private theorem secondRunBound_bound (model : queryContract.Model) (input : Bool) :
+    secondRunBound.bound model input = QuantitativeBoundedClosureTest.oneQueryBound := by
+  rw [PolynomialRunBound.bound_apply]
+  simp only [secondRunBound, oneQueryPolynomial, ExecutionCostPolynomial.eval_const]
+
+private def secondOutputRecovery :
+    queryBackend.PolyOutputSizeRecovery (queryBoundary.mid queryFinalRep) where
+  polynomial := FirstOrderPolynomial.input
+  output_le _ := le_rfl
+
+private noncomputable def secondWitness :
+    PolynomialProgramWitness queryBackend (queryBoundary.mid queryFinalRep)
+      queryContract secondProgram where
+  realization := querySecond
+  implements := secondImplements
+  outputRecovery := secondOutputRecovery
+  runBound := secondRunBound
+
+private def handoffForModel (model : queryContract.Model) :
+    SeqCompHandoffBound queryFirst model.resourceModel.allows
+      (secondRunBound.bound model) := by
+  exact
+    { bound := fun _ ↦ QuantitativeBoundedClosureTest.oneQueryBound
+      returned_le := by
+        intro input finish trace htrace value view_eq
+        exact (secondRunBound_bound model value).le }
+
+private theorem handoffForModel_bound (model : queryContract.Model) (input : PUnit) :
+    (handoffForModel model).bound input =
+      QuantitativeBoundedClosureTest.oneQueryBound := by
+  rcases model with ⟨model, hmodel⟩
+  change model = queryResponseModel at hmodel
+  subst model
+  rfl
+
+/-- The handoff envelope is oriented from reached first-phase answers to second-phase bounds. -/
+private def polynomialHandoff :
+    PolynomialSeqCompHandoffBound queryFirst querySecond queryContract secondRunBound where
+  polynomial := oneQueryPolynomial
+  certificate := handoffForModel
+  bound_le := by
+    intro model input
+    rw [handoffForModel_bound]
+    simp only [oneQueryPolynomial, ExecutionCostPolynomial.eval_const]
+    exact le_rfl
+
+private def seqCompCostForModel (model : queryContract.Model) :
+    SeqCompCostCertificate queryFirst querySecond model.resourceModel.allows := by
+  rcases model with ⟨model, hmodel⟩
+  change model = queryResponseModel at hmodel
+  subst model
+  exact QuantitativeBoundedClosureTest.querySeqCompCost
+
+private theorem seqCompCostForModel_overhead (model : queryContract.Model) (input : PUnit) :
+    (seqCompCostForModel model).overhead input = 0 := by
+  rcases model with ⟨model, hmodel⟩
+  change model = queryResponseModel at hmodel
+  subst model
+  rfl
+
+/-- The existing exact source-decomposition certificate supplies zero structural overhead. -/
+private def polynomialSeqCompCost :
+    PolynomialSeqCompCostCertificate queryFirst querySecond queryContract where
+  polynomial := .const 0
+  certificate := seqCompCostForModel
+  overhead_le := by
+    intro model input
+    rw [seqCompCostForModel_overhead]
+    simp only [ExecutionCostPolynomial.eval_const]
+    exact le_rfl
+
+/-- The reached Boolean is fed to the second phase, not bounded in the reverse direction. -/
+private example : secondRunBound.bound queryModel true ≤
+    (polynomialHandoff.certificate queryModel).bound PUnit.unit := by
+  exact (polynomialHandoff.certificate queryModel).returned_le PUnit.unit
+    (QuantitativeBoundedClosureTest.firstQueryTrace true)
+    (QuantitativeBoundedClosureTest.firstQueryTrace true).conforms_all rfl
+
+/-- Two one-query witnesses compose through the program-level `bind` constructor. -/
+private noncomputable def compositeWitness :=
+  firstWitness.bind secondWitness polynomialHandoff polynomialSeqCompCost
+
+/-- The composite returned-size theorem charges the final right-phase readout. -/
+private example : queryBackend.size (queryBoundary.withOut queryFinalRep).out 4 ≤
+    compositeWitness.outputSizePolynomial.eval queryModel.modulus
+      (queryBackend.size queryBoundary.input PUnit.unit) := by
+  exact compositeWitness.returnedSize_le queryModel PUnit.unit
+    (QuantitativeBoundedClosureTest.queryCrossingTrace true false)
+    (QuantitativeBoundedClosureTest.queryCrossingTrace true false).conforms_all 4 rfl
+
+/-- The all-response model exposes the `FreeM.bind` syntax through `isTotalRollBound`. -/
+private example :=
+  compositeWitness.isTotalRollBound queryModel (fun _ _ ↦ trivial) PUnit.unit
 
 end PFunctor.QuantitativeResourceTest

--- a/PolyFunTest/Realizability/QuantitativeResource.lean
+++ b/PolyFunTest/Realizability/QuantitativeResource.lean
@@ -348,8 +348,10 @@ private example : firstPotentialCertificate.toRankedRunCertificate.rank none = 1
 private example : firstPotentialCertificate.toRankedRunCertificate.rank (some true) = 0 := rfl
 
 private def firstOutputRecovery : queryBackend.PolyOutputSizeRecovery queryBoundary where
-  polynomial := FirstOrderPolynomial.input
-  output_le _ := le_rfl
+  polynomial := .const 7
+  output_le _ := by
+    change 1 ≤ 7
+    omega
 
 private def oneQueryPolynomial : ExecutionCostPolynomial (ResponseModulus Bool) :=
   .const QuantitativeBoundedClosureTest.oneQueryBound
@@ -414,18 +416,25 @@ private noncomputable def secondWitness :
   outputRecovery := secondOutputRecovery
   runBound := secondRunBound
 
+/-- A strict handoff envelope, larger than either concrete one-query second-phase run. -/
+private def handoffBound : ExecutionCost := QuantitativeBoundedClosureTest.twoQueryBound
+
+/-- A still larger polynomial envelope, making `bound_le` orientation observable too. -/
+private def handoffPolynomialBound : ExecutionCost := ⟨8, 3, 6, 1, 1⟩
+
 private def handoffForModel (model : queryContract.Model) :
     SeqCompHandoffBound queryFirst model.resourceModel.allows
       (secondRunBound.bound model) := by
   exact
-    { bound := fun _ ↦ QuantitativeBoundedClosureTest.oneQueryBound
+    { bound := fun _ ↦ handoffBound
       returned_le := by
         intro input finish trace htrace value view_eq
-        exact (secondRunBound_bound model value).le }
+        rw [secondRunBound_bound]
+        rw [ExecutionCost.le_iff]
+        decide }
 
 private theorem handoffForModel_bound (model : queryContract.Model) (input : PUnit) :
-    (handoffForModel model).bound input =
-      QuantitativeBoundedClosureTest.oneQueryBound := by
+    (handoffForModel model).bound input = handoffBound := by
   rcases model with ⟨model, hmodel⟩
   change model = queryResponseModel at hmodel
   subst model
@@ -434,13 +443,25 @@ private theorem handoffForModel_bound (model : queryContract.Model) (input : PUn
 /-- The handoff envelope is oriented from reached first-phase answers to second-phase bounds. -/
 private def polynomialHandoff :
     PolynomialSeqCompHandoffBound queryFirst querySecond queryContract secondRunBound where
-  polynomial := oneQueryPolynomial
+  polynomial := .const handoffPolynomialBound
   certificate := handoffForModel
   bound_le := by
     intro model input
     rw [handoffForModel_bound]
-    simp only [oneQueryPolynomial, ExecutionCostPolynomial.eval_const]
-    exact le_rfl
+    simp only [ExecutionCostPolynomial.eval_const]
+    rw [ExecutionCost.le_iff]
+    decide
+
+private theorem polynomialHandoff_certificate_bound
+    (model : queryContract.Model) (input : PUnit) :
+    (polynomialHandoff.certificate model).bound input = handoffBound := by
+  change (handoffForModel model).bound input = handoffBound
+  exact handoffForModel_bound model input
+
+private theorem polynomialHandoff_eval (model : queryContract.Model) (input : PUnit) :
+    polynomialHandoff.polynomial.eval model.modulus
+      (queryBackend.size queryBoundary.input input) = handoffPolynomialBound := by
+  simp only [polynomialHandoff, ExecutionCostPolynomial.eval_const]
 
 private def seqCompCostForModel (model : queryContract.Model) :
     SeqCompCostCertificate queryFirst querySecond model.resourceModel.allows := by
@@ -474,9 +495,29 @@ private example : secondRunBound.bound queryModel true ≤
     (QuantitativeBoundedClosureTest.firstQueryTrace true)
     (QuantitativeBoundedClosureTest.firstQueryTrace true).conforms_all rfl
 
+/-- Reversing the reached-value handoff inequality is false on the concrete asymmetric bounds. -/
+private example : ¬ (polynomialHandoff.certificate queryModel).bound PUnit.unit ≤
+    secondRunBound.bound queryModel true := by
+  rw [polynomialHandoff_certificate_bound, secondRunBound_bound]
+  rw [ExecutionCost.le_iff]
+  decide
+
+/-- Reversing the polynomial-envelope inequality is independently false. -/
+private example : ¬ polynomialHandoff.polynomial.eval queryModel.modulus
+      (queryBackend.size queryBoundary.input PUnit.unit) ≤
+    (polynomialHandoff.certificate queryModel).bound PUnit.unit := by
+  rw [polynomialHandoff_eval, polynomialHandoff_certificate_bound]
+  rw [ExecutionCost.le_iff]
+  decide
+
 /-- Two one-query witnesses compose through the program-level `bind` constructor. -/
 private noncomputable def compositeWitness :=
   firstWitness.bind secondWitness polynomialHandoff polynomialSeqCompCost
+
+/-- Composition selects the second phase's recovery polynomial, not the distinguishable first. -/
+private example : firstWitness.outputRecovery.polynomial.eval 2 = 7 := rfl
+private example : secondWitness.outputRecovery.polynomial.eval 2 = 2 := rfl
+private example : compositeWitness.outputRecovery.polynomial.eval 2 = 2 := rfl
 
 /-- The composite returned-size theorem charges the final right-phase readout. -/
 private example : queryBackend.size (queryBoundary.withOut queryFinalRep).out 4 ≤

--- a/PolyFunTest/Realizability/QuantitativeResource.lean
+++ b/PolyFunTest/Realizability/QuantitativeResource.lean
@@ -1,0 +1,116 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+
+module
+
+public import PolyFun.Realizability.Quantitative.Resource
+public import PolyFunTest.Realizability.QuantitativePolynomial
+
+/-!
+# Quantitative resource-contract checks
+
+The componentwise arithmetic canary uses nonzero, distinct values so swapping or dropping a cost
+field fails elaboration. The cost-free executable fixture separately checks that response contracts
+do not get conflated with semantic implementation witnesses for immediately returning programs.
+-/
+
+@[expose] public section
+
+namespace PFunctor.QuantitativeResourceTest
+
+open Complexity
+open DynSystem.DynComputation
+open QuantitativePolynomialTest
+
+/-- A concrete response-size environment for the empty-response test interface. -/
+def emptyModel :
+    ResponseResourceModel zeroBackend unitBoundary.interface (fun _ ↦ true) where
+  allows _ answer := nomatch answer
+  responseSize _ size := size + 1
+  responseSize_monotone _ _ _ hle := Nat.add_le_add_right hle 1
+  responseSize_le _ answer := nomatch answer
+
+/-- A nonempty contract which accepts every model with the pinned singleton label. -/
+def emptyContract : ResponseResourceContract zeroBackend unitBoundary.interface Bool where
+  labelOf _ := true
+  admissible _ := True
+  model_nonempty := ⟨emptyModel, True.intro⟩
+
+/-- The dependent response model is exposed as the intended second-order modulus. -/
+example : emptyModel.modulus (.responseSize true) 4 = 5 := by
+  simp [emptyModel]
+
+/-- A component-distinguishing polynomial used to guard evaluation and composition. -/
+def samplePolynomial : ExecutionCostPolynomial (ResponseModulus Bool) where
+  work := .oracle (.responseSize true) (.add .input (.const 1))
+  queries := .input
+  traffic := .mul .input (.const 3)
+  peakStateSize := .const 5
+  peakHeadSize := .const 7
+
+/-- A nontrivial monotone length environment for the arithmetic canary. -/
+def doubleModulus : ResponseModulus Bool → ℕ → ℕ
+  | .responseSize _ => fun size ↦ 2 * size
+
+/-- Evaluation preserves all five fields and applies the response modulus at the nested argument. -/
+example : samplePolynomial.eval doubleModulus 3 =
+    { work := 8, queries := 3, traffic := 9, peakStateSize := 5, peakHeadSize := 7 } :=
+  by
+    ext <;> simp [samplePolynomial, doubleModulus]
+
+/-- Input composition changes the argument seen by both ordinary and response-length terms. -/
+example : (samplePolynomial.comp (.add .input (.const 2))).eval doubleModulus 3 =
+    { work := 12, queries := 5, traffic := 15, peakStateSize := 5, peakHeadSize := 7 } :=
+  by
+    rw [ExecutionCostPolynomial.eval_comp]
+    ext <;> simp [samplePolynomial, doubleModulus]
+
+/-- Substitution replaces the response-length symbol while leaving the other components intact. -/
+example :
+    (samplePolynomial.subst (target := PEmpty)
+      (fun _ ↦ .mul .input (.const 3))).eval PEmpty.elim 2 =
+      { work := 9, queries := 2, traffic := 6, peakStateSize := 5, peakHeadSize := 7 } :=
+  by
+    rw [ExecutionCostPolynomial.eval_subst]
+    ext <;> simp [samplePolynomial]
+
+/-- Conservative polynomial addition dominates `ExecutionCost`'s additive and peak combination. -/
+example : samplePolynomial.eval doubleModulus 3 + samplePolynomial.eval doubleModulus 4 ≤
+    (samplePolynomial + samplePolynomial).eval doubleModulus 4 := by
+  have hmono : samplePolynomial.eval doubleModulus 3 ≤
+      samplePolynomial.eval doubleModulus 4 :=
+    ExecutionCostPolynomial.eval_mono_input _ (by
+        intro symbol
+        cases symbol
+        intro left right hle
+        exact Nat.mul_le_mul_left 2 hle) (by omega)
+  exact (ExecutionCost.add_le_add hmono le_rfl).trans
+    (ExecutionCostPolynomial.add_eval_le_eval_add samplePolynomial samplePolynomial
+      doubleModulus 4)
+
+/-- Executable data for the pure identity program. -/
+def pureCertificate : PureResourceCertificate zeroBackend unitBoundary id :=
+  PureResourceCertificate.ofPolyRealizer zeroModel
+    (zeroPolyRealizer unitBoundary.input unitBoundary.out id)
+
+/-- Pure executable data yields a syntax-independent run bound under the response contract. -/
+example : PolynomialRunBound pureCertificate.realization emptyContract :=
+  pureCertificate.runBound emptyContract
+
+/-- Adding semantic implementation produces the corresponding `FreeM.pure` program witness. -/
+def pureWitness : PolynomialProgramWitness zeroBackend unitBoundary emptyContract
+    (fun input ↦ FreeM.pure (P := emptyResponse) input) :=
+  pureCertificate.programWitness emptyContract
+
+/-- The program witness projects to ordinary quantitative realizability. -/
+example :=
+  pureWitness.isQuantitativelyRealizableBy
+
+/-- Every admitted response model receives the exact input-indexed bound from the same witness. -/
+example (model : emptyContract.Model) :=
+  pureWitness.isQuantitativelyRealizableWithinUnder model
+
+end PFunctor.QuantitativeResourceTest

--- a/docs/wiki/realizability.md
+++ b/docs/wiki/realizability.md
@@ -45,6 +45,10 @@ PolyFun/Realizability/
   Quantitative/Polynomial.lean
                     first-order polynomial work/output certificates and an
                     explicit categorical/structural model bundle
+  Quantitative/Resource.lean
+                    response-size contracts; componentwise second-order cost
+                    polynomials; split run/program witnesses; pure, ranked-potential,
+                    and sequential-composition resource certificates
   Quantitative/WordClass.lean
                     lift costed word-function code through pinned encodings
 ```
@@ -314,6 +318,17 @@ ordinary value collecting that category with a `StructuralKernel` and
 `PolynomialStructuralClosure`; it is deliberately not a global instance.
 Structural product, sum, and option encodings carry construction and payload
 recovery bounds in both directions.
+
+`Quantitative/Resource.lean` adds the generic open-system resource boundary. A
+`ResponseResourceContract` pins how interface positions are labelled and which
+response environments are admissible; every admitted response is bounded by a
+monotone size modulus. `ExecutionCostPolynomial` places a second-order
+polynomial over each `ExecutionCost` component. The central split is deliberate:
+`PolynomialRunBound` bounds one selected realization without mentioning syntax,
+while `PolynomialProgramWitness` separately records `FreeM` implementation and
+returned-output recovery. Pure programs, ranked local potentials, and sequential
+composition have constructors that discharge the shared run-bound interface.
+These are backend-relative contracts, not a declaration of any complexity class.
 
 `QuantitativeWordClass` lifts code, size, and cost from a word-function backend
 through `WordClass` representations. Separate category adapters lift either a

--- a/docs/wiki/repo-map.md
+++ b/docs/wiki/repo-map.md
@@ -242,12 +242,17 @@ Realizability/Quantitative -> Realizability/Quantitative/Closure
 Realizability/Quantitative/Closure -> Realizability/Quantitative/BoundedClosure
 {Complexity/SecondOrderPolynomial, Realizability/Quantitative/Closure}
   -> Realizability/Quantitative/Polynomial
+{Realizability/Quantitative/BoundedClosure,
+ Realizability/Quantitative/Polynomial}
+  -> Realizability/Quantitative/Resource
 Realizability/{Instances, Quantitative} -> Realizability/Quantitative/WordClass
 Mathlib/Order/Monotone/Basic -> Complexity/SecondOrderPolynomial
   (Instances additionally draws on Mathlib's Computability and Fintype layers;
    Quantitative/Closure assembles executable structural code but asserts no
    polynomial-time closure; Quantitative/Polynomial packages explicit
-   backend-relative polynomial certificates; Complexity contains syntax, not feasibility;
+   backend-relative polynomial certificates; Quantitative/Resource adds
+   response-relative second-order run contracts without naming a complexity class;
+   Complexity contains syntax, not feasibility;
    nothing under PFunctor/, ITree/, or Interaction/ depends on Realizability/)
 ```
 


### PR DESCRIPTION
## Summary

This PR moves the generic polynomial resource layer into PolyFun, above its existing quantitative realizability machinery.

It adds five-component second-order bounds for `ExecutionCost`, response-size contracts, separate machine-run and semantic-program witnesses, and reusable pure, sequential, bind, and ranked certificates. The motivating consumer is [VCVio #545](https://github.com/Verified-zkEVM/VCVio/pull/545); no probability, cryptographic security, concrete machine adequacy, or unqualified PPT claim is introduced.

### Diff metadata

- Base: `04c448418272d18cf76ae21d9719547d2d7bcfef` (`main`)
- Head: `70465dfe413135f03a283dcf34c60e6db73f95ad`
- Commits: 3
- Files changed: 7
- Diff: 1,425 insertions, 1 deletion

## Motivation

PolyFun already owns backend-relative execution traces, exact interaction costs, progress, termination, and bounded composition. The next layer—second-order polynomial bounds and response contracts—is equally domain-agnostic and should be reusable by arbitrary `FreeM` programs and `DynComputation` realizations rather than duplicated in VCVio.

## Change surface

| Area | Added owner-layer API |
|---|---|
| Shared interface representation | `InterfaceBoundary` and `Boundary.interface` |
| Five-component bounds | `ExecutionCostPolynomial` |
| Admitted-response sizes | `ResponseResourceModel` and nonempty `ResponseResourceContract` |
| Machine-only bound | `PolynomialRunBound` with public `bound_apply` |
| Program semantics | `PolynomialProgramWitness` |
| Constructors | `PureResourceCertificate`, ranked potential/program certificates |
| Composition | Explicit polynomial handoff/cost certificates, `seqComp`, and program-level `bind` |

Handoff and assembled-machine overhead remain explicit because they require concrete backend evidence.

## Scope

This is backend-relative realizability. It does not define conventional Turing/RAM adequacy, an unqualified complexity class, probability semantics, cryptographic security, or total-runtime complexity for divergent resumptions, ITrees, or persistent responders.

## Falsifiable owner coverage

The tests directly exercise:

- all five cost components, second-order substitution, and two-label reindexing;
- a genuinely dependent Bool/Fin-3 response model with nonconstant encodings;
- pure zero-query and real one-query ranked witnesses;
- rank 1→0 and terminal-readout versus query-update accounting;
- a strict asymmetric handoff ladder:
  `secondBound < handoffBound < polynomialBound`;
- negative reverse-inequality checks for both handoff arrows;
- distinguishable first/second recovery polynomials, proving bind selects the second;
- two-phase bind, strict returned-size accounting, and total roll bounds.

The query-bearing tests reuse existing exact positive-cost machines and traces instead of duplicating fixtures.

## Commit map

- `320b794` — generic resource contracts and certificates;
- `12e7661` — dependent response, reindex, ranked, and bind producers;
- `70465df` — asymmetric handoff and recovery-orientation guards.

## Validation at `70465df`

Passed:

- targeted resource owner build;
- `./scripts/validate.sh --lint --test`;
- production umbrella and complete PolyFunTest builds;
- environment lint;
- module/import/docs and diff checks;
- no added `sorry`, `admit`, `stop`, unsafe declaration, or linter suppression.

The final stacked successor additionally passes `--axioms`, with zero `sorryAx` and zero nonstandard-axiom dependencies.

## Reviewer map

1. `PolyFun/Realizability/Basic.lean`
2. `PolyFun/Realizability/Quantitative/Resource.lean`
3. `PolyFunTest/Realizability/QuantitativeResource.lean`
4. reused positive-cost fixtures in `QuantitativeBoundedClosure.lean`
5. realizability and repository-map documentation
