### PR TITLE
feat(control): add exact-support relational algebras and transformer bridges

### DIFF
--- a/PolyFun.lean
+++ b/PolyFun.lean
@@ -10,9 +10,11 @@ public import PolyFun.Control.LTS.Trace
 public import PolyFun.Control.Lawful.Basic
 public import PolyFun.Control.Monad.Algebra
 public import PolyFun.Control.Monad.Algebra.Relational
+public import PolyFun.Control.Monad.Algebra.Relational.Support
 public import PolyFun.Control.Monad.Free
 public import PolyFun.Control.Monad.FreeCont
 public import PolyFun.Control.Monad.Hom
+public import PolyFun.Control.Monad.Hom.Writer
 public import PolyFun.Control.Monad.Indexed
 public import PolyFun.Control.Monad.Iter
 public import PolyFun.Control.Monad.Support

--- a/PolyFun/Control/Monad/Algebra/Relational.lean
+++ b/PolyFun/Control/Monad/Algebra/Relational.lean
@@ -18,9 +18,10 @@ This file introduces a two-monad relational analogue of `MAlgOrdered`:
 * Asynchronous (one-sided) bind rules `relWP_bind_left_le` / `relWP_bind_right_le`
   and their `Triple` forms, recovering Maillard et al.'s asynchronous shapes.
 * Structural pure rules for `if`, `dite`, `Option.elim`, `Sum.elim`.
-* Named side lifts for heterogeneous stacks (`StateT`, `OptionT`, `ExceptT`).
+* Named side lifts for heterogeneous stacks (`StateT`, `ReaderT`, `OptionT`, `ExceptT`).
 * `StrictBind` subclass capturing strict relational effect observations
-  (in the sense of Maillard et al.) together with `StateT` lifts that preserve it.
+  (in the sense of Maillard et al.) together with `StateT` and `ReaderT` lifts that
+  preserve it.
 
 The framework is the predicate-transformer specialization of Maillard et al.'s
 *simple framework* (POPL 2020, §2): the relational specification monad is fixed
@@ -354,6 +355,73 @@ noncomputable def stateTBoth (σ₁ σ₂ : Type u) :
         (f := fun p₁ => (f p₁.1).run p₁.2) (g := fun p₂ => (g p₂.1).run p₂.2)
         (post := fun p₁ p₂ => post p₁.1 p₂.1 p₁.2 p₂.2))
 
+/-- Left `ReaderT` lift for heterogeneous relational algebras.
+
+The environment is exposed in the carrier so the relational postcondition can depend
+on the environment used to run the left computation. As with the `StateT` lifts, this is
+named rather than globally registered to avoid inequivalent instance paths. -/
+@[instance_reducible]
+noncomputable def readerTLeft (ρ : Type u) :
+    MAlgRelOrdered (ReaderT ρ m₁) m₂ (ρ → l) where
+  rwp x y post := fun r =>
+    MAlgRelOrdered.rwp (x.run r) y (fun a b => post a b r)
+  rwp_pure a b post := by
+    funext r
+    simp [ReaderT.run_pure]
+  rwp_mono hpost := by
+    intro r
+    exact MAlgRelOrdered.rwp_mono (m₁ := m₁) (m₂ := m₂) (l := l)
+      (fun a b => hpost a b r)
+  rwp_bind_le x y f g post := by
+    intro r
+    simpa [ReaderT.run_bind] using
+      (MAlgRelOrdered.rwp_bind_le (m₁ := m₁) (m₂ := m₂) (l := l)
+        (x := x.run r) (y := y) (f := fun a => (f a).run r) (g := g)
+        (post := fun c d => post c d r))
+
+/-- Right `ReaderT` lift for heterogeneous relational algebras. See `readerTLeft` for
+why transformer-side choices are explicit. -/
+@[instance_reducible]
+noncomputable def readerTRight (ρ : Type u) :
+    MAlgRelOrdered m₁ (ReaderT ρ m₂) (ρ → l) where
+  rwp x y post := fun r =>
+    MAlgRelOrdered.rwp x (y.run r) (fun a b => post a b r)
+  rwp_pure a b post := by
+    funext r
+    simp [ReaderT.run_pure]
+  rwp_mono hpost := by
+    intro r
+    exact MAlgRelOrdered.rwp_mono (m₁ := m₁) (m₂ := m₂) (l := l)
+      (fun a b => hpost a b r)
+  rwp_bind_le x y f g post := by
+    intro r
+    simpa [ReaderT.run_bind] using
+      (MAlgRelOrdered.rwp_bind_le (m₁ := m₁) (m₂ := m₂) (l := l)
+        (x := x) (y := y.run r) (f := f) (g := fun b => (g b).run r)
+        (post := fun c d => post c d r))
+
+/-- Two-sided `ReaderT` lift: each computation is run in its own environment, and the
+postcondition can inspect both environments in left-to-right order. -/
+@[instance_reducible]
+noncomputable def readerTBoth (ρ₁ ρ₂ : Type u) :
+    MAlgRelOrdered (ReaderT ρ₁ m₁) (ReaderT ρ₂ m₂) (ρ₁ → ρ₂ → l) where
+  rwp x y post := fun r₁ r₂ =>
+    MAlgRelOrdered.rwp (x.run r₁) (y.run r₂) (fun a b => post a b r₁ r₂)
+  rwp_pure a b post := by
+    funext r₁ r₂
+    simp [ReaderT.run_pure]
+  rwp_mono hpost := by
+    intro r₁ r₂
+    exact MAlgRelOrdered.rwp_mono (m₁ := m₁) (m₂ := m₂) (l := l)
+      (fun a b => hpost a b r₁ r₂)
+  rwp_bind_le x y f g post := by
+    intro r₁ r₂
+    simpa [ReaderT.run_bind] using
+      (MAlgRelOrdered.rwp_bind_le (m₁ := m₁) (m₂ := m₂) (l := l)
+        (x := x.run r₁) (y := y.run r₂)
+        (f := fun a => (f a).run r₁) (g := fun b => (g b).run r₂)
+        (post := fun c d => post c d r₁ r₂))
+
 end Instances
 
 section FailureInstances
@@ -657,6 +725,46 @@ theorem strictBindStateTBoth [StrictBind m₁ m₂ l] (σ₁ σ₂ : Type u) :
     (x := x.run s₁) (y := y.run s₂)
     (f := fun p₁ => (f p₁.1).run p₁.2) (g := fun p₂ => (g p₂.1).run p₂.2)
     (post := fun p₁ p₂ => post p₁.1 p₂.1 p₁.2 p₂.2)
+  convert h using 1 <;> rfl
+
+/-- Strictness lifts through the named left `ReaderT` algebra. -/
+theorem strictBindReaderTLeft [StrictBind m₁ m₂ l] (ρ : Type u) :
+    letI := readerTLeft (m₁ := m₁) (m₂ := m₂) (l := l) ρ
+    StrictBind (ReaderT ρ m₁) m₂ (ρ → l) := by
+  let := readerTLeft (m₁ := m₁) (m₂ := m₂) (l := l) ρ
+  refine { rwp_bind := ?_ }
+  intro α β γ δ x y f g post
+  funext r
+  have h := StrictBind.rwp_bind (m₁ := m₁) (m₂ := m₂) (l := l)
+    (x := x.run r) (y := y) (f := fun a => (f a).run r) (g := g)
+    (post := fun c d => post c d r)
+  convert h using 1 <;> rfl
+
+/-- Strictness lifts through the named right `ReaderT` algebra. -/
+theorem strictBindReaderTRight [StrictBind m₁ m₂ l] (ρ : Type u) :
+    letI := readerTRight (m₁ := m₁) (m₂ := m₂) (l := l) ρ
+    StrictBind m₁ (ReaderT ρ m₂) (ρ → l) := by
+  let := readerTRight (m₁ := m₁) (m₂ := m₂) (l := l) ρ
+  refine { rwp_bind := ?_ }
+  intro α β γ δ x y f g post
+  funext r
+  have h := StrictBind.rwp_bind (m₁ := m₁) (m₂ := m₂) (l := l)
+    (x := x) (y := y.run r) (f := f) (g := fun b => (g b).run r)
+    (post := fun c d => post c d r)
+  convert h using 1 <;> rfl
+
+/-- Strictness lifts through the named two-sided `ReaderT` algebra. -/
+theorem strictBindReaderTBoth [StrictBind m₁ m₂ l] (ρ₁ ρ₂ : Type u) :
+    letI := readerTBoth (m₁ := m₁) (m₂ := m₂) (l := l) ρ₁ ρ₂
+    StrictBind (ReaderT ρ₁ m₁) (ReaderT ρ₂ m₂) (ρ₁ → ρ₂ → l) := by
+  let := readerTBoth (m₁ := m₁) (m₂ := m₂) (l := l) ρ₁ ρ₂
+  refine { rwp_bind := ?_ }
+  intro α β γ δ x y f g post
+  funext r₁ r₂
+  have h := StrictBind.rwp_bind (m₁ := m₁) (m₂ := m₂) (l := l)
+    (x := x.run r₁) (y := y.run r₂)
+    (f := fun a => (f a).run r₁) (g := fun b => (g b).run r₂)
+    (post := fun c d => post c d r₁ r₂)
   convert h using 1 <;> rfl
 
 end StrictBindInstances

--- a/PolyFun/Control/Monad/Algebra/Relational/Support.lean
+++ b/PolyFun/Control/Monad/Algebra/Relational/Support.lean
@@ -1,0 +1,155 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+module
+
+public import PolyFun.Control.Monad.Algebra.Relational
+public import PolyFun.Control.Monad.Support
+
+/-!
+# Relational weakest preconditions from exact support
+
+This file supplies two concrete `Prop`-valued relational monad algebras for monads with
+exact support:
+
+* the **demonic** algebra requires the postcondition for every pair of possible outputs;
+* the **angelic** algebra requires it for some pair of possible outputs.
+
+Both observations satisfy strict bind and are anchored to their matching unary support
+algebras. The definitions are deliberately named rather than global instances because
+the demonic and angelic interpretations have the same instance head, and because other
+relational semantics (for example couplings) may be appropriate for the same monads.
+-/
+
+@[expose] public section
+
+universe v₁ v₂
+
+namespace MonadAttach
+
+open MAlgRelOrdered
+
+variable {m₁ : Type → Type v₁} {m₂ : Type → Type v₂}
+variable [Monad m₁] [Monad m₂] [LawfulMonad m₁] [LawfulMonad m₂]
+variable [MonadAttach m₁] [MonadAttach m₂] [ExactMonadAttach m₁] [ExactMonadAttach m₂]
+
+/-- The demonic relational support algebra: every possible left output and every possible
+right output must satisfy the relational postcondition. -/
+@[instance_reducible]
+def mAlgRelOrderedPropDemonic : MAlgRelOrdered m₁ m₂ Prop where
+  rwp x y post := AllOutputs (fun a => AllOutputs (post a) y) x
+  rwp_pure _ _ _ := by simp
+  rwp_mono hpost := by
+    intro h a ha b hb
+    exact hpost a b (h a ha b hb)
+  rwp_bind_le x y f g post := by
+    intro h c hc d hd
+    obtain ⟨a, ha, hc⟩ := mem_support_bind.mp hc
+    obtain ⟨b, hb, hd⟩ := mem_support_bind.mp hd
+    exact h a ha b hb c hc d hd
+
+/-- The angelic relational support algebra: some possible left/right output pair must
+satisfy the relational postcondition. -/
+@[instance_reducible]
+def mAlgRelOrderedPropAngelic : MAlgRelOrdered m₁ m₂ Prop where
+  rwp x y post := SomeOutput (fun a => SomeOutput (post a) y) x
+  rwp_pure _ _ _ := by simp
+  rwp_mono hpost := by
+    rintro ⟨a, ha, b, hb, hab⟩
+    exact ⟨a, ha, b, hb, hpost a b hab⟩
+  rwp_bind_le x y f g post := by
+    rintro ⟨a, ha, b, hb, c, hc, d, hd, hcd⟩
+    exact ⟨c, mem_support_bind.mpr ⟨a, ha, hc⟩,
+      d, mem_support_bind.mpr ⟨b, hb, hd⟩, hcd⟩
+
+section Demonic
+
+attribute [local instance] mAlgRelOrderedPropDemonic mAlgOrderedPropDemonic
+
+/-- Support characterization of the demonic relational weakest precondition. -/
+theorem relWP_demonic_iff_forall_support {α β : Type} (x : m₁ α) (y : m₂ β)
+    (post : α → β → Prop) :
+    RelWP x y post ↔ ∀ a ∈ support x, ∀ b ∈ support y, post a b :=
+  Iff.rfl
+
+/-- Exact support makes the demonic relational bind law an equality. -/
+theorem strictBindPropDemonic : StrictBind m₁ m₂ Prop := by
+  refine { rwp_bind := ?_ }
+  intro α β γ δ x y f g post
+  apply propext
+  constructor
+  · intro h c hc d hd
+    obtain ⟨a, ha, hc⟩ := mem_support_bind.mp hc
+    obtain ⟨b, hb, hd⟩ := mem_support_bind.mp hd
+    exact h a ha b hb c hc d hd
+  · intro h a ha b hb c hc d hd
+    exact h c (mem_support_bind.mpr ⟨a, ha, hc⟩)
+      d (mem_support_bind.mpr ⟨b, hb, hd⟩)
+
+/-- The demonic relational support algebra is anchored to the demonic unary support
+algebra on both sides. -/
+theorem anchoredPropDemonic : Anchored m₁ m₂ Prop := by
+  refine { rwp_pure_left := ?_, rwp_pure_right := ?_ }
+  · intro α β a y post
+    apply propext
+    change AllOutputs (fun a' => AllOutputs (post a') y) (pure a : m₁ α) ↔
+      MAlgOrdered.wp y (post a)
+    rw [allOutputs_pure, wp_iff_allOutputs]
+  · intro α β x b post
+    apply propext
+    change AllOutputs (fun a => AllOutputs (post a) (pure b : m₂ β)) x ↔
+      MAlgOrdered.wp x (fun a => post a b)
+    rw [wp_iff_allOutputs]
+    apply allOutputs_congr
+    intro a
+    exact allOutputs_pure (post a) b
+
+end Demonic
+
+section Angelic
+
+attribute [local instance] mAlgRelOrderedPropAngelic mAlgOrderedPropAngelic
+
+/-- Support characterization of the angelic relational weakest precondition. -/
+theorem relWP_angelic_iff_exists_support {α β : Type} (x : m₁ α) (y : m₂ β)
+    (post : α → β → Prop) :
+    RelWP x y post ↔ ∃ a ∈ support x, ∃ b ∈ support y, post a b :=
+  Iff.rfl
+
+/-- Exact support makes the angelic relational bind law an equality. -/
+theorem strictBindPropAngelic : StrictBind m₁ m₂ Prop := by
+  refine { rwp_bind := ?_ }
+  intro α β γ δ x y f g post
+  apply propext
+  constructor
+  · rintro ⟨a, ha, b, hb, c, hc, d, hd, hcd⟩
+    exact ⟨c, mem_support_bind.mpr ⟨a, ha, hc⟩,
+      d, mem_support_bind.mpr ⟨b, hb, hd⟩, hcd⟩
+  · rintro ⟨c, hc, d, hd, hcd⟩
+    obtain ⟨a, ha, hc⟩ := mem_support_bind.mp hc
+    obtain ⟨b, hb, hd⟩ := mem_support_bind.mp hd
+    exact ⟨a, ha, b, hb, c, hc, d, hd, hcd⟩
+
+/-- The angelic relational support algebra is anchored to the angelic unary support
+algebra on both sides. -/
+theorem anchoredPropAngelic : Anchored m₁ m₂ Prop := by
+  refine { rwp_pure_left := ?_, rwp_pure_right := ?_ }
+  · intro α β a y post
+    apply propext
+    change SomeOutput (fun a' => SomeOutput (post a') y) (pure a : m₁ α) ↔
+      MAlgOrdered.wp y (post a)
+    rw [someOutput_pure, wp_angelic_iff_someOutput]
+  · intro α β x b post
+    apply propext
+    change SomeOutput (fun a => SomeOutput (post a) (pure b : m₂ β)) x ↔
+      MAlgOrdered.wp x (fun a => post a b)
+    rw [wp_angelic_iff_someOutput]
+    apply someOutput_congr
+    intro a
+    exact someOutput_pure (post a) b
+
+end Angelic
+
+end MonadAttach

--- a/PolyFun/Control/Monad/Hom/Writer.lean
+++ b/PolyFun/Control/Monad/Hom/Writer.lean
@@ -1,0 +1,59 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+module
+
+public import Mathlib.Control.Monad.Writer
+public import PolyFun.Control.Monad.Hom
+
+/-!
+# Writer transformers on monad morphisms
+
+This module gives `WriterT ω` its functorial action on PolyFun's bundled `MonadHom`.
+It is separate from `PolyFun.Control.Monad.Hom` so consumers of the base morphism API
+do not acquire Mathlib's Writer dependency unless they use it.
+-/
+
+@[expose] public section
+
+universe u v w x
+
+namespace WriterT
+
+variable {m : Type u → Type v} {n : Type u → Type w} [Monad m] [Monad n]
+  [LawfulMonad m] [LawfulMonad n] {ω α : Type u} [Monoid ω]
+
+/-- `WriterT ω` is functorial on monad morphisms: the morphism acts on the underlying
+computation while the returned value and accumulated output are left unchanged. -/
+def mapHom (φ : m →ᵐ n) : WriterT ω m →ᵐ WriterT ω n where
+  toFun _ x := WriterT.mk (φ x.run)
+  toFun_pure' a := by
+    apply WriterT.ext
+    simp [WriterT.run_pure]
+  toFun_bind' x y := by
+    apply WriterT.ext
+    simp only [WriterT.run_bind, WriterT.run_mk, MonadHom.mmap_bind]
+    exact bind_congr fun aw => by
+      simp only [MonadHom.mmap_map]
+
+@[simp] lemma run_mapHom (φ : m →ᵐ n) (x : WriterT ω m α) :
+    (WriterT.mapHom φ x).run = φ x.run := rfl
+
+@[simp] theorem mapHom_id :
+    WriterT.mapHom (ω := ω) (MonadHom.id m) = MonadHom.id (WriterT ω m) := by
+  apply MonadHom.ext'
+  intro α x
+  rfl
+
+variable {n' : Type u → Type x} [Monad n'] [LawfulMonad n']
+
+@[simp] theorem mapHom_comp (G : n →ᵐ n') (F : m →ᵐ n) :
+    WriterT.mapHom (ω := ω) (G ∘ₘ F) =
+      WriterT.mapHom (ω := ω) G ∘ₘ WriterT.mapHom (ω := ω) F := by
+  apply MonadHom.ext'
+  intro α x
+  rfl
+
+end WriterT

--- a/PolyFunTest/Control/MonadAlgebraRelational.lean
+++ b/PolyFunTest/Control/MonadAlgebraRelational.lean
@@ -160,6 +160,65 @@ example : (RelWP (m₁ := StateT Bool Id) (m₂ := StateT Nat Id)
 
 end BothStates
 
+section Readers
+
+noncomputable local instance instLeftReader :
+    MAlgRelOrdered (ReaderT Bool Id) Id (Bool → Prop) :=
+  readerTLeft Bool
+
+noncomputable local instance instStrictLeftReader :
+    StrictBind (ReaderT Bool Id) Id (Bool → Prop) :=
+  strictBindReaderTLeft Bool
+
+#synth StrictBind (ReaderT Bool Id) Id (Bool → Prop)
+
+/-- A left reader exposes the environment used to select its result. -/
+example : (RelWP (m₁ := ReaderT Bool Id) (m₂ := Id) (l := Bool → Prop)
+    (fun flag => if flag then 7 else 11) (8 : Nat)
+    (fun left right env => left + 1 = right ∧ env = true)) true := by
+  change 7 + 1 = 8 ∧ true = true
+  decide
+
+end Readers
+
+section RightReader
+
+noncomputable local instance instRightReader :
+    MAlgRelOrdered Id (ReaderT Nat Id) (Nat → Prop) :=
+  readerTRight Nat
+
+noncomputable local instance instStrictRightReader :
+    StrictBind Id (ReaderT Nat Id) (Nat → Prop) :=
+  strictBindReaderTRight Nat
+
+#synth StrictBind Id (ReaderT Nat Id) (Nat → Prop)
+
+end RightReader
+
+section BothReaders
+
+noncomputable local instance instBothReaders :
+    MAlgRelOrdered (ReaderT Bool Id) (ReaderT Nat Id) (Bool → Nat → Prop) :=
+  readerTBoth Bool Nat
+
+noncomputable local instance instStrictBothReaders :
+    StrictBind (ReaderT Bool Id) (ReaderT Nat Id) (Bool → Nat → Prop) :=
+  strictBindReaderTBoth Bool Nat
+
+#synth StrictBind (ReaderT Bool Id) (ReaderT Nat Id) (Bool → Nat → Prop)
+
+/-- The two-sided lift exposes distinct left and right environments in that order. -/
+example : (RelWP (m₁ := ReaderT Bool Id) (m₂ := ReaderT Nat Id)
+    (l := Bool → Nat → Prop)
+    (fun leftEnv => if leftEnv then 4 else 0)
+    (fun rightEnv => rightEnv + 1)
+    (fun left right leftEnv rightEnv =>
+      left = 4 ∧ right = 6 ∧ leftEnv = true ∧ rightEnv = 5)) true 5 := by
+  change 4 = 4 ∧ 6 = 6 ∧ true = true ∧ 5 = 5
+  decide
+
+end BothReaders
+
 section RightOption
 
 noncomputable local instance instRightOption :

--- a/PolyFunTest/Control/MonadAlgebraRelationalSupport.lean
+++ b/PolyFunTest/Control/MonadAlgebraRelationalSupport.lean
@@ -1,0 +1,82 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+module
+
+public import PolyFun.Control.Monad.Algebra.Relational.Support
+
+/-!
+# Exact-support relational algebra canaries
+
+These tests distinguish the production demonic and angelic relational observations and
+pin their `StrictBind` and `Anchored` witnesses on the nondeterministic `SetM` monad.
+-/
+
+@[expose] public section
+
+namespace PolyFunTest.MonadAlgebraRelationalSupport
+
+open MAlgRelOrdered MonadAttach
+
+def leftChoices : SetM Nat := ({0, 1} : Set Nat)
+def rightChoices : SetM Nat := ({1, 2} : Set Nat)
+
+section Demonic
+
+local instance instDemonicLeft : MAlgOrdered SetM Prop := mAlgOrderedPropDemonic
+local instance instDemonicRel : MAlgRelOrdered SetM SetM Prop :=
+  mAlgRelOrderedPropDemonic
+local instance instDemonicStrict : StrictBind SetM SetM Prop := strictBindPropDemonic
+local instance instDemonicAnchored : Anchored SetM SetM Prop := anchoredPropDemonic
+
+#synth StrictBind SetM SetM Prop
+#synth Anchored SetM SetM Prop
+
+/-- Equality does not hold demoniacally: every cross-product pair would have to agree. -/
+example : ¬ RelWP leftChoices rightChoices (· = ·) := by
+  rw [relWP_demonic_iff_forall_support]
+  intro h
+  have h0 : 0 ∈ support leftChoices := by
+    change 0 ∈ ({0, 1} : Set Nat)
+    simp
+  have h1 : 1 ∈ support rightChoices := by
+    change 1 ∈ ({1, 2} : Set Nat)
+    simp
+  exact Nat.zero_ne_one (h 0 h0 1 h1)
+
+/-- Ordering does hold for every pair in this particular cross product. -/
+example : RelWP leftChoices rightChoices (· ≤ ·) := by
+  rw [relWP_demonic_iff_forall_support]
+  intro a ha b hb
+  change a ∈ ({0, 1} : Set Nat) at ha
+  change b ∈ ({1, 2} : Set Nat) at hb
+  simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at ha hb
+  rcases ha with rfl | rfl <;> rcases hb with rfl | rfl <;> decide
+
+end Demonic
+
+section Angelic
+
+local instance instAngelicLeft : MAlgOrdered SetM Prop := mAlgOrderedPropAngelic
+local instance instAngelicRel : MAlgRelOrdered SetM SetM Prop :=
+  mAlgRelOrderedPropAngelic
+local instance instAngelicStrict : StrictBind SetM SetM Prop := strictBindPropAngelic
+local instance instAngelicAnchored : Anchored SetM SetM Prop := anchoredPropAngelic
+
+#synth StrictBind SetM SetM Prop
+#synth Anchored SetM SetM Prop
+
+/-- Equality does hold angelically: the shared output `1` witnesses it. -/
+example : RelWP leftChoices rightChoices (· = ·) := by
+  rw [relWP_angelic_iff_exists_support]
+  refine ⟨1, ?_, 1, ?_, rfl⟩
+  · change 1 ∈ ({0, 1} : Set Nat)
+    simp
+  · change 1 ∈ ({1, 2} : Set Nat)
+    simp
+
+end Angelic
+
+end PolyFunTest.MonadAlgebraRelationalSupport

--- a/PolyFunTest/Control/MonadHomExamples.lean
+++ b/PolyFunTest/Control/MonadHomExamples.lean
@@ -5,7 +5,8 @@ Authors: Devon Tuma
 -/
 module
 
-public import PolyFun.Control.Monad.Hom
+public import Mathlib.Algebra.Group.Nat.Defs
+public import PolyFun.Control.Monad.Hom.Writer
 
 /-!
 # Examples for the monad-morphism hierarchy
@@ -93,6 +94,11 @@ example : (OptionT.mapHom idToOption absent).run = some none := rfl
 def rejected : ExceptT String Id Nat := ExceptT.mk (.error "rejected")
 
 example : (ExceptT.mapHom idToOption rejected).run = some (.error "rejected") := rfl
+
+/-- Writer output remains data while the underlying effect is transported. -/
+def logged : WriterT Nat Id Nat := WriterT.mk (7, 3)
+
+example : (WriterT.mapHom idToOption logged).run = some (7, 3) := rfl
 
 end TransformerMaps
 

--- a/docs/reading/program-logic-landscape.md
+++ b/docs/reading/program-logic-landscape.md
@@ -43,9 +43,14 @@ substrates; core `Std.Do` is used only behind a two-file quarantine.
 - `Control/Monad/Algebra.lean` — the pre-existing kernel: `MAlgOrdered`,
   `wp`/`Triple`, transformer lifts, honest `wpExc`/`wpOpt`.
 - `Control/Monad/Algebra/Relational.lean` — `MAlgRelOrdered` (relational
-  `rwp`/`RelWP`/`Triple`, asynchronous bind rules, `StrictBind`, `Anchored`),
+  `rwp`/`RelWP`/`Triple`, asynchronous bind rules, `StrictBind`, `Anchored`, and
+  named left/right/both `StateT` and `ReaderT` lifts preserving strict bind),
   upstreamed from VCVio's `ToMathlib/Control/Monad/RelationalAlgebra.lean`
   (near-verbatim; three unused `LawfulMonad` binders dropped).
+- `Control/Monad/Algebra/Relational/Support.lean` — production demonic and
+  angelic relations obtained from exact support. They quantify universally or
+  existentially over the cross product of the two supports, respectively, and
+  ship matching `StrictBind` and `Anchored` witnesses as opt-in definitions.
 - `Control/Monad/Support.lean` — the support layer, built on Lean core's
   `MonadAttach` (shipped since v4.28; `CanReturn` *is* the support predicate).
   Core proves only the elimination half of the theory, and provably cannot prove
@@ -127,12 +132,15 @@ implemented).
   invariant inside the state relation, since `ITree` has no possible-output
   predicate for a postcondition to range over. wp-congruence under `WeakBisim`
   remains open.
-- The angelic WP bridge is **structurally blocked**, not merely unwritten.
+- The public angelic WP bridge is **blocked at the current Lean 4.33.1 pin**, not
+  merely unwritten.
   `Std.Do.PredTrans` carries conjunctivity as a structure field, stated as a
   bi-entailment; `AllOutputs` distributes over `∧` both ways but `SomeOutput` only
   left-to-right, so there is no angelic `Std.Do.WP`. Core's newer stack makes
   conjunctivity an opt-in `WPConjunctive`. That class asks for the direction angelic
-  support fails; optionality unblocks the base WP bridge, which must omit the class.
+  support fails; optionality in the public Lean 4.35 `Std.WP` API unblocks the base
+  WP bridge, which must omit the class. PolyFun does not import the current pin's
+  `Std.Internal.Do` as a stopgap.
   `PolyFunTest/Control/MonadAttach.lean` pins both directions and the failure.
 - The ε-additive approximate-triple algebra (ArkLib's sequencing blocker).
 - Optional `MonadFinSupport` (Finset-valued support, generalizing VCVio's

--- a/docs/wiki/program-logic.md
+++ b/docs/wiki/program-logic.md
@@ -11,7 +11,8 @@ migration sketch live in
 | Module | Content |
 |---|---|
 | `PolyFun/Control/Monad/Algebra.lean` | `MAlgOrdered m l`: ordered monad algebras over a complete lattice, with `wp`, `Triple`, the structural rule set, `StateT`/`ReaderT`/`ExceptT`/`OptionT` lifts, and the honest two-postcondition `wpExc`/`wpOpt` |
-| `PolyFun/Control/Monad/Algebra/Relational.lean` | `MAlgRelOrdered m₁ m₂ l`: relational `rwp`/`RelWP`/`Triple`, asynchronous one-sided bind rules, structural pure rules, explicit named side lifts, and the `StrictBind` / `Anchored` subclasses (Maillard et al. POPL 2020 shapes) |
+| `PolyFun/Control/Monad/Algebra/Relational.lean` | `MAlgRelOrdered m₁ m₂ l`: relational `rwp`/`RelWP`/`Triple`, asynchronous one-sided bind rules, structural pure rules, explicit named `StateT`/`ReaderT` side lifts, and the `StrictBind` / `Anchored` subclasses (Maillard et al. POPL 2020 shapes) |
+| `PolyFun/Control/Monad/Algebra/Relational/Support.lean` | Named demonic and angelic exact-support relational algebras; support characterizations; matching `StrictBind` and `Anchored` witnesses |
 | `PolyFun/Control/Monad/Support.lean` | `ExactMonadAttach m`: the introduction rules core omits for `MonadAttach.CanReturn`; `MonadAttach.support`; the `AllOutputs`/`SomeOutput`/`NoOutput` judgments and scoped `⊨ₐ`/`⊨ₛ`/`⊭` notation; the named demonic `MAlgOrdered m Prop` choice; instances for `Except`/`SetM` (absent upstream) and the `ExceptT` universe alias |
 | `PolyFun/PFunctor/Free/Support.lean` | `MonadAttach`/`ExactMonadAttach` for `FreeM P` with a computable, axiom-free `attach`; structural equations by `rfl`; coherence with `Free/Path.lean` (`support_eq_range_output`) and with the powerset fold (`support_eq_liftM_univ`) |
 | `PolyFun/PFunctor/Free/WP.lean` | `OpSpec P l` per-operation specs; syntactic `FreeM.wpFold` (with `demonic`/`angelic`); `OpSpec.toMAlgOrdered`; semantic `FreeM.wpVia` through a `Handler`; soundness `wpFold_le_wpVia`/`wpFold_eq_wpVia` |
@@ -76,12 +77,27 @@ different environments. The test suite pins both failures. Reason per run instea
 specification layer (`PFunctor/Free/WP.lean`), which indexes the notion by a
 per-operation answer assignment.
 
-The support-based `MAlgOrdered m Prop` and relational transformer lifts are
+The support-based unary and relational `Prop` algebras and the relational transformer lifts are
 explicit named definitions, not unrestricted global instances. This keeps
 support partial correctness distinct from the existing failure-as-`⊥`
 `OptionT`/`ExceptT` algebras and prevents inequivalent left/right transformer
-instance paths. Install the intended algebra locally at each verification
-boundary.
+instance paths. The demonic relational algebra quantifies over every pair in the
+two supports; the angelic algebra asks for one witnessing pair. Both satisfy
+`StrictBind` and are `Anchored` to the corresponding unary support algebra.
+Install the intended definitions and witnesses locally at each verification boundary.
+
+```lean
+local instance : MAlgOrdered m₁ Prop := MonadAttach.mAlgOrderedPropDemonic
+local instance : MAlgOrdered m₂ Prop := MonadAttach.mAlgOrderedPropDemonic
+local instance : MAlgRelOrdered m₁ m₂ Prop :=
+  MonadAttach.mAlgRelOrderedPropDemonic
+local instance : StrictBind m₁ m₂ Prop := MonadAttach.strictBindPropDemonic
+local instance : Anchored m₁ m₂ Prop := MonadAttach.anchoredPropDemonic
+```
+
+Use the `Angelic` definitions with the same pattern when existential support is
+the intended observation. `ReaderT` itself is not `ExactMonadAttach`; its named
+relational lifts instead reason at explicit left/right environments.
 
 ## Support: which interface is canonical
 

--- a/docs/wiki/repo-map.md
+++ b/docs/wiki/repo-map.md
@@ -98,6 +98,9 @@ Logic/HEq, Control/{Coalgebra, Comonad, Lawful, Monad, Bisimulation, LTS/Trace}
   is cslib's, reached through `Control.LTS.toLts`.
 
 Control/Monad/Algebra -> Control/Monad/Algebra/Relational
+Control/Monad/{Algebra/Relational, Support}
+  -> Control/Monad/Algebra/Relational/Support
+Control/Monad/Hom + Mathlib.Control.Monad.Writer -> Control/Monad/Hom/Writer
 Control/Monad/Support -> Control/Do/Basic  (also imports Std.Tactic.Do; see
   the quarantine rule in program-logic.md)
 


### PR DESCRIPTION
## Summary

This PR completes the small, generic control-layer bridges deferred from the recent program-logic work.

It adds:

- named left, right, and two-sided `ReaderT` relational-algebra lifts, with `StrictBind` preservation;
- `WriterT.mapHom` in a separate opt-in module, with identity and composition laws;
- production demonic and angelic relational algebras derived from exact monadic support;
- matching `StrictBind` and `Anchored` witnesses for both support interpretations;
- focused nondeterministic and transformer canaries, plus consumer-facing documentation.

### Diff metadata

- Base: `1aabae22b49d892c8fbbc549b255e2941f3d7d00` (`main`)
- Head: `ed310ab46c58dde50a2fbae59c6b1654145f2d1f`
- Commits: 1
- Files changed: 10
- Diff: 508 insertions, 10 deletions

## Motivation

The generic relational framework already exposed `StrictBind` and `Anchored`, but consumers still had to rebuild several routine bridges:

- `ReaderT` had no relational counterparts to the existing `StateT` lifts;
- bundled monad morphisms could be transported through several standard transformers, but not `WriterT`;
- exact support supplied unary demonic and angelic WPs, but no reusable relational cross-support model or production anchoring witness.

Keeping these pieces in PolyFun avoids repeating probability-free infrastructure in VCVio while preserving explicit choices at instance boundaries.

## Change-surface overview

| Area | Before | After |
|---|---|---|
| Relational transformers | Named `StateT`, `OptionT`, and `ExceptT` lifts | Adds named `ReaderT` left/right/both lifts and strict-bind witnesses |
| Monad morphisms | `mapHom` for `StateT`, `ReaderT`, `OptionT`, and `ExceptT` | Adds opt-in `WriterT.mapHom` with functorial laws |
| Exact support | Named unary demonic/angelic `MAlgOrdered` algebras | Adds named relational cross-support algebras |
| Relational laws | Consumers supplied concrete witnesses | Demonic and angelic support models ship `StrictBind` and `Anchored` witnesses |
| Public WP bridge | Demonic `Std.Do.WP` bridge only | Unchanged at Lean 4.33.1; the angelic base-WP bridge is documented for public `Std.WP` in Lean 4.35 |

## Implementation

### Reader transformers

`readerTLeft`, `readerTRight`, and `readerTBoth` expose the environment(s) in the relational carrier and run each computation at its corresponding environment. They remain named definitions, matching the existing transformer policy and avoiding inequivalent global instance paths. Each lift has a matching theorem showing that strict relational bind is preserved.

### Writer morphisms

`PolyFun.Control.Monad.Hom.Writer` keeps Mathlib's Writer dependency out of the base morphism module. `WriterT.mapHom` acts only on the underlying monadic computation; the returned value and accumulated output remain data. `run_mapHom`, `mapHom_id`, and `mapHom_comp` pin that behavior.

### Exact-support relations

For exact-support monads:

- `mAlgRelOrderedPropDemonic` requires the postcondition for every pair in the two support sets;
- `mAlgRelOrderedPropAngelic` requires one witnessing pair.

Both definitions are opt-in because they share an instance head and because consumers may choose another relational semantics, such as couplings. Exact `pure` and `bind` support laws prove strict bind. The matching unary support algebra proves both anchoring equations.

## Abstraction and compatibility

- No CSLib changes.
- No probability or cryptographic dependencies.
- No global competing `MAlgOrdered` or `MAlgRelOrdered` instances.
- No `Std.Internal.Do` imports and no expansion of the existing `Std.Do` quarantine.
- No existing API is removed or behavior changed; all new semantic choices are named and opt-in.

## Validation completed at `ed310ab`

The following passed locally against the exact head:

- `./scripts/validate.sh --lint --test --axioms`;
- full 1,531-module PolyFun build;
- full 1,641-module `PolyFunTest` build;
- environment lint and documentation/module-boundary checks;
- kernel axiom sweep over 10,588 declarations: zero `sorryAx` and zero non-standard-axiom taint;
- `lake exe lint-style`;
- `git diff --check`.

CI is intentionally not claimed here until GitHub completes it.

## Remaining work

The angelic bridge into core's public WP framework remains intentionally deferred. Lean 4.33.1's public `Std.Do.PredTrans` requires conjunctivity, which existential support does not satisfy. Lean 4.35 promotes the non-conjunctive base interface to public `Std.WP`; after a pin upgrade, PolyFun can add the angelic base-WP construction without a `WPConjunctive` instance. This PR does not expose the current internal API as a workaround.

## Reviewer map

Suggested order:

1. `PolyFun/Control/Monad/Algebra/Relational/Support.lean`
2. the new `ReaderT` blocks in `PolyFun/Control/Monad/Algebra/Relational.lean`
3. `PolyFun/Control/Monad/Hom/Writer.lean`
4. `PolyFunTest/Control/MonadAlgebraRelationalSupport.lean`
5. the focused transformer tests and program-logic documentation
