### PR TITLE
feat(realizability): bridge local nonuniform machine certificates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
         run: lake exe cache get
 
       - name: Build production libraries
-        run: lake build PolyFun ToCslib --wfail
+        run: lake build PolyFun ToCslib PolyFunCslib --wfail
 
       - name: Run environment linters
         run: lake lint

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -20,6 +20,6 @@ jobs:
         with:
           mode: check
       # The action invokes lint-style with the default target (PolyFun).
-      # ToCslib is intentionally a separate, non-default production library.
-      - name: Lint auxiliary production library
-        run: lake exe lint-style ToCslib
+      # ToCslib and PolyFunCslib are separate, non-default production libraries.
+      - name: Lint auxiliary production libraries
+        run: lake exe lint-style ToCslib PolyFunCslib

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,8 +101,8 @@ and depend on this library.
   admissible translation, boundary-level realizability invariance, and
   admissible word encode/decode retractions. Generic quantitative realizability
   and backend-relative trace accounting also live here. Optional concrete
-  realizability adapters are isolated under `Realizability/Backend/`; the cslib
-  P/poly adapter exposes a non-uniform, boundary-pinned certificate without
+  realizability adapters live in separate library roots; `PolyFunCslib/` exposes
+  a non-uniform, boundary-pinned P/poly certificate without
   importing oracle, probability, or cryptographic policy. Named cryptographic
   adversary classes and protocol-specific adequacy results remain downstream.
 - `PolyFun/Control/`: monad and comonad infrastructure transitively
@@ -119,6 +119,8 @@ and depend on this library.
   pinned cslib machine API. It imports cslib and Mathlib but never PolyFun,
   oracle semantics, probability, or cryptography. Concrete PolyFun backend
   adapters may import it explicitly; the generated `PolyFun` umbrella does not.
+- `PolyFunCslib/`: an optional adapter library combining generic PolyFun machines
+  with `ToCslib` certificates. It is excluded from the `PolyFun` umbrella.
 - `PolyFunTest/`: separate test / worked-example library (glob
   `PolyFunTest.+`), built by `lake test` and kept out of the `lake lint`
   scope. Holds the dynamical / interaction worked examples and the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,8 +100,11 @@ and depend on this library.
   from any class of word functions. `Representation.lean` supplies mutual
   admissible translation, boundary-level realizability invariance, and
   admissible word encode/decode retractions. Generic quantitative realizability
-  and backend-relative trace accounting also live here. *Generic only* —
-  concrete machine adequacy and complexity classes live downstream.
+  and backend-relative trace accounting also live here. Optional concrete
+  realizability adapters are isolated under `Realizability/Backend/`; the cslib
+  P/poly adapter exposes a non-uniform, boundary-pinned certificate without
+  importing oracle, probability, or cryptographic policy. Named cryptographic
+  adversary classes and protocol-specific adequacy results remain downstream.
 - `PolyFun/Control/`: monad and comonad infrastructure transitively
   required by the above (coalgebra, comonad, free / freecont monad
   algebra, monad iter / hom), plus the program-logic

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,9 @@ and depend on this library.
   silent/visible `Control.LTS` layer and preservation by weak simulation.
 - `PolyFun/Logic/`: small logic helpers (`HEq`).
 - `ToCslib/`: a separate low-level Lake library of reusable extensions to the
-  pinned cslib machine API. It imports cslib and Mathlib but never PolyFun,
+  pinned cslib machine API, including local complexity theory while upstream
+  APIs stabilize: encoded polynomial-time families and machine-counting separation.
+  It imports cslib and Mathlib but never PolyFun,
   oracle semantics, probability, or cryptography. Concrete PolyFun backend
   adapters may import it explicitly; the generated `PolyFun` umbrella does not.
 - `PolyFunCslib/`: an optional adapter library combining generic PolyFun machines

--- a/PolyFun.lean
+++ b/PolyFun.lean
@@ -258,6 +258,7 @@ public import PolyFun.PFunctor.Supply.Trace
 public import PolyFun.PFunctor.Trace
 public import PolyFun.PFunctor.Wiring
 public import PolyFun.PFunctor.Wiring.Parallel
+public import PolyFun.Realizability.Backend.Cslib.PPoly
 public import PolyFun.Realizability.Basic
 public import PolyFun.Realizability.Closure
 public import PolyFun.Realizability.DynSystem

--- a/PolyFun.lean
+++ b/PolyFun.lean
@@ -258,7 +258,6 @@ public import PolyFun.PFunctor.Supply.Trace
 public import PolyFun.PFunctor.Trace
 public import PolyFun.PFunctor.Wiring
 public import PolyFun.PFunctor.Wiring.Parallel
-public import PolyFun.Realizability.Backend.Cslib.PPoly
 public import PolyFun.Realizability.Basic
 public import PolyFun.Realizability.Closure
 public import PolyFun.Realizability.DynSystem

--- a/PolyFun/Realizability/Backend/Cslib/PPoly.lean
+++ b/PolyFun/Realizability/Backend/Cslib/PPoly.lean
@@ -1,0 +1,312 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma, Quang Dao
+-/
+
+module
+
+public import PolyFun.Realizability.Quantitative.Polynomial
+public import ToCslib.Computability.BitEncoding
+
+/-!
+# Non-uniform P/poly realizations backed by cslib machines
+
+This module connects the parameter-indexed single-tape certificates in
+`ToCslib` to PolyFun returning dynamical computations. It deliberately uses
+PolyFun's compositional first-order boundary: initialization, the combined
+return-or-query `head`, and the enabled partial transition `update?`.
+
+The predicate is named `IsPPolyBy`, rather than unqualified polynomial time or
+PPT. Its witness contains one cslib machine for each security parameter and a
+single polynomial bound on machine descriptions, so it is explicitly
+non-uniform. Boundary encodings remain pinned parameters and are never chosen
+existentially by the predicate.
+-/
+
+@[expose] public section
+
+universe u
+
+namespace PFunctor
+namespace CslibPPoly
+
+open ToCslib.Computability
+open DynSystem.DynComputation
+
+variable {p : ℕ → PFunctor.{u, u}} {input output : ℕ → Type u}
+
+/-! ## Pinned parameterized boundaries -/
+
+/-- Fixed binary representations for a parameterized program family and its
+polynomial-functor interface. -/
+structure Boundary (p : ℕ → PFunctor.{u, u}) (input output : ℕ → Type u) where
+  /-- Fixed-width input representation. -/
+  input : BitEncFam input
+  /-- Fixed-width returned-value representation. -/
+  output : BitEncFam output
+  /-- Fixed-width representation of query positions. -/
+  position : BitEncFam fun n ↦ (p n).A
+  /-- Fixed-width representation of dependent position/answer pairs. -/
+  index : BitEncFam fun n ↦ (p n).Idx
+
+namespace Boundary
+
+variable {nextOutput : ℕ → Type u}
+
+/-- Variable-width representation of the combined return-or-query head. -/
+noncomputable def head (bd : Boundary p input output) :
+    StrEncFam fun n ↦ output n ⊕ (p n).A :=
+  bd.output.toStrEncFam.sum bd.position.toStrEncFam
+
+/-- Replace the input representation. -/
+def withInput (bd : Boundary p input output) (encoding : BitEncFam nextOutput) :
+    Boundary p nextOutput output :=
+  ⟨encoding, bd.output, bd.position, bd.index⟩
+
+/-- Replace the output representation. -/
+def withOutput (bd : Boundary p input output) (encoding : BitEncFam nextOutput) :
+    Boundary p input nextOutput :=
+  ⟨bd.input, encoding, bd.position, bd.index⟩
+
+@[simp] theorem withInput_input (bd : Boundary p input output)
+    (encoding : BitEncFam nextOutput) : (bd.withInput encoding).input = encoding := rfl
+
+@[simp] theorem withOutput_output (bd : Boundary p input output)
+    (encoding : BitEncFam nextOutput) : (bd.withOutput encoding).output = encoding := rfl
+
+@[simp] theorem withInput_head (bd : Boundary p input output)
+    (encoding : BitEncFam nextOutput) : (bd.withInput encoding).head = bd.head := rfl
+
+@[simp] theorem withOutput_input (bd : Boundary p input output)
+    (encoding : BitEncFam nextOutput) : (bd.withOutput encoding).input = bd.input := rfl
+
+end Boundary
+
+/-! ## Machine families -/
+
+variable [∀ n, DecidableEq (p n).A]
+
+/-- A family of PolyFun machines whose three compositional step maps are
+implemented by cslib single-tape machines with uniform time and description
+bounds. The polynomial `rounds` bounds visible interactions. -/
+structure Realization (bd : Boundary p input output) where
+  /-- One returning dynamical computation per security parameter. -/
+  machine : (n : ℕ) → DynSystem.DynComputation (p n) (input n) (output n)
+  /-- Uniform polynomial bound on visible interaction rounds. -/
+  rounds : Polynomial ℕ
+  /-- Polynomially length-bounded representation of hidden states. -/
+  state : StrEncFam fun n ↦ (machine n).State
+  /-- Cslib code for initialization. -/
+  initCode : EncPolyTimeFam bd.input.enc state.enc fun n ↦ (machine n).init
+  /-- Cslib code for the combined returned-value-or-query head. -/
+  headCode : EncPolyTimeFam state.enc bd.head.enc fun n ↦ (machine n).head
+  /-- Cslib code for the enabled partial transition. -/
+  updateCode : EncPolyTimeFam (state.pairVar bd.index).enc state.option.enc
+    fun n ↦ (machine n).update?
+
+namespace Realization
+
+variable {bd : Boundary p input output}
+
+/-- One polynomial dominating the three local machine time bounds. -/
+noncomputable def localTime (realization : Realization bd) : Polynomial ℕ :=
+  realization.initCode.time + realization.headCode.time + realization.updateCode.time
+
+/-- Initialization time after substituting the canonical input-width bound. -/
+noncomputable def initTime (realization : Realization bd) : Polynomial ℕ :=
+  realization.initCode.time.comp (.X + bd.input.widBound)
+
+/-- Observation time after substituting the hidden-state length bound. -/
+noncomputable def headTime (realization : Realization bd) : Polynomial ℕ :=
+  realization.headCode.time.comp (.X + realization.state.bound)
+
+/-- Enabled-transition time after substituting the state and index length bounds. -/
+noncomputable def updateTime (realization : Realization bd) : Polynomial ℕ :=
+  realization.updateCode.time.comp
+    (.X + realization.state.bound + bd.index.widBound)
+
+/-- Additive worst-case time for initialization, at most `rounds` visible updates,
+and one observation before every update plus the final observation. This avoids the
+invalid shortcut of composing a step-machine polynomial `rounds` times. -/
+noncomputable def totalTime (realization : Realization bd) : Polynomial ℕ :=
+  realization.initTime + (realization.rounds + 1) * realization.headTime +
+    realization.rounds * realization.updateTime
+
+/-- One polynomial dominating all machine descriptions carried by the family. -/
+noncomputable def descriptionSize (realization : Realization bd) : Polynomial ℕ :=
+  realization.initCode.size + realization.headCode.size + realization.updateCode.size
+
+/-- The parameter-substituted initialization polynomial bounds the actual cslib
+machine on every canonically encoded input. -/
+theorem initTime_le (realization : Realization bd) (n : ℕ) (value : input n) :
+    ((realization.initCode.wit n).time).eval (bd.input.enc n value).length ≤
+      realization.initTime.eval n := by
+  refine (realization.initCode.time_le n _).trans ?_
+  rw [initTime, Polynomial.eval_comp]
+  simp only [Polynomial.eval_add, Polynomial.eval_X]
+  rw [bd.input.len_eq]
+  exact Polynomial.eval_le_eval (Nat.add_le_add_left (bd.input.wid_le n) n)
+
+/-- The parameter-substituted observation polynomial bounds every hidden state. -/
+theorem headTime_le (realization : Realization bd) (n : ℕ)
+    (state : (realization.machine n).State) :
+    ((realization.headCode.wit n).time).eval (realization.state.enc n state).length ≤
+      realization.headTime.eval n := by
+  refine (realization.headCode.time_le n _).trans ?_
+  rw [headTime, Polynomial.eval_comp]
+  simp only [Polynomial.eval_add, Polynomial.eval_X]
+  exact Polynomial.eval_le_eval (Nat.add_le_add_left (realization.state.len_le n state) n)
+
+/-- The parameter-substituted transition polynomial bounds every flattened index,
+including mismatched tags on which `update?` is allowed to return `none`. -/
+theorem updateTime_le (realization : Realization bd) (n : ℕ)
+    (step : (realization.machine n).State × (p n).Idx) :
+    ((realization.updateCode.wit n).time).eval
+        ((realization.state.pairVar bd.index).enc n step).length ≤
+      realization.updateTime.eval n := by
+  refine (realization.updateCode.time_le n _).trans ?_
+  rw [updateTime, Polynomial.eval_comp]
+  simp only [Polynomial.eval_add, Polynomial.eval_X]
+  apply Polynomial.eval_le_eval
+  simp only [StrEncFam.pairVar_enc, List.length_append]
+  rw [bd.index.len_eq]
+  have stateLength := realization.state.len_le n step.1
+  have indexWidth := bd.index.wid_le n
+  omega
+
+/-- Precompose the input of a realization with a supplied cslib machine family. -/
+noncomputable def precomp {nextInput : ℕ → Type u} (realization : Realization bd)
+    (function : (n : ℕ) → nextInput n → input n) (encoding : BitEncFam nextInput)
+    (code : EncPolyTimeFam encoding.enc bd.input.enc function) :
+    Realization (bd.withInput encoding) where
+  machine n := (realization.machine n).setInit fun value ↦
+    (realization.machine n).init (function n value)
+  rounds := realization.rounds
+  state := realization.state
+  initCode := (code.comp realization.initCode).copy _ fun _ _ ↦ rfl
+  headCode := realization.headCode.copy _ fun n state ↦ by
+    exact (head_setInit (realization.machine n)
+      (fun value ↦ (realization.machine n).init (function n value)) state).symm
+  updateCode := realization.updateCode.copy _ fun n step ↦ by
+    exact (update?_setInit (realization.machine n)
+      (fun value ↦ (realization.machine n).init (function n value)) step).symm
+
+/-- Postcompose returned values with supplied code for the induced head map. -/
+noncomputable def mapResult {nextOutput : ℕ → Type u} (realization : Realization bd)
+    (function : (n : ℕ) → output n → nextOutput n) (encoding : BitEncFam nextOutput)
+    (headMapCode : EncPolyTimeFam bd.head.enc (bd.withOutput encoding).head.enc
+      fun n ↦ Sum.map (function n) id) : Realization (bd.withOutput encoding) where
+  machine n := (realization.machine n).mapResult (function n)
+  rounds := realization.rounds
+  state := realization.state
+  initCode := realization.initCode.copy _ fun _ _ ↦ rfl
+  headCode := (realization.headCode.comp headMapCode).copy _ fun n state ↦ by
+    simpa only [Function.comp_apply] using
+      (head_mapResult (realization.machine n) (function n) state).symm
+  updateCode := realization.updateCode.copy _ fun n step ↦ by
+    exact (update?_mapResult (realization.machine n) (function n) step).symm
+
+end Realization
+
+/-! ## Program witnesses and predicate -/
+
+variable {bd : Boundary p input output}
+
+/-- Agreement of a cslib-backed realization with a parameterized free-program
+family at its polynomial round budget. -/
+def Realization.Implements (realization : Realization bd)
+    (program : (n : ℕ) → input n → FreeM (p n) (output n)) : Prop :=
+  ∀ n, (realization.machine n).ImplementsWithin (program n) (realization.rounds.eval n)
+
+/-- A non-uniform P/poly witness for a parameterized free-program family. -/
+structure Witness (bd : Boundary p input output)
+    (program : (n : ℕ) → input n → FreeM (p n) (output n)) where
+  /-- The cslib-backed machine family. -/
+  realization : Realization bd
+  /-- The machines implement the programs within the polynomial round bound. -/
+  implements : realization.Implements program
+
+/-- Backend-relative non-uniform P/poly realizability at a pinned boundary. -/
+def IsPPolyBy (bd : Boundary p input output)
+    (program : (n : ℕ) → input n → FreeM (p n) (output n)) : Prop :=
+  Nonempty (Witness bd program)
+
+namespace Witness
+
+variable {bd : Boundary p input output}
+  {program : (n : ℕ) → input n → FreeM (p n) (output n)}
+
+/-- Every certified computation resolves along every typed answer path within
+the witness round bound. -/
+theorem resolvesIn (witness : Witness bd program) (n : ℕ) (value : input n) :
+    (witness.realization.machine n).ResolvesIn
+      (witness.realization.rounds.eval n) ((witness.realization.machine n).init value) :=
+  (witness.implements n).resolvesIn value
+
+/-- The implemented syntax itself has the polynomial total interaction bound. -/
+theorem isTotalRollBound (witness : Witness bd program) (n : ℕ) (value : input n) :
+    (program n value).IsTotalRollBound (witness.realization.rounds.eval n) :=
+  ((implementsWithin_iff_implements_and_bound
+    (witness.realization.machine n) (program n)
+      (witness.realization.rounds.eval n)).mp (witness.implements n)).2 value
+
+end Witness
+
+namespace IsPPolyBy
+
+variable {bd : Boundary p input output}
+  {program program' : (n : ℕ) → input n → FreeM (p n) (output n)}
+
+/-- Transport a P/poly certificate along pointwise program equality. -/
+theorem congr (equality : ∀ n value, program n value = program' n value)
+    (certificate : IsPPolyBy bd program) : IsPPolyBy bd program' := by
+  obtain ⟨witness⟩ := certificate
+  exact ⟨{
+    realization := witness.realization
+    implements := fun n value ↦ by
+      rw [← equality n value]
+      exact witness.implements n value }⟩
+
+/-- P/poly is closed under input precomposition when the input map carries a
+cslib family certificate. -/
+theorem precomp {nextInput : ℕ → Type u} (certificate : IsPPolyBy bd program)
+    (function : (n : ℕ) → nextInput n → input n) (encoding : BitEncFam nextInput)
+    (code : EncPolyTimeFam encoding.enc bd.input.enc function) :
+    IsPPolyBy (bd.withInput encoding) fun n value ↦ program n (function n value) := by
+  obtain ⟨witness⟩ := certificate
+  refine ⟨{
+    realization := witness.realization.precomp function encoding code
+    implements := fun n value ↦ ?_ }⟩
+  change ((witness.realization.machine n).setInit fun value ↦
+      (witness.realization.machine n).init (function n value)).unroll
+        (witness.realization.rounds.eval n)
+        ((witness.realization.machine n).init (function n value)) = _
+  rw [unroll_setInit]
+  exact witness.implements n (function n value)
+
+/-- P/poly is closed under result mapping when the induced head map carries a
+cslib family certificate. -/
+theorem mapResult {nextOutput : ℕ → Type u} (certificate : IsPPolyBy bd program)
+    (function : (n : ℕ) → output n → nextOutput n) (encoding : BitEncFam nextOutput)
+    (headMapCode : EncPolyTimeFam bd.head.enc (bd.withOutput encoding).head.enc
+      fun n ↦ Sum.map (function n) id) :
+    IsPPolyBy (bd.withOutput encoding) fun n value ↦
+      FreeM.map (function n) (program n value) := by
+  obtain ⟨witness⟩ := certificate
+  refine ⟨{
+    realization := witness.realization.mapResult function encoding headMapCode
+    implements := fun n value ↦ ?_ }⟩
+  have implementation := witness.implements n value
+  change (witness.realization.machine n).unroll
+      (witness.realization.rounds.eval n) ((witness.realization.machine n).init value) = _
+    at implementation
+  change ((witness.realization.machine n).mapResult (function n)).unroll
+      (witness.realization.rounds.eval n) ((witness.realization.machine n).init value) = _
+  rw [unroll_mapResult, implementation, ← FreeM.comp_map, ← FreeM.comp_map]
+  rfl
+
+end IsPPolyBy
+
+end CslibPPoly
+end PFunctor

--- a/PolyFun/Realizability/Quantitative.lean
+++ b/PolyFun/Realizability/Quantitative.lean
@@ -466,6 +466,22 @@ def length {start finish : R.machine.State} : ExecutionTrace R start finish → 
   | .nil _ => 0
   | .query _ _ tail => tail.length + 1
 
+/-- Every execution prefix fits within a branchwise resolution budget at its start. -/
+theorem length_le_of_resolvesIn {start finish : R.machine.State} {budget : ℕ}
+    (trace : ExecutionTrace R start finish) (resolves : R.machine.ResolvesIn budget start) :
+    trace.length ≤ budget := by
+  induction trace generalizing budget with
+  | nil => simp [length]
+  | @query state position next finish view_eq direction tail ih =>
+      cases budget with
+      | zero =>
+          exact False.elim
+            (R.machine.not_resolvesIn_query_zero state position next view_eq resolves)
+      | succ budget =>
+          exact Nat.succ_le_succ (ih
+            ((R.machine.resolvesIn_query_succ_iff budget state position next view_eq).mp
+              resolves direction))
+
 /-- Number of query-answer transitions carrying one selected interface label. -/
 def queryCount {label : Type*} [DecidableEq label] (labelOf : p.A → label)
     (interface : label) {start finish : R.machine.State} :
@@ -520,6 +536,25 @@ def cost {start finish : R.machine.State} : ExecutionTrace R start finish → Ex
           (Q.size bd.head (R.machine.head start)) +
         ExecutionCost.query (Q.size bd.pos position)
           (Q.size bd.idx ⟨position, direction⟩) + cost tail
+
+/-- Constant bounds on head and transition work give an additive bound for a trace and
+its final head observation: one head per visited state and one update per query. -/
+theorem work_cost_add_finalHead_le
+    (headBound updateBound : ℕ)
+    (head_le : ∀ state, Q.cost R.headCode state ≤ headBound)
+    (update_le : ∀ step, Q.cost R.updateCode step ≤ updateBound)
+    {start finish : R.machine.State} (trace : ExecutionTrace R start finish) :
+    trace.cost.work + Q.cost R.headCode finish ≤
+      (trace.length + 1) * headBound + trace.length * updateBound := by
+  induction trace with
+  | nil state => simpa [cost, length] using head_le state
+  | @query state position next finish view_eq direction tail ih =>
+      have headAtState := head_le state
+      have updateAtState := update_le (state, ⟨position, direction⟩)
+      simp only [cost, length, ExecutionCost.work_add, ExecutionCost.work_ofWork,
+        ExecutionCost.work_observe, ExecutionCost.work_query, Nat.add_zero]
+      simp only [Nat.add_mul, Nat.one_mul] at ih ⊢
+      omega
 
 /-- A trace starting at a returning state is empty: its final state is unchanged and it incurs no
 transition cost.

--- a/PolyFunCslib.lean
+++ b/PolyFunCslib.lean
@@ -1,0 +1,18 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+
+public import PolyFunCslib.Nontriviality
+public import PolyFunCslib.PPoly
+
+/-!
+# PolyFun's optional cslib-backed layer
+
+This umbrella exposes the adapter between PolyFun computations and the
+machine-grounded definitions maintained in `ToCslib`. It is a separate Lake
+library and is intentionally absent from the dependency-light `PolyFun` root.
+-/

--- a/PolyFunCslib.lean
+++ b/PolyFunCslib.lean
@@ -6,6 +6,7 @@ Authors: Quang Dao
 
 module
 
+public import PolyFunCslib.Backend
 public import PolyFunCslib.Nontriviality
 public import PolyFunCslib.PPoly
 

--- a/PolyFunCslib/Backend.lean
+++ b/PolyFunCslib/Backend.lean
@@ -22,7 +22,7 @@ purpose is to carry concrete encodings into the generic boundary and trace API.
 The quantitative realizer remains the load-bearing executable evidence.
 -/
 
-@[expose] public section
+public section
 
 universe u
 
@@ -31,27 +31,42 @@ namespace PFunctor.CslibBackend
 open ToCslib.Computability
 
 /-- Raw Boolean-string representations with unconstrained qualitative
-admissibility. Concrete quantitative morphisms still require cslib code. -/
-@[reducible] def encodingStepClass : StepClass.{u, u} where
+admissibility. Concrete quantitative morphisms still require cslib code.
+
+This definition is reducibly exposed so that `encodingStepClass.Str type`
+elaborates as the function type `type → List Bool` across module boundaries. -/
+@[expose, reducible] def encodingStepClass : StepClass.{u, u} where
   Str type := type → List Bool
   Hom _ _ _ := True
   id_mem _ := trivial
   comp_mem _ _ := trivial
 
-@[instance_reducible] instance : encodingStepClass.HasProd where
+@[instance_reducible] instance instHasProd : encodingStepClass.HasProd where
   prod left right value := left value.1 ++ right value.2
   fst_mem _ _ := trivial
   snd_mem _ _ := trivial
   pair_mem _ _ := trivial
 
-@[instance_reducible] instance : encodingStepClass.HasSum where
+@[simp] theorem prod_apply {A B : Type u} (left : A → List Bool)
+    (right : B → List Bool) (value : A × B) :
+    instHasProd.prod left right value = left value.1 ++ right value.2 := rfl
+
+@[instance_reducible] instance instHasSum : encodingStepClass.HasSum where
   sum left right := Sum.elim (fun value ↦ false :: left value)
     (fun value ↦ true :: right value)
   inl_mem _ _ := trivial
   inr_mem _ _ := trivial
   elim_mem _ _ := trivial
 
-@[instance_reducible] instance : encodingStepClass.HasOption where
+@[simp] theorem sum_inl {A B : Type u} (left : A → List Bool)
+    (right : B → List Bool) (value : A) :
+    instHasSum.sum left right (Sum.inl value) = false :: left value := rfl
+
+@[simp] theorem sum_inr {A B : Type u} (left : A → List Bool)
+    (right : B → List Bool) (value : B) :
+    instHasSum.sum left right (Sum.inr value) = true :: right value := rfl
+
+@[instance_reducible] instance instHasOption : encodingStepClass.HasOption where
   option encoding
     | none => [false]
     | some value => true :: encoding value
@@ -60,12 +75,22 @@ admissibility. Concrete quantitative morphisms still require cslib code. -/
   obindCtx_mem _ := trivial
   some_mem _ := trivial
 
+@[simp] theorem option_none {A : Type u} (encoding : A → List Bool) :
+    instHasOption.option encoding none = [false] := rfl
+
+@[simp] theorem option_some {A : Type u} (encoding : A → List Bool) (value : A) :
+    instHasOption.option encoding (some value) = true :: encoding value := rfl
+
 instance : encodingStepClass.IsDistributive where
   distrib_mem _ _ _ := trivial
 
 /-- Cslib single-tape code as a concrete quantitative backend. The work charge
-is a certified operational upper envelope, not an exact step counter. -/
-@[reducible] noncomputable def quantitative : QuantitativeStepClass encodingStepClass where
+is a certified operational upper envelope, not an exact step counter.
+
+This definition is reducibly exposed so that its generic `Realizer` family
+elaborates as `EncPolyTime`; the named size and cost laws below remain the proof
+API. -/
+@[expose, reducible] noncomputable def quantitative : QuantitativeStepClass encodingStepClass where
   Realizer source target function := EncPolyTime source target function
   size representation value := (representation value).length
   cost := @fun _ _ source _ _ code input ↦

--- a/PolyFunCslib/Backend.lean
+++ b/PolyFunCslib/Backend.lean
@@ -1,0 +1,143 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+
+public import PolyFun.Realizability.Quantitative
+public import ToCslib.Computability.PolyTime
+
+/-!
+# Cslib's single-tape backend for quantitative PolyFun realizability
+
+This module is the narrow adapter between the generic quantitative layer and
+cslib. Objects are represented by raw Boolean-string encodings. Quantitative
+realizers are `EncPolyTime` witnesses, and their backend-relative work charge is
+the witness's certified time polynomial evaluated at the encoded input length.
+
+The qualitative step class intentionally accepts every semantic function: its
+purpose is to carry concrete encodings into the generic boundary and trace API.
+The quantitative realizer remains the load-bearing executable evidence.
+-/
+
+@[expose] public section
+
+universe u
+
+namespace PFunctor.CslibBackend
+
+open ToCslib.Computability
+
+/-- Raw Boolean-string representations with unconstrained qualitative
+admissibility. Concrete quantitative morphisms still require cslib code. -/
+@[reducible] def encodingStepClass : StepClass.{u, u} where
+  Str type := type → List Bool
+  Hom _ _ _ := True
+  id_mem _ := trivial
+  comp_mem _ _ := trivial
+
+@[instance_reducible] instance : encodingStepClass.HasProd where
+  prod left right value := left value.1 ++ right value.2
+  fst_mem _ _ := trivial
+  snd_mem _ _ := trivial
+  pair_mem _ _ := trivial
+
+@[instance_reducible] instance : encodingStepClass.HasSum where
+  sum left right := Sum.elim (fun value ↦ false :: left value)
+    (fun value ↦ true :: right value)
+  inl_mem _ _ := trivial
+  inr_mem _ _ := trivial
+  elim_mem _ _ := trivial
+
+@[instance_reducible] instance : encodingStepClass.HasOption where
+  option encoding
+    | none => [false]
+    | some value => true :: encoding value
+  omap_mem _ := trivial
+  none_mem _ _ := trivial
+  obindCtx_mem _ := trivial
+  some_mem _ := trivial
+
+instance : encodingStepClass.IsDistributive where
+  distrib_mem _ _ _ := trivial
+
+/-- Cslib single-tape code as a concrete quantitative backend. The work charge
+is a certified operational upper envelope, not an exact step counter. -/
+@[reducible] noncomputable def quantitative : QuantitativeStepClass encodingStepClass where
+  Realizer source target function := EncPolyTime source target function
+  size representation value := (representation value).length
+  cost := @fun _ _ source _ _ code input ↦
+    code.time.eval (source input).length
+  admissible _ := trivial
+
+noncomputable instance : quantitative.HasCategory where
+  identity representation := EncPolyTime.id representation
+  compose first second := first.comp second
+  composeOverhead := @fun _ _ _ source _ _ _ _ first second input ↦
+    second.time.eval
+      (1 + (source input).length + first.time.eval (source input).length)
+  cost_compose_le := @fun _ _ _ source target _ function _ first second input ↦ by
+    change (first.comp second).time.eval (source input).length ≤
+      first.time.eval (source input).length +
+        second.time.eval (target (function input)).length +
+        second.time.eval
+          (1 + (source input).length + first.time.eval (source input).length)
+    rw [EncPolyTime.comp_time_eval]
+    omega
+
+@[simp] theorem size_eq_length {type : Type u} (representation : type → List Bool)
+    (value : type) : quantitative.size representation value = (representation value).length :=
+  rfl
+
+@[simp] theorem cost_eq_time_envelope {source target : Type u}
+    {sourceEncoding : source → List Bool} {targetEncoding : target → List Bool}
+    {function : source → target}
+    (code : EncPolyTime sourceEncoding targetEncoding function) (input : source) :
+    quantitative.cost code input = code.time.eval (sourceEncoding input).length :=
+  rfl
+
+/-! ## Generic trace envelope -/
+
+variable {p : PFunctor.{u, u}} {input output : Type u} [DecidableEq p.A]
+  {boundary : DynSystem.DynComputation.Boundary encodingStepClass p input output}
+
+/-- If every head and enabled-transition code has a constant work envelope,
+the generic quantitative trace fold plus its final head is bounded additively. -/
+theorem traceWork_add_finalHead_le
+    (realization : DynSystem.DynComputation.QuantitativeRealization quantitative boundary)
+    (headBound updateBound : ℕ)
+    (head_le : ∀ state, quantitative.cost realization.headCode state ≤ headBound)
+    (update_le : ∀ step, quantitative.cost realization.updateCode step ≤ updateBound)
+    {start finish : realization.machine.State}
+    (trace : realization.ExecutionTrace start finish) :
+    trace.cost.work + quantitative.cost realization.headCode finish ≤
+      (trace.length + 1) * headBound + trace.length * updateBound := by
+  induction trace with
+  | nil state =>
+      simpa [DynSystem.DynComputation.QuantitativeRealization.ExecutionTrace.cost,
+        DynSystem.DynComputation.QuantitativeRealization.ExecutionTrace.length] using
+        head_le state
+  | @query state position next finish view_eq direction tail induction =>
+      have headAtState := head_le state
+      have updateAtState := update_le (state, ⟨position, direction⟩)
+      change realization.headCode.time.eval (realization.state state).length ≤ headBound
+        at headAtState
+      change realization.updateCode.time.eval
+          ((boundary.stateIdx realization.state) (state, ⟨position, direction⟩)).length ≤
+        updateBound at updateAtState
+      change tail.cost.work +
+          realization.headCode.time.eval (realization.state finish).length ≤
+        (tail.length + 1) * headBound + tail.length * updateBound at induction
+      simp only [DynSystem.DynComputation.QuantitativeRealization.ExecutionTrace.cost,
+        DynSystem.DynComputation.QuantitativeRealization.ExecutionTrace.length,
+        ExecutionCost.work_add, ExecutionCost.work_ofWork, ExecutionCost.work_observe,
+        ExecutionCost.work_query, Nat.add_zero]
+      calc
+        _ ≤ headBound + updateBound +
+            ((tail.length + 1) * headBound + tail.length * updateBound) := by omega
+        _ = (tail.length + 1 + 1) * headBound +
+            (tail.length + 1) * updateBound := by ring
+
+end PFunctor.CslibBackend

--- a/PolyFunCslib/Backend.lean
+++ b/PolyFunCslib/Backend.lean
@@ -123,46 +123,4 @@ noncomputable instance : quantitative.HasCategory where
     quantitative.cost code input = code.time.eval (sourceEncoding input).length :=
   rfl
 
-/-! ## Generic trace envelope -/
-
-variable {p : PFunctor.{u, u}} {input output : Type u} [DecidableEq p.A]
-  {boundary : DynSystem.DynComputation.Boundary encodingStepClass p input output}
-
-/-- If every head and enabled-transition code has a constant work envelope,
-the generic quantitative trace fold plus its final head is bounded additively. -/
-theorem traceWork_add_finalHead_le
-    (realization : DynSystem.DynComputation.QuantitativeRealization quantitative boundary)
-    (headBound updateBound : ℕ)
-    (head_le : ∀ state, quantitative.cost realization.headCode state ≤ headBound)
-    (update_le : ∀ step, quantitative.cost realization.updateCode step ≤ updateBound)
-    {start finish : realization.machine.State}
-    (trace : realization.ExecutionTrace start finish) :
-    trace.cost.work + quantitative.cost realization.headCode finish ≤
-      (trace.length + 1) * headBound + trace.length * updateBound := by
-  induction trace with
-  | nil state =>
-      simpa [DynSystem.DynComputation.QuantitativeRealization.ExecutionTrace.cost,
-        DynSystem.DynComputation.QuantitativeRealization.ExecutionTrace.length] using
-        head_le state
-  | @query state position next finish view_eq direction tail induction =>
-      have headAtState := head_le state
-      have updateAtState := update_le (state, ⟨position, direction⟩)
-      change realization.headCode.time.eval (realization.state state).length ≤ headBound
-        at headAtState
-      change realization.updateCode.time.eval
-          ((boundary.stateIdx realization.state) (state, ⟨position, direction⟩)).length ≤
-        updateBound at updateAtState
-      change tail.cost.work +
-          realization.headCode.time.eval (realization.state finish).length ≤
-        (tail.length + 1) * headBound + tail.length * updateBound at induction
-      simp only [DynSystem.DynComputation.QuantitativeRealization.ExecutionTrace.cost,
-        DynSystem.DynComputation.QuantitativeRealization.ExecutionTrace.length,
-        ExecutionCost.work_add, ExecutionCost.work_ofWork, ExecutionCost.work_observe,
-        ExecutionCost.work_query, Nat.add_zero]
-      calc
-        _ ≤ headBound + updateBound +
-            ((tail.length + 1) * headBound + tail.length * updateBound) := by omega
-        _ = (tail.length + 1 + 1) * headBound +
-            (tail.length + 1) * updateBound := by ring
-
 end PFunctor.CslibBackend

--- a/PolyFunCslib/Nontriviality.lean
+++ b/PolyFunCslib/Nontriviality.lean
@@ -18,7 +18,7 @@ says that polynomially bounded non-uniform machine families cannot contain all
 families of Boolean predicates on `BitVec n`.
 -/
 
-@[expose] public section
+public section
 
 open Filter
 open ToCslib.Computability
@@ -76,9 +76,10 @@ theorem realizableLE_of_isPPolyBy_pure
     (certificate : IsPPolyBy coinBoundary
       (fun n value ↦ FreeM.pure (function n value))) :
     ∃ q : Polynomial ℕ, ∀ n, function n ∈ RealizableLE n (q.eval n) := by
-  obtain ⟨witness⟩ := certificate
+  obtain ⟨witness⟩ := certificate.toNonempty
   let outputCode := witness.realization.headCode.comp decodeCoinHeadCode
   refine ⟨witness.realization.initCode.size + outputCode.size, fun n ↦ ?_⟩
+  apply mem_realizableLE.mpr
   refine ⟨(witness.realization.machine n).State, witness.realization.state.enc n,
     (witness.realization.machine n).init,
     decodeCoinHead ∘ (witness.realization.machine n).head,

--- a/PolyFunCslib/Nontriviality.lean
+++ b/PolyFunCslib/Nontriviality.lean
@@ -1,0 +1,140 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+
+public import PolyFunCslib.PPoly
+public import ToCslib.Computability.SingleTape.Counting
+
+/-!
+# Non-triviality of the cslib-backed P/poly model
+
+This module connects the semantic `IsPPolyBy` certificate to `ToCslib`'s
+machine-counting theorem at one pinned Boolean boundary. The resulting theorem
+says that polynomially bounded non-uniform machine families cannot contain all
+families of Boolean predicates on `BitVec n`.
+-/
+
+@[expose] public section
+
+open Filter
+open ToCslib.Computability
+
+namespace PFunctor.CslibPPoly
+
+/-! ## The pinned pure-Boolean boundary -/
+
+/-- One Boolean-answer query. The non-triviality theorem concerns pure programs,
+but retaining a genuine query interface makes it directly reusable by oracle
+libraries. -/
+abbrev Coin : PFunctor := PFunctor.mk PUnit fun _ ↦ Bool
+
+/-- The parameter-constant family of Boolean-answer query interfaces. -/
+abbrev CoinFam : ℕ → PFunctor := fun _ ↦ Coin
+
+instance instDecidableEqCoinFam : (n : ℕ) → DecidableEq (CoinFam n).A :=
+  fun _ ↦ inferInstanceAs (DecidableEq PUnit)
+
+noncomputable instance instFintypeCoinIndex : Fintype Coin.Idx := by
+  change Fintype (Σ _ : PUnit, Bool)
+  infer_instance
+
+/-- Canonical, fixed representations for bitvector inputs, Boolean results, the
+single query position, and its Boolean answer. -/
+noncomputable def coinBoundary :
+    Boundary CoinFam (fun n ↦ BitVec n) (fun _ ↦ Bool) where
+  input := BitEncFam.bitVecX
+  output := BitEncFam.bool
+  position := BitEncFam.unit
+  index := BitEncFam.const Coin.Idx
+
+/-- Extract a returned Boolean, rejecting the sole query position. -/
+def decodeCoinHead : Bool ⊕ PUnit → Option Bool
+  | .inl value => some value
+  | .inr _ => none
+
+/-- Finite-table decoder from the combined return-or-query head to the canonical
+optional Boolean encoding used by the counting theorem. -/
+noncomputable def decodeCoinHeadCode :
+    EncPolyTimeFam coinBoundary.head.enc BitEncFam.bool.option.enc
+      (fun _ ↦ decodeCoinHead) :=
+  .ofFintype coinBoundary.head.enc_injective (fun _ ↦ decodeCoinHead)
+    (.C 3) (fun _ ↦ by simp [Coin, CoinFam])
+    coinBoundary.head.bound coinBoundary.head.len_le
+    BitEncFam.bool.option.widBound
+    (fun n value ↦
+      (BitEncFam.bool.option.len_eq n (decodeCoinHead value)).le.trans
+        (BitEncFam.bool.option.wid_le n))
+
+/-- A pure Boolean P/poly certificate yields the two cslib machines counted by
+`RealizableLE`: initialization, followed by decoded initial-state observation. -/
+theorem realizableLE_of_isPPolyBy_pure
+    {function : (n : ℕ) → BitVec n → Bool}
+    (certificate : IsPPolyBy coinBoundary
+      (fun n value ↦ FreeM.pure (function n value))) :
+    ∃ q : Polynomial ℕ, ∀ n, function n ∈ RealizableLE n (q.eval n) := by
+  obtain ⟨witness⟩ := certificate
+  let outputCode := witness.realization.headCode.comp decodeCoinHeadCode
+  refine ⟨witness.realization.initCode.size + outputCode.size, fun n ↦ ?_⟩
+  refine ⟨(witness.realization.machine n).State, witness.realization.state.enc n,
+    (witness.realization.machine n).init,
+    decodeCoinHead ∘ (witness.realization.machine n).head,
+    witness.realization.initCode.wit n, outputCode.wit n, ?_, ?_, ?_⟩
+  · have initBound := witness.realization.initCode.size_le n
+    simp only [Polynomial.eval_add]
+    exact initBound.trans (Nat.le_add_right _ _)
+  · have outputBound := outputCode.size_le n
+    simp only [Polynomial.eval_add]
+    exact outputBound.trans (Nat.le_add_left _ _)
+  · intro value
+    rw [Function.comp_apply, witness.head_init_eq_of_pure]
+    rfl
+
+/-! ## Diagonalization -/
+
+private theorem existsDiagonalRealizable :
+    ∃ (function : (n : ℕ) → BitVec n → Bool)
+      (cover : (n : ℕ) → Finset (BitVec n → Bool)),
+      (∀ n, RealizableLE n (2 ^ (n / 4)) ⊆ ↑(cover n)) ∧
+        (∀ᶠ n in atTop, function n ∉ cover n) := by
+  classical
+  let cover : (n : ℕ) → Finset (BitVec n → Bool) :=
+    fun n ↦ (exists_realizableLE_covering n (2 ^ (n / 4))).choose
+  have covered : ∀ n, RealizableLE n (2 ^ (n / 4)) ⊆ ↑(cover n) := fun n ↦
+    (exists_realizableLE_covering n (2 ^ (n / 4))).choose_spec.1
+  have cardBound : ∀ n,
+      (cover n).card ≤ Cslib.Turing.SingleTapeTM.B (2 ^ (n / 4)) ^ 2 := fun n ↦
+    (exists_realizableLE_covering n (2 ^ (n / 4))).choose_spec.2
+  have coverSmall : ∀ᶠ n in atTop, (cover n).card < 2 ^ (2 ^ n) :=
+    eventually_count_lt.mono fun n bound ↦ lt_of_le_of_lt (cardBound n) bound
+  obtain ⟨function, misses⟩ := exists_diagonal cover coverSmall
+  exact ⟨function, cover, covered, misses⟩
+
+private theorem notRealizableOfDiagonal
+    {function : (n : ℕ) → BitVec n → Bool}
+    {cover : (n : ℕ) → Finset (BitVec n → Bool)}
+    (covered : ∀ n, RealizableLE n (2 ^ (n / 4)) ⊆ ↑(cover n))
+    (misses : ∀ᶠ n in atTop, function n ∉ cover n)
+    (q : Polynomial ℕ) (realizable : ∀ n, function n ∈ RealizableLE n (q.eval n)) :
+    False := by
+  have belongs : ∀ᶠ n in atTop, function n ∈ cover n :=
+    (eventually_poly_le q).mono fun n bound ↦
+      Finset.mem_coe.mp (covered n (realizableLE_mono bound (realizable n)))
+  obtain ⟨n, belongsAtN, missesAtN⟩ := (belongs.and misses).exists
+  exact missesAtN belongsAtN
+
+/-- There is a Boolean predicate family whose pure programs have no
+cslib-backed non-uniform P/poly certificate at the pinned coin boundary. -/
+theorem exists_not_isPPolyBy_pure :
+    ∃ function : (n : ℕ) → BitVec n → Bool,
+      ¬ IsPPolyBy coinBoundary
+        (fun n value ↦ FreeM.pure (function n value)) := by
+  obtain ⟨function, cover, covered, misses⟩ := existsDiagonalRealizable
+  refine ⟨function, fun certificate ↦ ?_⟩
+  obtain ⟨q, realizable⟩ := realizableLE_of_isPPolyBy_pure certificate
+  exact notRealizableOfDiagonal covered misses q realizable
+
+end PFunctor.CslibPPoly

--- a/PolyFunCslib/Nontriviality.lean
+++ b/PolyFunCslib/Nontriviality.lean
@@ -20,7 +20,6 @@ families of Boolean predicates on `BitVec n`.
 
 public section
 
-open Filter
 open ToCslib.Computability
 
 namespace PFunctor.CslibPPoly
@@ -94,48 +93,14 @@ theorem realizableLE_of_isPPolyBy_pure
     rw [Function.comp_apply, witness.head_init_eq_of_pure]
     rfl
 
-/-! ## Diagonalization -/
-
-private theorem existsDiagonalRealizable :
-    ∃ (function : (n : ℕ) → BitVec n → Bool)
-      (cover : (n : ℕ) → Finset (BitVec n → Bool)),
-      (∀ n, RealizableLE n (2 ^ (n / 4)) ⊆ ↑(cover n)) ∧
-        (∀ᶠ n in atTop, function n ∉ cover n) := by
-  classical
-  let cover : (n : ℕ) → Finset (BitVec n → Bool) :=
-    fun n ↦ (exists_realizableLE_covering n (2 ^ (n / 4))).choose
-  have covered : ∀ n, RealizableLE n (2 ^ (n / 4)) ⊆ ↑(cover n) := fun n ↦
-    (exists_realizableLE_covering n (2 ^ (n / 4))).choose_spec.1
-  have cardBound : ∀ n,
-      (cover n).card ≤ Cslib.Turing.SingleTapeTM.B (2 ^ (n / 4)) ^ 2 := fun n ↦
-    (exists_realizableLE_covering n (2 ^ (n / 4))).choose_spec.2
-  have coverSmall : ∀ᶠ n in atTop, (cover n).card < 2 ^ (2 ^ n) :=
-    eventually_count_lt.mono fun n bound ↦ lt_of_le_of_lt (cardBound n) bound
-  obtain ⟨function, misses⟩ := exists_diagonal cover coverSmall
-  exact ⟨function, cover, covered, misses⟩
-
-private theorem notRealizableOfDiagonal
-    {function : (n : ℕ) → BitVec n → Bool}
-    {cover : (n : ℕ) → Finset (BitVec n → Bool)}
-    (covered : ∀ n, RealizableLE n (2 ^ (n / 4)) ⊆ ↑(cover n))
-    (misses : ∀ᶠ n in atTop, function n ∉ cover n)
-    (q : Polynomial ℕ) (realizable : ∀ n, function n ∈ RealizableLE n (q.eval n)) :
-    False := by
-  have belongs : ∀ᶠ n in atTop, function n ∈ cover n :=
-    (eventually_poly_le q).mono fun n bound ↦
-      Finset.mem_coe.mp (covered n (realizableLE_mono bound (realizable n)))
-  obtain ⟨n, belongsAtN, missesAtN⟩ := (belongs.and misses).exists
-  exact missesAtN belongsAtN
-
 /-- There is a Boolean predicate family whose pure programs have no
 cslib-backed non-uniform P/poly certificate at the pinned coin boundary. -/
 theorem exists_not_isPPolyBy_pure :
     ∃ function : (n : ℕ) → BitVec n → Bool,
       ¬ IsPPolyBy coinBoundary
         (fun n value ↦ FreeM.pure (function n value)) := by
-  obtain ⟨function, cover, covered, misses⟩ := existsDiagonalRealizable
-  refine ⟨function, fun certificate ↦ ?_⟩
-  obtain ⟨q, realizable⟩ := realizableLE_of_isPPolyBy_pure certificate
-  exact notRealizableOfDiagonal covered misses q realizable
+  obtain ⟨function, notRealizable⟩ := exists_not_realizableLE_poly
+  exact ⟨function, fun certificate ↦
+    notRealizable (realizableLE_of_isPPolyBy_pure certificate)⟩
 
 end PFunctor.CslibPPoly

--- a/PolyFunCslib/PPoly.lean
+++ b/PolyFunCslib/PPoly.lean
@@ -24,7 +24,7 @@ non-uniform. Boundary encodings remain pinned parameters and are never chosen
 existentially by the predicate.
 -/
 
-@[expose] public section
+public section
 
 universe u
 
@@ -69,6 +69,22 @@ noncomputable def toGeneric (bd : Boundary p input output) (n : ℕ) :
   pos := bd.position.enc n
   idx := bd.index.enc n
 
+@[simp] theorem toGeneric_input (bd : Boundary p input output) (n : ℕ) :
+    (bd.toGeneric n).input = bd.input.enc n := by
+  simp [toGeneric]
+
+@[simp] theorem toGeneric_out (bd : Boundary p input output) (n : ℕ) :
+    (bd.toGeneric n).out = bd.output.enc n := by
+  simp [toGeneric]
+
+@[simp] theorem toGeneric_pos (bd : Boundary p input output) (n : ℕ) :
+    (bd.toGeneric n).pos = bd.position.enc n := by
+  simp [toGeneric]
+
+@[simp] theorem toGeneric_idx (bd : Boundary p input output) (n : ℕ) :
+    (bd.toGeneric n).idx = bd.index.enc n := by
+  simp [toGeneric]
+
 /-- Replace the input representation. -/
 def withInput (bd : Boundary p input output) (encoding : BitEncFam nextOutput) :
     Boundary p nextOutput output :=
@@ -80,16 +96,67 @@ def withOutput (bd : Boundary p input output) (encoding : BitEncFam nextOutput) 
   ⟨bd.input, encoding, bd.position, bd.index⟩
 
 @[simp] theorem withInput_input (bd : Boundary p input output)
-    (encoding : BitEncFam nextOutput) : (bd.withInput encoding).input = encoding := rfl
+    (encoding : BitEncFam nextOutput) : (bd.withInput encoding).input = encoding := by
+  simp [withInput]
 
 @[simp] theorem withOutput_output (bd : Boundary p input output)
-    (encoding : BitEncFam nextOutput) : (bd.withOutput encoding).output = encoding := rfl
+    (encoding : BitEncFam nextOutput) : (bd.withOutput encoding).output = encoding := by
+  simp [withOutput]
 
 @[simp] theorem withInput_head (bd : Boundary p input output)
-    (encoding : BitEncFam nextOutput) : (bd.withInput encoding).head = bd.head := rfl
+    (encoding : BitEncFam nextOutput) : (bd.withInput encoding).head = bd.head := by
+  simp [head, withInput]
 
 @[simp] theorem withOutput_input (bd : Boundary p input output)
-    (encoding : BitEncFam nextOutput) : (bd.withOutput encoding).input = bd.input := rfl
+    (encoding : BitEncFam nextOutput) : (bd.withOutput encoding).input = bd.input := by
+  simp [withOutput]
+
+@[simp] theorem withInput_output (bd : Boundary p input output)
+    (encoding : BitEncFam nextOutput) : (bd.withInput encoding).output = bd.output := by
+  simp [withInput]
+
+@[simp] theorem withInput_position (bd : Boundary p input output)
+    (encoding : BitEncFam nextOutput) : (bd.withInput encoding).position = bd.position := by
+  simp [withInput]
+
+@[simp] theorem withInput_index (bd : Boundary p input output)
+    (encoding : BitEncFam nextOutput) : (bd.withInput encoding).index = bd.index := by
+  simp [withInput]
+
+@[simp] theorem withOutput_position (bd : Boundary p input output)
+    (encoding : BitEncFam nextOutput) : (bd.withOutput encoding).position = bd.position := by
+  simp [withOutput]
+
+@[simp] theorem withOutput_index (bd : Boundary p input output)
+    (encoding : BitEncFam nextOutput) : (bd.withOutput encoding).index = bd.index := by
+  simp [withOutput]
+
+@[simp] theorem withInput_self (bd : Boundary p input output) :
+    bd.withInput bd.input = bd := by
+  cases bd
+  simp [withInput]
+
+@[simp] theorem withOutput_self (bd : Boundary p input output) :
+    bd.withOutput bd.output = bd := by
+  cases bd
+  simp [withOutput]
+
+/-- The generic boundary's head representation is the parameterized head encoding. -/
+@[simp] theorem toGeneric_head (bd : Boundary p input output) (n : ℕ)
+    (value : output n ⊕ (p n).A) :
+    (bd.toGeneric n).head value = bd.head.enc n value := by
+  cases value <;>
+    simp [toGeneric, DynSystem.DynComputation.Boundary.head,
+      CslibBackend.encodingStepClass, head]
+
+/-- The generic boundary's transition-domain representation agrees with
+`StrEncFam.pairVar`. -/
+@[simp] theorem toGeneric_stateIdx {state : ℕ → Type u} (bd : Boundary p input output)
+    (encoding : StrEncFam state) (n : ℕ) (step : state n × (p n).Idx) :
+    (bd.toGeneric n).stateIdx (encoding.enc n) step =
+      (encoding.pairVar bd.index).enc n step := by
+  simp [toGeneric, DynSystem.DynComputation.Boundary.stateIdx,
+    CslibBackend.encodingStepClass]
 
 end Boundary
 
@@ -152,18 +219,69 @@ variable {bd : Boundary p input output}
 
 /-- One member of the family as an ordinary generic quantitative PolyFun
 realization. This is the canonical bridge through which trace, progress,
-traffic, peak-size, and closure APIs are consumed. -/
-noncomputable def toQuantitative (realization : Realization bd) (n : ℕ) :
+traffic, peak-size, and closure APIs are consumed.
+
+Its body is exposed because the generic trace API is dependently indexed by
+the realization's machine-state type: the bridge promises that projection is
+definitionally the original family member. Named projection and cost laws
+below provide the ordinary proof API. -/
+@[expose] noncomputable def toQuantitative (realization : Realization bd) (n : ℕ) :
     DynSystem.DynComputation.QuantitativeRealization CslibBackend.quantitative
       (bd.toGeneric n) where
   machine := realization.machine n
   state := realization.state.enc n
-  initCode := realization.initCode.wit n
-  headCode := realization.headCode.wit n
+  initCode := (realization.initCode.wit n).recode id
+    (realization.machine n).init (fun value ↦ by simp) (fun _ ↦ rfl)
+  headCode := (realization.headCode.wit n).recode id
+    (realization.machine n).head (fun _ ↦ rfl) (fun state ↦ by simp)
   updateCode := (realization.updateCode.wit n).recode id
-    (realization.machine n).update? (fun _ ↦ rfl) (fun step ↦ by
+    (realization.machine n).update? (fun step ↦ by simp) (fun step ↦ by
       change _ = realization.state.option.enc n ((realization.machine n).update? step)
-      cases value : (realization.machine n).update? step <;> rfl)
+      cases value : (realization.machine n).update? step <;>
+        simp [CslibBackend.encodingStepClass])
+
+@[simp] theorem toQuantitative_machine (realization : Realization bd) (n : ℕ) :
+    (realization.toQuantitative n).machine = realization.machine n := rfl
+
+@[simp] theorem toQuantitative_state (realization : Realization bd) (n : ℕ) :
+    (realization.toQuantitative n).state = realization.state.enc n := rfl
+
+/-- The generic bridge charges the original initialization code's time envelope. -/
+theorem toQuantitative_initCost (realization : Realization bd) (n : ℕ)
+    (value : input n) :
+    CslibBackend.quantitative.cost (realization.toQuantitative n).initCode value =
+      ((realization.initCode.wit n).time).eval (bd.input.enc n value).length := by
+  simp [toQuantitative]
+
+/-- The generic bridge charges the original observation code's time envelope. -/
+theorem toQuantitative_headCost (realization : Realization bd) (n : ℕ)
+    (state : (realization.machine n).State) :
+    CslibBackend.quantitative.cost (realization.toQuantitative n).headCode state =
+      ((realization.headCode.wit n).time).eval
+        (realization.state.enc n state).length := by
+  simp [toQuantitative]
+
+/-- The generic bridge charges the original transition code's time envelope. -/
+theorem toQuantitative_updateCost (realization : Realization bd) (n : ℕ)
+    (step : (realization.machine n).State × (p n).Idx) :
+    CslibBackend.quantitative.cost (realization.toQuantitative n).updateCode step =
+      ((realization.updateCode.wit n).time).eval
+        ((realization.state.pairVar bd.index).enc n step).length := by
+  simp [toQuantitative]
+
+/-- The work projection of generic execution cost uses the original three code
+families carried by the parameterized realization. -/
+@[simp] theorem toQuantitative_executionCost_work (realization : Realization bd)
+    (n : ℕ) (value : input n) {finish : (realization.machine n).State}
+    (trace : DynSystem.DynComputation.QuantitativeRealization.ExecutionTrace
+      (realization.toQuantitative n) ((realization.machine n).init value) finish) :
+    ((realization.toQuantitative n).executionCost value trace).work =
+      ((realization.initCode.wit n).time).eval (bd.input.enc n value).length +
+        trace.cost.work +
+          ((realization.headCode.wit n).time).eval
+            (realization.state.enc n finish).length := by
+  simp [DynSystem.DynComputation.QuantitativeRealization.executionCost,
+    toQuantitative]
 
 /-- Initialization time after substituting the canonical input-width bound. -/
 noncomputable def initTime (realization : Realization bd) : Polynomial ℕ :=
@@ -262,13 +380,12 @@ theorem certifiedTimeCharge_le (realization : Realization bd)
       trace.length * realization.updateTime.eval n := by
   apply CslibBackend.traceWork_add_finalHead_le
   · intro state
-    change ((realization.headCode.wit n).time).eval
-      (realization.state.enc n state).length ≤ realization.headTime.eval n
+    change (realization.machine n).State at state
+    rw [realization.toQuantitative_headCost]
     exact realization.headTime_le n state
   · intro step
-    change ((realization.updateCode.wit n).time).eval
-      ((realization.state.pairVar bd.index).enc n step).length ≤
-        realization.updateTime.eval n
+    change (realization.machine n).State × (p n).Idx at step
+    rw [realization.toQuantitative_updateCost]
     exact realization.updateTime_le n step
 
 /-- The work component of PolyFun's generic `executionCost` is bounded by the
@@ -282,14 +399,11 @@ theorem executionWork_le_totalTime (realization : Realization bd) (value : input
       realization.totalTime.eval n := by
   have initBound := realization.initTime_le n value
   have traceBound := realization.certifiedTimeCharge_le trace
-  change trace.cost.work +
-        ((realization.headCode.wit n).time).eval
-          (realization.state.enc n finish).length ≤
-      (trace.length + 1) * realization.headTime.eval n +
-        trace.length * realization.updateTime.eval n at traceBound
+  rw [realization.toQuantitative_headCost] at traceBound
   have headFactor : trace.length + 1 ≤ realization.rounds.eval n + 1 := by omega
   have headBound := Nat.mul_le_mul_right (realization.headTime.eval n) headFactor
   have updateBound := Nat.mul_le_mul_right (realization.updateTime.eval n) roundBound
+  rw [realization.toQuantitative_executionCost_work]
   change ((realization.initCode.wit n).time).eval (bd.input.enc n value).length +
       trace.cost.work +
         ((realization.headCode.wit n).time).eval
@@ -342,6 +456,34 @@ def Realization.Implements (realization : Realization bd)
     (program : (n : ℕ) → input n → FreeM (p n) (output n)) : Prop :=
   ∀ n, (realization.machine n).ImplementsWithin (program n) (realization.rounds.eval n)
 
+/-- Full characterization of family implementation at the declared round bound. -/
+theorem Realization.implements_iff (realization : Realization bd)
+    (program : (n : ℕ) → input n → FreeM (p n) (output n)) :
+    realization.Implements program ↔
+      ∀ n, (realization.machine n).ImplementsWithin
+        (program n) (realization.rounds.eval n) := by
+  simp [Realization.Implements]
+
+namespace Realization.Implements
+
+/-- Package pointwise implementations as a family implementation. -/
+theorem intro {realization : Realization bd}
+    {program : (n : ℕ) → input n → FreeM (p n) (output n)}
+    (implementation : ∀ n, (realization.machine n).ImplementsWithin
+      (program n) (realization.rounds.eval n)) :
+    realization.Implements program :=
+  (realization.implements_iff program).mpr implementation
+
+/-- Specialize a family implementation to one parameter. -/
+theorem apply {realization : Realization bd}
+    {program : (n : ℕ) → input n → FreeM (p n) (output n)}
+    (implementation : realization.Implements program) (n : ℕ) :
+    (realization.machine n).ImplementsWithin
+      (program n) (realization.rounds.eval n) :=
+  (realization.implements_iff program).mp implementation n
+
+end Realization.Implements
+
 /-- A non-uniform P/poly witness for a parameterized free-program family. -/
 structure Witness (bd : Boundary p input output)
     (program : (n : ℕ) → input n → FreeM (p n) (output n)) where
@@ -367,14 +509,14 @@ the witness round bound. -/
 theorem resolvesIn (witness : Witness bd program) (n : ℕ) (value : input n) :
     (witness.realization.machine n).ResolvesIn
       (witness.realization.rounds.eval n) ((witness.realization.machine n).init value) :=
-  (witness.implements n).resolvesIn value
+  (witness.implements.apply n).resolvesIn value
 
 /-- The implemented syntax itself has the polynomial total interaction bound. -/
 theorem isTotalRollBound (witness : Witness bd program) (n : ℕ) (value : input n) :
     (program n value).IsTotalRollBound (witness.realization.rounds.eval n) :=
   ((implementsWithin_iff_implements_and_bound
-    (witness.realization.machine n) (program n)
-      (witness.realization.rounds.eval n)).mp (witness.implements n)).2 value
+      (witness.realization.machine n) (program n)
+      (witness.realization.rounds.eval n)).mp (witness.implements.apply n)).2 value
 
 /-- A realization of an immediately returning program exposes that return at
 its initial state. This is the bridge from PolyFun's coinductive semantics to
@@ -387,7 +529,7 @@ theorem head_init_eq_of_pure {function : (n : ℕ) → input n → output n}
   have implementation :=
     ((implementsWithin_iff_implements_and_bound
       (witness.realization.machine n) (fun value ↦ FreeM.pure (function n value))
-        (witness.realization.rounds.eval n)).mp (witness.implements n)).1 value
+        (witness.realization.rounds.eval n)).mp (witness.implements.apply n)).1 value
   have firstStep := congrArg Resumption.dest implementation
   rw [DynSystem.DynComputation.dest_denote] at firstStep
   change Sum.map (fun result ↦ result)
@@ -413,18 +555,26 @@ namespace IsPPolyBy
 variable {bd : Boundary p input output}
   {program program' : (n : ℕ) → input n → FreeM (p n) (output n)}
 
+/-- Construct a P/poly certificate from its explicit witness. -/
+theorem intro (witness : Witness bd program) : IsPPolyBy bd program := by
+  simpa [CslibPPoly.IsPPolyBy] using (show Nonempty (Witness bd program) from ⟨witness⟩)
+
+/-- Recover the nonempty witness package carried by a P/poly certificate. -/
+theorem toNonempty (certificate : IsPPolyBy bd program) : Nonempty (Witness bd program) := by
+  simpa [CslibPPoly.IsPPolyBy] using certificate
+
 /-- Transport a P/poly certificate along pointwise program equality. -/
 theorem congr (equality : ∀ n value, program n value = program' n value)
     (certificate : IsPPolyBy bd program) : IsPPolyBy bd program' := by
-  obtain ⟨witness⟩ := certificate
-  exact ⟨{
+  obtain ⟨witness⟩ := certificate.toNonempty
+  exact intro {
     realization := witness.realization
-    implements := fun n value ↦ by
+    implements := Realization.Implements.intro fun n value ↦ by
       rw [← equality n value]
-      exact witness.implements n value
+      exact witness.implements.apply n value
     progress := fun n value ↦ by
       rw [← equality n value]
-      exact witness.progress n value }⟩
+      exact witness.progress n value }
 
 /-- P/poly is closed under input precomposition when the input map carries a
 cslib family certificate. -/
@@ -432,17 +582,18 @@ theorem precomp {nextInput : ℕ → Type u} (certificate : IsPPolyBy bd program
     (function : (n : ℕ) → nextInput n → input n) (encoding : BitEncFam nextInput)
     (code : EncPolyTimeFam encoding.enc bd.input.enc function) :
     IsPPolyBy (bd.withInput encoding) fun n value ↦ program n (function n value) := by
-  obtain ⟨witness⟩ := certificate
-  refine ⟨{
+  obtain ⟨witness⟩ := certificate.toNonempty
+  apply intro
+  refine {
     realization := witness.realization.precomp function encoding code
-    implements := fun n value ↦ ?_
-    progress := fun n value ↦ witness.progress n (function n value) }⟩
+    implements := Realization.Implements.intro fun n value ↦ ?_
+    progress := fun n value ↦ witness.progress n (function n value) }
   change ((witness.realization.machine n).setInit fun value ↦
       (witness.realization.machine n).init (function n value)).unroll
         (witness.realization.rounds.eval n)
         ((witness.realization.machine n).init (function n value)) = _
   rw [unroll_setInit]
-  exact witness.implements n (function n value)
+  exact witness.implements.apply n (function n value)
 
 /-- P/poly is closed under result mapping when the induced head map carries a
 cslib family certificate. -/
@@ -452,13 +603,14 @@ theorem mapResult {nextOutput : ℕ → Type u} (certificate : IsPPolyBy bd prog
       fun n ↦ Sum.map (function n) id) :
     IsPPolyBy (bd.withOutput encoding) fun n value ↦
       FreeM.map (function n) (program n value) := by
-  obtain ⟨witness⟩ := certificate
-  refine ⟨{
+  obtain ⟨witness⟩ := certificate.toNonempty
+  apply intro
+  refine {
     realization := witness.realization.mapResult function encoding headMapCode
-    implements := fun n value ↦ ?_
+    implements := Realization.Implements.intro fun n value ↦ ?_
     progress := fun n value ↦
-      (witness.progress n value).map (function n) }⟩
-  have implementation := witness.implements n value
+      (witness.progress n value).map (function n) }
+  have implementation := witness.implements.apply n value
   change (witness.realization.machine n).unroll
       (witness.realization.rounds.eval n) ((witness.realization.machine n).init value) = _
     at implementation

--- a/PolyFunCslib/PPoly.lean
+++ b/PolyFunCslib/PPoly.lean
@@ -6,7 +6,7 @@ Authors: Devon Tuma, Quang Dao
 
 module
 
-public import PolyFun.Realizability.Quantitative.Polynomial
+public import PolyFun.Realizability.Machine
 public import ToCslib.Computability.BitEncoding
 
 /-!
@@ -138,7 +138,7 @@ noncomputable def descriptionSize (realization : Realization bd) : Polynomial �
   realization.initCode.size + realization.headCode.size + realization.updateCode.size
 
 /-- The parameter-substituted initialization polynomial bounds the actual cslib
-machine on every canonically encoded input. -/
+  machine on every pinned encoded input. -/
 theorem initTime_le (realization : Realization bd) (n : ℕ) (value : input n) :
     ((realization.initCode.wit n).time).eval (bd.input.enc n value).length ≤
       realization.initTime.eval n := by
@@ -174,6 +174,87 @@ theorem updateTime_le (realization : Realization bd) (n : ℕ)
   have stateLength := realization.state.len_le n step.1
   have indexWidth := bd.index.wid_le n
   omega
+
+/-! ## Pathwise total running time -/
+
+/-- A fully typed visible execution prefix of one family member. The constructor
+records only enabled transitions, so the cost below never charges the arbitrary
+`none` behavior of `update?` on a mismatched flattened index. -/
+inductive ExecutionTrace (realization : Realization bd) (n : ℕ) :
+    (realization.machine n).State → (realization.machine n).State → Type u where
+  | nil (state : (realization.machine n).State) : ExecutionTrace realization n state state
+  | query {state : (realization.machine n).State} {position : (p n).A}
+      {next : (p n).B position → (realization.machine n).State}
+      {finish : (realization.machine n).State}
+      (view_eq : (realization.machine n).view state = Sum.inr ⟨position, next⟩)
+      (direction : (p n).B position)
+      (tail : ExecutionTrace realization n (next direction) finish) :
+      ExecutionTrace realization n state finish
+
+namespace ExecutionTrace
+
+variable {realization : Realization bd} {n : ℕ}
+
+/-- Number of visible query-answer transitions in the prefix. -/
+def length {start finish : (realization.machine n).State} :
+    ExecutionTrace realization n start finish → ℕ
+  | .nil _ => 0
+  | .query _ _ tail => tail.length + 1
+
+/-- Actual cslib-machine work charged to the observations and enabled updates
+along a trace, including the final observation. -/
+noncomputable def work {start finish : (realization.machine n).State} :
+    ExecutionTrace realization n start finish → ℕ
+  | .nil state =>
+      ((realization.headCode.wit n).time).eval
+        (realization.state.enc n state).length
+  | .query (state := state) (position := position) _ direction tail =>
+      ((realization.headCode.wit n).time).eval
+          (realization.state.enc n state).length +
+        ((realization.updateCode.wit n).time).eval
+          ((realization.state.pairVar bd.index).enc n
+            (state, ⟨position, direction⟩)).length + tail.work
+
+/-- Every typed prefix is bounded by one observation per state and one update
+per visible transition. -/
+theorem work_le {start finish : (realization.machine n).State}
+    (trace : ExecutionTrace realization n start finish) :
+    trace.work ≤ (trace.length + 1) * realization.headTime.eval n +
+      trace.length * realization.updateTime.eval n := by
+  induction trace with
+  | nil state =>
+      simpa [work, length] using realization.headTime_le n state
+  | @query state position next finish view_eq direction tail induction =>
+      have headBound := realization.headTime_le n state
+      have updateBound := realization.updateTime_le n (state, ⟨position, direction⟩)
+      simp only [work, length]
+      calc
+        _ ≤ realization.headTime.eval n + realization.updateTime.eval n +
+            ((tail.length + 1) * realization.headTime.eval n +
+              tail.length * realization.updateTime.eval n) :=
+          Nat.add_le_add (Nat.add_le_add headBound updateBound) induction
+        _ = (tail.length + 1 + 1) * realization.headTime.eval n +
+            (tail.length + 1) * realization.updateTime.eval n := by ring
+
+/-- Initialization plus every typed prefix of at most the declared round budget
+is bounded by `totalTime`. This is the load-bearing whole-run P/poly theorem:
+local machine bounds are added along a path rather than polynomially composed. -/
+theorem runWork_le_totalTime (value : input n)
+    {finish : (realization.machine n).State}
+    (trace : ExecutionTrace realization n ((realization.machine n).init value) finish)
+    (roundBound : trace.length ≤ realization.rounds.eval n) :
+    ((realization.initCode.wit n).time).eval (bd.input.enc n value).length + trace.work ≤
+      realization.totalTime.eval n := by
+  have initBound := realization.initTime_le n value
+  have traceBound := trace.work_le
+  have headFactor : trace.length + 1 ≤ realization.rounds.eval n + 1 := by omega
+  have headBound := Nat.mul_le_mul_right (realization.headTime.eval n) headFactor
+  have updateBound := Nat.mul_le_mul_right (realization.updateTime.eval n) roundBound
+  rw [Realization.totalTime]
+  simp only [Polynomial.eval_add, Polynomial.eval_mul, Polynomial.eval_one]
+  omega
+
+end ExecutionTrace
 
 /-- Precompose the input of a realization with a supplied cslib machine family. -/
 noncomputable def precomp {nextInput : ℕ → Type u} (realization : Realization bd)
@@ -250,6 +331,36 @@ theorem isTotalRollBound (witness : Witness bd program) (n : ℕ) (value : input
   ((implementsWithin_iff_implements_and_bound
     (witness.realization.machine n) (program n)
       (witness.realization.rounds.eval n)).mp (witness.implements n)).2 value
+
+/-- A realization of an immediately returning program exposes that return at
+its initial state. This is the bridge from PolyFun's coinductive semantics to
+the first-order `headCode` consumed by machine-counting arguments. -/
+theorem head_init_eq_of_pure {function : (n : ℕ) → input n → output n}
+    (witness : Witness bd (fun n value ↦ FreeM.pure (function n value)))
+    (n : ℕ) (value : input n) :
+    (witness.realization.machine n).head
+        ((witness.realization.machine n).init value) = Sum.inl (function n value) := by
+  have implementation :=
+    ((implementsWithin_iff_implements_and_bound
+      (witness.realization.machine n) (fun value ↦ FreeM.pure (function n value))
+        (witness.realization.rounds.eval n)).mp (witness.implements n)).1 value
+  have firstStep := congrArg Resumption.dest implementation
+  rw [DynSystem.DynComputation.dest_denote] at firstStep
+  change Sum.map (fun result ↦ result)
+      ((p n).map (witness.realization.machine n).toDynSystem.behavior)
+        ((witness.realization.machine n).view
+          ((witness.realization.machine n).init value)) =
+      Sum.inl (function n value) at firstStep
+  cases viewEquation : (witness.realization.machine n).view
+      ((witness.realization.machine n).init value) with
+  | inl result =>
+      rw [viewEquation] at firstStep
+      simp only [Sum.map_inl, Sum.inl.injEq] at firstStep
+      simpa [firstStep] using
+        (witness.realization.machine n).head_eq_inl_of_view viewEquation
+  | inr query =>
+      rw [viewEquation] at firstStep
+      simp at firstStep
 
 end Witness
 

--- a/PolyFunCslib/PPoly.lean
+++ b/PolyFunCslib/PPoly.lean
@@ -6,7 +6,7 @@ Authors: Devon Tuma, Quang Dao
 
 module
 
-public import PolyFun.Realizability.Machine
+public import PolyFunCslib.Backend
 public import ToCslib.Computability.BitEncoding
 
 /-!
@@ -59,6 +59,16 @@ noncomputable def head (bd : Boundary p input output) :
     StrEncFam fun n ↦ output n ⊕ (p n).A :=
   bd.output.toStrEncFam.sum bd.position.toStrEncFam
 
+/-- Specialize a parameterized pinned boundary to the generic PolyFun
+quantitative boundary at one security parameter. -/
+noncomputable def toGeneric (bd : Boundary p input output) (n : ℕ) :
+    DynSystem.DynComputation.Boundary CslibBackend.encodingStepClass
+      (p n) (input n) (output n) where
+  input := bd.input.enc n
+  out := bd.output.enc n
+  pos := bd.position.enc n
+  idx := bd.index.enc n
+
 /-- Replace the input representation. -/
 def withInput (bd : Boundary p input output) (encoding : BitEncFam nextOutput) :
     Boundary p nextOutput output :=
@@ -82,6 +92,37 @@ def withOutput (bd : Boundary p input output) (encoding : BitEncFam nextOutput) 
     (encoding : BitEncFam nextOutput) : (bd.withOutput encoding).input = bd.input := rfl
 
 end Boundary
+
+/-! ## Program progress -/
+
+/-- Every query in a finite free program has at least one typed answer, and the
+same holds recursively on every answer branch. This is separate from a
+branchwise query bound: universal branch obligations are vacuous at a query
+whose answer type is empty. -/
+def ProgramProgress {p : PFunctor.{u, u}} {result : Type u} : FreeM p result → Prop
+  | .pure _ => True
+  | .liftBind position next =>
+      Nonempty (p.B position) ∧ ∀ direction, ProgramProgress (next direction)
+
+theorem programProgress_pure {p : PFunctor.{u, u}} {result : Type u}
+    (value : result) : ProgramProgress (FreeM.pure (P := p) value) :=
+  trivial
+
+theorem programProgress_liftBind {p : PFunctor.{u, u}} {result : Type u}
+    (position : p.A) (next : p.B position → FreeM p result) :
+    ProgramProgress (FreeM.liftBind position next) ↔
+      Nonempty (p.B position) ∧ ∀ direction, ProgramProgress (next direction) :=
+  Iff.rfl
+
+/-- Mapping returned values preserves the reachable query tree and hence
+program progress. -/
+theorem ProgramProgress.map {p : PFunctor.{u, u}} {source target : Type u}
+    {program : FreeM p source} (progress : ProgramProgress program)
+    (function : source → target) : ProgramProgress (FreeM.map function program) := by
+  induction program with
+  | pure value => trivial
+  | lift_bind position next induction =>
+      exact ⟨progress.1, fun direction ↦ induction direction (progress.2 direction)⟩
 
 /-! ## Machine families -/
 
@@ -109,9 +150,20 @@ namespace Realization
 
 variable {bd : Boundary p input output}
 
-/-- One polynomial dominating the three local machine time bounds. -/
-noncomputable def localTime (realization : Realization bd) : Polynomial ℕ :=
-  realization.initCode.time + realization.headCode.time + realization.updateCode.time
+/-- One member of the family as an ordinary generic quantitative PolyFun
+realization. This is the canonical bridge through which trace, progress,
+traffic, peak-size, and closure APIs are consumed. -/
+noncomputable def toQuantitative (realization : Realization bd) (n : ℕ) :
+    DynSystem.DynComputation.QuantitativeRealization CslibBackend.quantitative
+      (bd.toGeneric n) where
+  machine := realization.machine n
+  state := realization.state.enc n
+  initCode := realization.initCode.wit n
+  headCode := realization.headCode.wit n
+  updateCode := (realization.updateCode.wit n).recode id
+    (realization.machine n).update? (fun _ ↦ rfl) (fun step ↦ by
+      change _ = realization.state.option.enc n ((realization.machine n).update? step)
+      cases value : (realization.machine n).update? step <;> rfl)
 
 /-- Initialization time after substituting the canonical input-width bound. -/
 noncomputable def initTime (realization : Realization bd) : Polynomial ℕ :=
@@ -175,86 +227,65 @@ theorem updateTime_le (realization : Realization bd) (n : ℕ)
   have indexWidth := bd.index.wid_le n
   omega
 
-/-! ## Pathwise total running time -/
+/-! ## Generic pathwise resource accounting -/
 
-/-- A fully typed visible execution prefix of one family member. The constructor
-records only enabled transitions, so the cost below never charges the arbitrary
-`none` behavior of `update?` on a mismatched flattened index. -/
-inductive ExecutionTrace (realization : Realization bd) (n : ℕ) :
-    (realization.machine n).State → (realization.machine n).State → Type u where
-  | nil (state : (realization.machine n).State) : ExecutionTrace realization n state state
-  | query {state : (realization.machine n).State} {position : (p n).A}
-      {next : (p n).B position → (realization.machine n).State}
-      {finish : (realization.machine n).State}
-      (view_eq : (realization.machine n).view state = Sum.inr ⟨position, next⟩)
-      (direction : (p n).B position)
-      (tail : ExecutionTrace realization n (next direction) finish) :
-      ExecutionTrace realization n state finish
+/-- The standard PolyFun quantitative trace for one member of the family. This
+alias deliberately exposes the generic trace API rather than maintaining a
+backend-specific parallel hierarchy. -/
+abbrev ExecutionTrace (realization : Realization bd) (n : ℕ) :=
+  (realization.toQuantitative n).ExecutionTrace
 
-namespace ExecutionTrace
+variable {n : ℕ}
 
-variable {realization : Realization bd} {n : ℕ}
-
-/-- Number of visible query-answer transitions in the prefix. -/
-def length {start finish : (realization.machine n).State} :
-    ExecutionTrace realization n start finish → ℕ
-  | .nil _ => 0
-  | .query _ _ tail => tail.length + 1
-
-/-- Actual cslib-machine work charged to the observations and enabled updates
-along a trace, including the final observation. -/
-noncomputable def work {start finish : (realization.machine n).State} :
-    ExecutionTrace realization n start finish → ℕ
-  | .nil state =>
-      ((realization.headCode.wit n).time).eval
-        (realization.state.enc n state).length
-  | .query (state := state) (position := position) _ direction tail =>
-      ((realization.headCode.wit n).time).eval
-          (realization.state.enc n state).length +
-        ((realization.updateCode.wit n).time).eval
-          ((realization.state.pairVar bd.index).enc n
-            (state, ⟨position, direction⟩)).length + tail.work
-
-/-- Every typed prefix is bounded by one observation per state and one update
-per visible transition. -/
-theorem work_le {start finish : (realization.machine n).State}
-    (trace : ExecutionTrace realization n start finish) :
-    trace.work ≤ (trace.length + 1) * realization.headTime.eval n +
+/-- The generic trace's cslib time-envelope charges, including its final head
+observation, are bounded by one observation per state and one enabled update per
+visible transition. -/
+theorem certifiedTimeCharge_le (realization : Realization bd)
+    {start finish : (realization.machine n).State}
+    (trace : DynSystem.DynComputation.QuantitativeRealization.ExecutionTrace
+      (realization.toQuantitative n) start finish) :
+    trace.cost.work +
+        CslibBackend.quantitative.cost
+          (realization.toQuantitative n).headCode finish ≤
+      (trace.length + 1) * realization.headTime.eval n +
       trace.length * realization.updateTime.eval n := by
-  induction trace with
-  | nil state =>
-      simpa [work, length] using realization.headTime_le n state
-  | @query state position next finish view_eq direction tail induction =>
-      have headBound := realization.headTime_le n state
-      have updateBound := realization.updateTime_le n (state, ⟨position, direction⟩)
-      simp only [work, length]
-      calc
-        _ ≤ realization.headTime.eval n + realization.updateTime.eval n +
-            ((tail.length + 1) * realization.headTime.eval n +
-              tail.length * realization.updateTime.eval n) :=
-          Nat.add_le_add (Nat.add_le_add headBound updateBound) induction
-        _ = (tail.length + 1 + 1) * realization.headTime.eval n +
-            (tail.length + 1) * realization.updateTime.eval n := by ring
+  apply CslibBackend.traceWork_add_finalHead_le
+  · intro state
+    change ((realization.headCode.wit n).time).eval
+      (realization.state.enc n state).length ≤ realization.headTime.eval n
+    exact realization.headTime_le n state
+  · intro step
+    change ((realization.updateCode.wit n).time).eval
+      ((realization.state.pairVar bd.index).enc n step).length ≤
+        realization.updateTime.eval n
+    exact realization.updateTime_le n step
 
-/-- Initialization plus every typed prefix of at most the declared round budget
-is bounded by `totalTime`. This is the load-bearing whole-run P/poly theorem:
-local machine bounds are added along a path rather than polynomially composed. -/
-theorem runWork_le_totalTime (value : input n)
+/-- The work component of PolyFun's generic `executionCost` is bounded by the
+family's declared total-time polynomial on every prefix within the round budget.
+The backend work metric is the cslib witness's certified time envelope. -/
+theorem executionWork_le_totalTime (realization : Realization bd) (value : input n)
     {finish : (realization.machine n).State}
     (trace : ExecutionTrace realization n ((realization.machine n).init value) finish)
     (roundBound : trace.length ≤ realization.rounds.eval n) :
-    ((realization.initCode.wit n).time).eval (bd.input.enc n value).length + trace.work ≤
+    ((realization.toQuantitative n).executionCost value trace).work ≤
       realization.totalTime.eval n := by
   have initBound := realization.initTime_le n value
-  have traceBound := trace.work_le
+  have traceBound := realization.certifiedTimeCharge_le trace
+  change trace.cost.work +
+        ((realization.headCode.wit n).time).eval
+          (realization.state.enc n finish).length ≤
+      (trace.length + 1) * realization.headTime.eval n +
+        trace.length * realization.updateTime.eval n at traceBound
   have headFactor : trace.length + 1 ≤ realization.rounds.eval n + 1 := by omega
   have headBound := Nat.mul_le_mul_right (realization.headTime.eval n) headFactor
   have updateBound := Nat.mul_le_mul_right (realization.updateTime.eval n) roundBound
+  change ((realization.initCode.wit n).time).eval (bd.input.enc n value).length +
+      trace.cost.work +
+        ((realization.headCode.wit n).time).eval
+          (realization.state.enc n finish).length ≤ realization.totalTime.eval n
   rw [Realization.totalTime]
   simp only [Polynomial.eval_add, Polynomial.eval_mul, Polynomial.eval_one]
   omega
-
-end ExecutionTrace
 
 /-- Precompose the input of a realization with a supplied cslib machine family. -/
 noncomputable def precomp {nextInput : ℕ → Type u} (realization : Realization bd)
@@ -307,6 +338,8 @@ structure Witness (bd : Boundary p input output)
   realization : Realization bd
   /-- The machines implement the programs within the polynomial round bound. -/
   implements : realization.Implements program
+  /-- Every syntactically reachable query has a possible typed response. -/
+  progress : ∀ n value, ProgramProgress (program n value)
 
 /-- Backend-relative non-uniform P/poly realizability at a pinned boundary. -/
 def IsPPolyBy (bd : Boundary p input output)
@@ -377,7 +410,10 @@ theorem congr (equality : ∀ n value, program n value = program' n value)
     realization := witness.realization
     implements := fun n value ↦ by
       rw [← equality n value]
-      exact witness.implements n value }⟩
+      exact witness.implements n value
+    progress := fun n value ↦ by
+      rw [← equality n value]
+      exact witness.progress n value }⟩
 
 /-- P/poly is closed under input precomposition when the input map carries a
 cslib family certificate. -/
@@ -388,7 +424,8 @@ theorem precomp {nextInput : ℕ → Type u} (certificate : IsPPolyBy bd program
   obtain ⟨witness⟩ := certificate
   refine ⟨{
     realization := witness.realization.precomp function encoding code
-    implements := fun n value ↦ ?_ }⟩
+    implements := fun n value ↦ ?_
+    progress := fun n value ↦ witness.progress n (function n value) }⟩
   change ((witness.realization.machine n).setInit fun value ↦
       (witness.realization.machine n).init (function n value)).unroll
         (witness.realization.rounds.eval n)
@@ -407,7 +444,9 @@ theorem mapResult {nextOutput : ℕ → Type u} (certificate : IsPPolyBy bd prog
   obtain ⟨witness⟩ := certificate
   refine ⟨{
     realization := witness.realization.mapResult function encoding headMapCode
-    implements := fun n value ↦ ?_ }⟩
+    implements := fun n value ↦ ?_
+    progress := fun n value ↦
+      (witness.progress n value).map (function n) }⟩
   have implementation := witness.implements n value
   change (witness.realization.machine n).unroll
       (witness.realization.rounds.eval n) ((witness.realization.machine n).init value) = _

--- a/PolyFunCslib/PPoly.lean
+++ b/PolyFunCslib/PPoly.lean
@@ -189,6 +189,17 @@ noncomputable def totalTime (realization : Realization bd) : Polynomial ℕ :=
 noncomputable def descriptionSize (realization : Realization bd) : Polynomial ℕ :=
   realization.initCode.size + realization.headCode.size + realization.updateCode.size
 
+/-- The sum of the three concrete cslib machine state counts at a parameter is
+bounded by the advertised description-size polynomial. -/
+theorem totalDescriptionSize_le (realization : Realization bd) (n : ℕ) :
+    (realization.initCode.wit n).size + (realization.headCode.wit n).size +
+        (realization.updateCode.wit n).size ≤ realization.descriptionSize.eval n := by
+  have init_le := realization.initCode.size_le n
+  have head_le := realization.headCode.size_le n
+  have update_le := realization.updateCode.size_le n
+  simp only [descriptionSize, Polynomial.eval_add]
+  omega
+
 /-- The parameter-substituted initialization polynomial bounds the actual cslib
   machine on every pinned encoded input. -/
 theorem initTime_le (realization : Realization bd) (n : ℕ) (value : input n) :

--- a/PolyFunCslib/PPoly.lean
+++ b/PolyFunCslib/PPoly.lean
@@ -17,11 +17,12 @@ This module connects the parameter-indexed single-tape certificates in
 PolyFun's compositional first-order boundary: initialization, the combined
 return-or-query `head`, and the enabled partial transition `update?`.
 
-The predicate is named `IsPPolyBy`, rather than unqualified polynomial time or
-PPT. Its witness contains one cslib machine for each security parameter and a
-single polynomial bound on machine descriptions, so it is explicitly
-non-uniform. Boundary encodings remain pinned parameters and are never chosen
-existentially by the predicate.
+`IsPPolyBy` is a backend-relative, nonuniform certificate. Its witness contains
+three cslib machines per size parameter, with uniform polynomial bounds on their
+time envelopes and description sizes, hidden-state encoding lengths, and visible
+query rounds. Boundary encodings remain pinned parameters. The work bound charges
+the three local machines; it excludes the cost of producing external answers and
+does not assert equivalence to the circuit definition of P/poly.
 -/
 
 public section
@@ -60,7 +61,7 @@ noncomputable def head (bd : Boundary p input output) :
   bd.output.toStrEncFam.sum bd.position.toStrEncFam
 
 /-- Specialize a parameterized pinned boundary to the generic PolyFun
-quantitative boundary at one security parameter. -/
+quantitative boundary at one size parameter. -/
 noncomputable def toGeneric (bd : Boundary p input output) (n : ℕ) :
     DynSystem.DynComputation.Boundary CslibBackend.encodingStepClass
       (p n) (input n) (output n) where
@@ -197,9 +198,9 @@ variable [∀ n, DecidableEq (p n).A]
 
 /-- A family of PolyFun machines whose three compositional step maps are
 implemented by cslib single-tape machines with uniform time and description
-bounds. The polynomial `rounds` bounds visible interactions. -/
+bounds. The declared `rounds` budget is enforced by `Realization.Implements`. -/
 structure Realization (bd : Boundary p input output) where
-  /-- One returning dynamical computation per security parameter. -/
+  /-- One returning dynamical computation per size parameter. -/
   machine : (n : ℕ) → DynSystem.DynComputation (p n) (input n) (output n)
   /-- Uniform polynomial bound on visible interaction rounds. -/
   rounds : Polynomial ℕ
@@ -378,7 +379,7 @@ theorem certifiedTimeCharge_le (realization : Realization bd)
           (realization.toQuantitative n).headCode finish ≤
       (trace.length + 1) * realization.headTime.eval n +
       trace.length * realization.updateTime.eval n := by
-  apply CslibBackend.traceWork_add_finalHead_le
+  apply trace.work_cost_add_finalHead_le
   · intro state
     change (realization.machine n).State at state
     rw [realization.toQuantitative_headCost]
@@ -510,6 +511,16 @@ theorem resolvesIn (witness : Witness bd program) (n : ℕ) (value : input n) :
     (witness.realization.machine n).ResolvesIn
       (witness.realization.rounds.eval n) ((witness.realization.machine n).init value) :=
   (witness.implements.apply n).resolvesIn value
+
+/-- Every execution prefix of a certified program satisfies the declared work envelope. -/
+theorem executionWork_le_totalTime (witness : Witness bd program) (n : ℕ) (value : input n)
+    {finish : (witness.realization.machine n).State}
+    (trace : witness.realization.ExecutionTrace n
+      ((witness.realization.machine n).init value) finish) :
+    ((witness.realization.toQuantitative n).executionCost value trace).work ≤
+      witness.realization.totalTime.eval n :=
+  witness.realization.executionWork_le_totalTime value trace
+    (trace.length_le_of_resolvesIn (witness.resolvesIn n value))
 
 /-- The implemented syntax itself has the polynomial total interaction bound. -/
 theorem isTotalRollBound (witness : Witness bd program) (n : ℕ) (value : input n) :

--- a/PolyFunTest/Realizability/CslibPPoly.lean
+++ b/PolyFunTest/Realizability/CslibPPoly.lean
@@ -73,6 +73,7 @@ noncomputable def boolWitness : Witness boolBoundary (fun _ value ↦ FreeM.pure
   realization := boolRealization
   implements _ value := by
     simp [boolRealization, boolMachine]
+  progress _ value := programProgress_pure value
 
 example : IsPPolyBy boolBoundary (fun _ value ↦ FreeM.pure value) :=
   ⟨boolWitness⟩
@@ -179,6 +180,9 @@ noncomputable def boolStepWitness : Witness boolStepBoundary boolQueryProgram wh
   implements n position := by
     simp only [boolStepRealization, Polynomial.eval_C]
     cases position <;> rfl
+  progress _ _ := by
+    rw [boolQueryProgram, programProgress_liftBind]
+    exact ⟨⟨false⟩, fun answer ↦ programProgress_pure answer⟩
 
 example : IsPPolyBy boolStepBoundary boolQueryProgram := ⟨boolStepWitness⟩
 
@@ -216,13 +220,12 @@ example (n : ℕ) (position answer : Bool) :
         (next := fun selected ↦ (position, some selected))
         (by change (boolStepMachine n).view (position, none) = _; rfl)
         answer (.nil _)
-    ((boolStepRealization.initCode.wit n).time).eval
-          (boolStepBoundary.input.enc n position).length + trace.work ≤
+    ((boolStepRealization.toQuantitative n).executionCost position trace).work ≤
         boolStepRealization.totalTime.eval n := by
   dsimp only
-  exact CslibPPoly.Realization.ExecutionTrace.runWork_le_totalTime
-    (realization := boolStepRealization) (n := n) position _ (by
-      simp [CslibPPoly.Realization.ExecutionTrace.length, boolStepRealization])
+  exact boolStepRealization.executionWork_le_totalTime position _ (by
+    simp [DynSystem.DynComputation.QuantitativeRealization.ExecutionTrace.length,
+      boolStepRealization])
 
 /-! The two closure canaries below use nontrivial maps. They ensure that both
 the certificate-level theorem and its encoded-machine plumbing elaborate. -/
@@ -253,5 +256,23 @@ example : IsPPolyBy boolStepBoundary (fun n value ↦
     FreeM.map (!·) (boolQueryProgram n value)) :=
   IsPPolyBy.mapResult ⟨boolStepWitness⟩ (fun _ value ↦ !value)
     BitEncFam.bool boolNegHeadCode
+
+/-! A positive round budget cannot disguise a stuck query with no answer. -/
+
+abbrev EmptyInteraction : PFunctor := PFunctor.mk PUnit fun _ ↦ PEmpty
+abbrev EmptyInteractionFam : ℕ → PFunctor := fun _ ↦ EmptyInteraction
+
+instance instDecidableEqEmptyInteractionFam :
+    (n : ℕ) → DecidableEq (EmptyInteractionFam n).A :=
+  fun _ ↦ inferInstanceAs (DecidableEq PUnit)
+
+def emptyQueryProgram (_n : ℕ) (_input : PUnit) : FreeM EmptyInteraction Bool :=
+  FreeM.liftBind PUnit.unit PEmpty.elim
+
+example (boundary : Boundary EmptyInteractionFam (fun _ ↦ PUnit) BoolFam) :
+    ¬ IsPPolyBy boundary emptyQueryProgram := by
+  rintro ⟨witness⟩
+  have progress := witness.progress 0 PUnit.unit
+  exact nomatch progress.1
 
 end PFunctor.CslibPPolyTest

--- a/PolyFunTest/Realizability/CslibPPoly.lean
+++ b/PolyFunTest/Realizability/CslibPPoly.lean
@@ -6,7 +6,7 @@ Authors: Quang Dao
 
 module
 
-public import PolyFun.Realizability.Backend.Cslib.PPoly
+public import PolyFunCslib.PPoly
 
 /-!
 # Direct canaries for the cslib-backed P/poly adapter
@@ -86,5 +86,172 @@ example (n : ℕ) (value : Bool) :
     (FreeM.pure value : (ConstBool n).FreeM Bool).IsTotalRollBound
       (boolRealization.rounds.eval n) :=
   boolWitness.isTotalRollBound n value
+
+/-! ## A branch-distinguishing one-query machine -/
+
+abbrev BoolInteraction : PFunctor := PFunctor.mk Bool fun _ ↦ Bool
+abbrev BoolInteractionFam : ℕ → PFunctor := fun _ ↦ BoolInteraction
+abbrev BoolStepState : Type := Bool × Option Bool
+
+instance instDecidableEqBoolInteractionFam :
+    (n : ℕ) → DecidableEq (BoolInteractionFam n).A := fun _ ↦ inferInstanceAs (DecidableEq Bool)
+
+noncomputable instance instFintypeBoolInteractionIndex : Fintype BoolInteraction.Idx :=
+  inferInstanceAs (Fintype ((_ : Bool) × Bool))
+
+def boolInteractionIndexEquiv : BoolInteraction.Idx ≃ Bool × Bool where
+  toFun index := (index.1, index.2)
+  invFun pair := ⟨pair.1, pair.2⟩
+  left_inv _ := rfl
+  right_inv _ := rfl
+
+theorem card_boolInteractionIndex : Fintype.card BoolInteraction.Idx = 4 := by
+  rw [Fintype.card_congr boolInteractionIndexEquiv]
+  decide
+
+noncomputable instance instFintypeBoolStepInput :
+    (n : ℕ) → Fintype (BoolStepState × (BoolInteractionFam n).Idx) :=
+  fun _ ↦ inferInstance
+
+noncomputable def boolIndexEncoding :
+    BitEncFam fun _ ↦ BoolInteraction.Idx where
+  wid _ := 2
+  widBound := .C 2
+  wid_le _ := by simp
+  enc _ index := [index.1, index.2]
+  len_eq _ _ := rfl
+  enc_injective _ left right equality := by
+    rcases left with ⟨leftPosition, leftAnswer⟩
+    rcases right with ⟨rightPosition, rightAnswer⟩
+    injection equality with positionEquality tailEquality
+    injection tailEquality with answerEquality
+    cases positionEquality
+    cases answerEquality
+    rfl
+
+noncomputable def boolStepBoundary :
+    Boundary BoolInteractionFam BoolFam BoolFam where
+  input := BitEncFam.bool
+  output := BitEncFam.bool
+  position := BitEncFam.bool
+  index := boolIndexEncoding
+
+noncomputable def boolStepStateEncoding : StrEncFam fun _ ↦ BoolStepState :=
+  (BitEncFam.bool.pair BitEncFam.bool.option).toStrEncFam
+
+@[reducible] def boolStepMachine (_n : ℕ) :
+    DynSystem.DynComputation BoolInteraction Bool Bool :=
+  .ofStep (S := BoolStepState)
+    (fun
+      | (position, none) => Sum.inr ⟨position, fun answer ↦ (position, some answer)⟩
+      | (_, some answer) => Sum.inl answer)
+    (fun position ↦ (position, none))
+
+noncomputable def boolStepRealization : CslibPPoly.Realization boolStepBoundary where
+  machine := boolStepMachine
+  rounds := .C 1
+  state := boolStepStateEncoding
+  initCode := .ofFintype BitEncFam.bool.enc_injective
+    (fun n ↦ (boolStepMachine n).init) (.C 2) (fun _ ↦ by simp)
+    BitEncFam.bool.widBound
+    (fun n value ↦ (BitEncFam.bool.len_eq n value).le.trans (BitEncFam.bool.wid_le n))
+    boolStepStateEncoding.bound (fun n value ↦ boolStepStateEncoding.len_le n _)
+  headCode := .ofFintype boolStepStateEncoding.enc_injective
+    (fun n ↦ (boolStepMachine n).head) (.C 6) (fun _ ↦ by norm_num [BoolStepState])
+    boolStepStateEncoding.bound boolStepStateEncoding.len_le
+    boolStepBoundary.head.bound (fun n value ↦ boolStepBoundary.head.len_le n _)
+  updateCode := .ofFintype
+    (boolStepStateEncoding.pairVar boolStepBoundary.index).enc_injective
+    (fun n ↦ (boolStepMachine n).update?) (.C 24)
+    (fun _ ↦ by
+      rw [Fintype.card_prod, card_boolInteractionIndex]
+      norm_num [BoolStepState])
+    (boolStepStateEncoding.pairVar boolStepBoundary.index).bound
+    (fun n value ↦ (boolStepStateEncoding.pairVar boolStepBoundary.index).len_le n _)
+    boolStepStateEncoding.option.bound
+    (fun n value ↦ boolStepStateEncoding.option.len_le n _)
+
+def boolQueryProgram (_n : ℕ) (position : Bool) : FreeM BoolInteraction Bool :=
+  FreeM.liftBind position FreeM.pure
+
+noncomputable def boolStepWitness : Witness boolStepBoundary boolQueryProgram where
+  realization := boolStepRealization
+  implements n position := by
+    simp only [boolStepRealization, Polynomial.eval_C]
+    cases position <;> rfl
+
+example : IsPPolyBy boolStepBoundary boolQueryProgram := ⟨boolStepWitness⟩
+
+example (position answer : Bool) :
+    (boolStepMachine 0).update? ((position, none), ⟨position, answer⟩) =
+      some (position, some answer) := by
+  change (if _ : position = position then some (position, some answer) else none) = _
+  simp
+
+example (position answer : Bool) :
+    (boolStepMachine 0).update? ((position, none), ⟨!position, answer⟩) = none := by
+  have viewEquation : (boolStepMachine 0).view (position, none) =
+      Sum.inr ⟨position, fun selected ↦ (position, some selected)⟩ := by rfl
+  exact DynSystem.DynComputation.update?_of_view_query_of_ne
+    (boolStepMachine 0) viewEquation (index := ⟨!position, answer⟩) (by
+      intro equality
+      cases position <;> simp at equality)
+
+example (position : Bool) :
+    (boolStepMachine 0).update? ((position, none), ⟨position, false⟩) ≠
+      (boolStepMachine 0).update? ((position, none), ⟨position, true⟩) := by
+  have viewEquation : (boolStepMachine 0).view (position, none) =
+      Sum.inr ⟨position, fun answer ↦ (position, some answer)⟩ := by rfl
+  rw [DynSystem.DynComputation.update?_of_view_query
+      (boolStepMachine 0) viewEquation false,
+    DynSystem.DynComputation.update?_of_view_query
+      (boolStepMachine 0) viewEquation true]
+  simp
+
+example (n : ℕ) (position answer : Bool) :
+    let trace : boolStepRealization.ExecutionTrace n
+        ((boolStepRealization.machine n).init position)
+        (show (boolStepRealization.machine n).State from (position, some answer)) :=
+      .query (position := position)
+        (next := fun selected ↦ (position, some selected))
+        (by change (boolStepMachine n).view (position, none) = _; rfl)
+        answer (.nil _)
+    ((boolStepRealization.initCode.wit n).time).eval
+          (boolStepBoundary.input.enc n position).length + trace.work ≤
+        boolStepRealization.totalTime.eval n := by
+  dsimp only
+  exact CslibPPoly.Realization.ExecutionTrace.runWork_le_totalTime
+    (realization := boolStepRealization) (n := n) position _ (by
+      simp [CslibPPoly.Realization.ExecutionTrace.length, boolStepRealization])
+
+/-! The two closure canaries below use nontrivial maps. They ensure that both
+the certificate-level theorem and its encoded-machine plumbing elaborate. -/
+
+noncomputable def boolNegCode :
+    EncPolyTimeFam BitEncFam.bool.enc BitEncFam.bool.enc (fun _ value ↦ !value) :=
+  .ofFintype BitEncFam.bool.enc_injective (fun _ value ↦ !value)
+    (.C 2) (fun _ ↦ by simp)
+    BitEncFam.bool.widBound
+    (fun n value ↦ (BitEncFam.bool.len_eq n value).le.trans (BitEncFam.bool.wid_le n))
+    BitEncFam.bool.widBound
+    (fun n value ↦ (BitEncFam.bool.len_eq n (!value)).le.trans (BitEncFam.bool.wid_le n))
+
+example : IsPPolyBy boolStepBoundary (fun n value ↦ boolQueryProgram n (!value)) :=
+  IsPPolyBy.precomp ⟨boolStepWitness⟩ (fun _ value ↦ !value)
+    BitEncFam.bool boolNegCode
+
+noncomputable def boolNegHeadCode :
+    EncPolyTimeFam boolStepBoundary.head.enc boolStepBoundary.head.enc
+      (fun _ ↦ Sum.map (!·) id) :=
+  .ofFintype boolStepBoundary.head.enc_injective (fun _ ↦ Sum.map (!·) id)
+    (.C 4) (fun _ ↦ by simp)
+    boolStepBoundary.head.bound boolStepBoundary.head.len_le
+    boolStepBoundary.head.bound
+    (fun n value ↦ boolStepBoundary.head.len_le n (Sum.map (!·) id value))
+
+example : IsPPolyBy boolStepBoundary (fun n value ↦
+    FreeM.map (!·) (boolQueryProgram n value)) :=
+  IsPPolyBy.mapResult ⟨boolStepWitness⟩ (fun _ value ↦ !value)
+    BitEncFam.bool boolNegHeadCode
 
 end PFunctor.CslibPPolyTest

--- a/PolyFunTest/Realizability/CslibPPoly.lean
+++ b/PolyFunTest/Realizability/CslibPPoly.lean
@@ -1,0 +1,90 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+
+public import PolyFun.Realizability.Backend.Cslib.PPoly
+
+/-!
+# Direct canaries for the cslib-backed P/poly adapter
+
+The producer example below assembles a complete certificate for an immediately
+returning Boolean program. The remaining examples exercise the derived resource
+bounds and compositional API through the public surface.
+-/
+
+open ToCslib.Computability
+
+@[expose] public section
+
+namespace PFunctor.CslibPPolyTest
+
+open CslibPPoly
+
+abbrev ConstBool : ℕ → PFunctor := fun _ ↦ PFunctor.C Bool
+abbrev BoolFam : ℕ → Type := fun _ ↦ Bool
+
+instance : (n : ℕ) → DecidableEq (ConstBool n).A :=
+  fun _ ↦ inferInstanceAs (DecidableEq Bool)
+
+noncomputable def emptyIndexEncoding : BitEncFam fun _ ↦ (PFunctor.C Bool).Idx where
+  wid _ := 0
+  widBound := 0
+  wid_le _ := by simp
+  enc _ index := index.2.elim
+  len_eq _ index := index.2.elim
+  enc_injective _ index := index.2.elim
+
+noncomputable def boolBoundary : Boundary ConstBool BoolFam BoolFam where
+  input := BitEncFam.bool
+  output := BitEncFam.bool
+  position := BitEncFam.bool
+  index := emptyIndexEncoding
+
+noncomputable def boolMachine (_n : ℕ) :
+    DynSystem.DynComputation (PFunctor.C Bool) Bool Bool :=
+  .ofFn id
+
+noncomputable def boolRealization : CslibPPoly.Realization boolBoundary where
+  machine := boolMachine
+  rounds := 0
+  state := BitEncFam.bool.toStrEncFam
+  initCode := .ofFintype BitEncFam.bool.enc_injective (fun _ ↦ id)
+    (.C 2) (fun _ ↦ by simp) BitEncFam.bool.widBound
+    (fun n value ↦ (BitEncFam.bool.len_eq n value).le.trans (BitEncFam.bool.wid_le n))
+    BitEncFam.bool.widBound
+    (fun n value ↦ (BitEncFam.bool.len_eq n value).le.trans (BitEncFam.bool.wid_le n))
+  headCode := .ofFintype BitEncFam.bool.enc_injective
+    (fun _ value ↦ Sum.inl value)
+    (.C 2) (fun _ ↦ by simp) BitEncFam.bool.widBound
+    (fun n value ↦ (BitEncFam.bool.len_eq n value).le.trans (BitEncFam.bool.wid_le n))
+    boolBoundary.head.bound (fun n value ↦ boolBoundary.head.len_le n _)
+  updateCode := (EncPolyTimeFam.const
+      (BitEncFam.bool.toStrEncFam.pairVar boolBoundary.index).enc
+      (fun _ ↦ none)
+      BitEncFam.bool.toStrEncFam.option.bound
+      (fun n ↦ BitEncFam.bool.toStrEncFam.option.len_le n none)).copy _
+    (fun _ step ↦ step.2.2.elim)
+
+noncomputable def boolWitness : Witness boolBoundary (fun _ value ↦ FreeM.pure value) where
+  realization := boolRealization
+  implements _ value := by
+    simp [boolRealization, boolMachine]
+
+example : IsPPolyBy boolBoundary (fun _ value ↦ FreeM.pure value) :=
+  ⟨boolWitness⟩
+
+example (n : ℕ) (value : Bool) :
+    ((boolRealization.initCode.wit n).time).eval
+        (boolBoundary.input.enc n value).length ≤ boolRealization.initTime.eval n :=
+  boolRealization.initTime_le n value
+
+example (n : ℕ) (value : Bool) :
+    (FreeM.pure value : (ConstBool n).FreeM Bool).IsTotalRollBound
+      (boolRealization.rounds.eval n) :=
+  boolWitness.isTotalRollBound n value
+
+end PFunctor.CslibPPolyTest

--- a/PolyFunTest/Realizability/CslibPPoly.lean
+++ b/PolyFunTest/Realizability/CslibPPoly.lean
@@ -83,6 +83,11 @@ example (n : ℕ) (value : Bool) :
         (boolBoundary.input.enc n value).length ≤ boolRealization.initTime.eval n :=
   boolRealization.initTime_le n value
 
+example (n : ℕ) :
+    (boolRealization.initCode.wit n).size + (boolRealization.headCode.wit n).size +
+        (boolRealization.updateCode.wit n).size ≤ boolRealization.descriptionSize.eval n :=
+  boolRealization.totalDescriptionSize_le n
+
 example (n : ℕ) (value : Bool) :
     (FreeM.pure value : (ConstBool n).FreeM Bool).IsTotalRollBound
       (boolRealization.rounds.eval n) :=

--- a/PolyFunTest/Realizability/CslibPPoly.lean
+++ b/PolyFunTest/Realizability/CslibPPoly.lean
@@ -52,15 +52,15 @@ noncomputable def boolRealization : CslibPPoly.Realization boolBoundary where
   machine := boolMachine
   rounds := 0
   state := BitEncFam.bool.toStrEncFam
-  initCode := .ofFintype BitEncFam.bool.enc_injective (fun _ ↦ id)
+  initCode := .ofFintype (eb := BitEncFam.bool.toStrEncFam.enc)
+    BitEncFam.bool.enc_injective (fun _ ↦ id)
     (.C 2) (fun _ ↦ by simp) BitEncFam.bool.widBound
     (fun n value ↦ (BitEncFam.bool.len_eq n value).le.trans (BitEncFam.bool.wid_le n))
-    BitEncFam.bool.widBound
-    (fun n value ↦ (BitEncFam.bool.len_eq n value).le.trans (BitEncFam.bool.wid_le n))
-  headCode := .ofFintype BitEncFam.bool.enc_injective
+    BitEncFam.bool.toStrEncFam.bound BitEncFam.bool.toStrEncFam.len_le
+  headCode := .ofFintype BitEncFam.bool.toStrEncFam.enc_injective
     (fun _ value ↦ Sum.inl value)
-    (.C 2) (fun _ ↦ by simp) BitEncFam.bool.widBound
-    (fun n value ↦ (BitEncFam.bool.len_eq n value).le.trans (BitEncFam.bool.wid_le n))
+    (.C 2) (fun _ ↦ by simp) BitEncFam.bool.toStrEncFam.bound
+    BitEncFam.bool.toStrEncFam.len_le
     boolBoundary.head.bound (fun n value ↦ boolBoundary.head.len_le n _)
   updateCode := (EncPolyTimeFam.const
       (BitEncFam.bool.toStrEncFam.pairVar boolBoundary.index).enc
@@ -71,12 +71,12 @@ noncomputable def boolRealization : CslibPPoly.Realization boolBoundary where
 
 noncomputable def boolWitness : Witness boolBoundary (fun _ value ↦ FreeM.pure value) where
   realization := boolRealization
-  implements _ value := by
+  implements := Realization.Implements.intro fun _ value ↦ by
     simp [boolRealization, boolMachine]
   progress _ value := programProgress_pure value
 
 example : IsPPolyBy boolBoundary (fun _ value ↦ FreeM.pure value) :=
-  ⟨boolWitness⟩
+  IsPPolyBy.intro boolWitness
 
 example (n : ℕ) (value : Bool) :
     ((boolRealization.initCode.wit n).time).eval
@@ -182,14 +182,14 @@ def boolQueryProgram (_n : ℕ) (position : Bool) : FreeM BoolInteraction Bool :
 
 noncomputable def boolStepWitness : Witness boolStepBoundary boolQueryProgram where
   realization := boolStepRealization
-  implements n position := by
+  implements := Realization.Implements.intro fun n position ↦ by
     simp only [boolStepRealization, Polynomial.eval_C]
     cases position <;> rfl
   progress _ _ := by
     rw [boolQueryProgram, programProgress_liftBind]
     exact ⟨⟨false⟩, fun answer ↦ programProgress_pure answer⟩
 
-example : IsPPolyBy boolStepBoundary boolQueryProgram := ⟨boolStepWitness⟩
+example : IsPPolyBy boolStepBoundary boolQueryProgram := IsPPolyBy.intro boolStepWitness
 
 example (position answer : Bool) :
     (boolStepMachine 0).update? ((position, none), ⟨position, answer⟩) =
@@ -245,8 +245,13 @@ noncomputable def boolNegCode :
     (fun n value ↦ (BitEncFam.bool.len_eq n (!value)).le.trans (BitEncFam.bool.wid_le n))
 
 example : IsPPolyBy boolStepBoundary (fun n value ↦ boolQueryProgram n (!value)) :=
-  IsPPolyBy.precomp ⟨boolStepWitness⟩ (fun _ value ↦ !value)
-    BitEncFam.bool boolNegCode
+  by
+    have code : EncPolyTimeFam boolStepBoundary.input.enc boolStepBoundary.input.enc
+        (fun _ value ↦ !value) := by
+      simpa [boolStepBoundary] using boolNegCode
+    simpa only [Boundary.withInput_self] using
+      IsPPolyBy.precomp (IsPPolyBy.intro boolStepWitness) (fun _ value ↦ !value)
+        boolStepBoundary.input code
 
 noncomputable def boolNegHeadCode :
     EncPolyTimeFam boolStepBoundary.head.enc boolStepBoundary.head.enc
@@ -259,8 +264,14 @@ noncomputable def boolNegHeadCode :
 
 example : IsPPolyBy boolStepBoundary (fun n value ↦
     FreeM.map (!·) (boolQueryProgram n value)) :=
-  IsPPolyBy.mapResult ⟨boolStepWitness⟩ (fun _ value ↦ !value)
-    BitEncFam.bool boolNegHeadCode
+  by
+    have code : EncPolyTimeFam boolStepBoundary.head.enc
+        (boolStepBoundary.withOutput boolStepBoundary.output).head.enc
+        (fun _ ↦ Sum.map (!·) id) := by
+      simpa only [Boundary.withOutput_self] using boolNegHeadCode
+    simpa only [Boundary.withOutput_self] using
+      IsPPolyBy.mapResult (IsPPolyBy.intro boolStepWitness) (fun _ value ↦ !value)
+        boolStepBoundary.output code
 
 /-! A positive round budget cannot disguise a stuck query with no answer. -/
 
@@ -276,8 +287,10 @@ def emptyQueryProgram (_n : ℕ) (_input : PUnit) : FreeM EmptyInteraction Bool 
 
 example (boundary : Boundary EmptyInteractionFam (fun _ ↦ PUnit) BoolFam) :
     ¬ IsPPolyBy boundary emptyQueryProgram := by
-  rintro ⟨witness⟩
+  intro certificate
+  obtain ⟨witness⟩ := certificate.toNonempty
   have progress := witness.progress 0 PUnit.unit
+  rw [emptyQueryProgram, programProgress_liftBind] at progress
   exact nomatch progress.1
 
 end PFunctor.CslibPPolyTest

--- a/PolyFunTest/Realizability/CslibPPoly.lean
+++ b/PolyFunTest/Realizability/CslibPPoly.lean
@@ -6,7 +6,7 @@ Authors: Quang Dao
 
 module
 
-public import PolyFunCslib.PPoly
+public import PolyFunCslib.Nontriviality
 
 /-!
 # Direct canaries for the cslib-backed P/poly adapter
@@ -228,9 +228,7 @@ example (n : ℕ) (position answer : Bool) :
     ((boolStepRealization.toQuantitative n).executionCost position trace).work ≤
         boolStepRealization.totalTime.eval n := by
   dsimp only
-  exact boolStepRealization.executionWork_le_totalTime position _ (by
-    simp [DynSystem.DynComputation.QuantitativeRealization.ExecutionTrace.length,
-      boolStepRealization])
+  exact boolStepWitness.executionWork_le_totalTime n position _
 
 /-! The two closure canaries below use nontrivial maps. They ensure that both
 the certificate-level theorem and its encoded-machine plumbing elaborate. -/
@@ -292,5 +290,10 @@ example (boundary : Boundary EmptyInteractionFam (fun _ ↦ PUnit) BoolFam) :
   have progress := witness.progress 0 PUnit.unit
   rw [emptyQueryProgram, programProgress_liftBind] at progress
   exact nomatch progress.1
+
+/-- Nontriviality is available to ordinary consumers of the optional adapter. -/
+example : ∃ f : (n : ℕ) → BitVec n → Bool,
+    ¬ IsPPolyBy coinBoundary (fun n value ↦ FreeM.pure (f n value)) :=
+  exists_not_isPPolyBy_pure
 
 end PFunctor.CslibPPolyTest

--- a/PolyFunTest/ToCslib/Basic.lean
+++ b/PolyFunTest/ToCslib/Basic.lean
@@ -38,6 +38,12 @@ example {n index : ℕ} (hindex : index < n) (bit : Bool) (value : BitVec n) :
 example : Fintype.card (BitVec 2 → Bool) = 16 := by
   simpa using card_bitVec_fun 2
 
+/-- The polynomial may depend on the predicate family; even this nonuniform claim fails. -/
+example : ¬ ∀ f : (n : ℕ) → BitVec n → Bool,
+    ∃ q : Polynomial ℕ, ∀ n, f n ∈ RealizableLE n (q.eval n) := by
+  obtain ⟨f, notRealizable⟩ := exists_not_realizableLE_poly
+  exact fun allFamilies ↦ notRealizable (allFamilies f)
+
 example (state : StrEncFam fun _ ↦ Bool) (parameter : ℕ) (value : Bool) :
     state.option.enc parameter none ≠ state.option.enc parameter (some value) := by
   simp

--- a/ToCslib.lean
+++ b/ToCslib.lean
@@ -14,8 +14,9 @@ public import ToCslib.Data.BitVec
 /-!
 # Extensions of the pinned cslib machine library
 
-This library contains reusable facts and constructions about cslib machines. It
+This library contains local machine and complexity theory over cslib: encoded
+polynomial-time families, machine constructions, and counting separation. It
 does not import PolyFun's realizability theory or any downstream oracle or
 cryptographic semantics. Optional backend libraries may import these modules
-explicitly without making cslib a dependency of generic PolyFun.
+explicitly without adding concrete machine extensions to the generic PolyFun umbrella.
 -/

--- a/ToCslib/Computability/BitEncoding.lean
+++ b/ToCslib/Computability/BitEncoding.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Devon Tuma
 -/
+
 module
 
 public import ToCslib.Computability.SingleTape.BasicMachines
@@ -12,8 +13,8 @@ public import Mathlib.Data.Nat.Log
 /-!
 # Pinned Fixed-Width Bit Encodings and Uniform Machine Families
 
-The pinned boundary representation for the polynomial-time adversary model, and the
-reusable unit of machine-computability it consumes.
+Fixed representations and uniform polynomial certificates for nonuniform machine
+families over the cslib substrate.
 
 ## Why encodings must be pinned
 
@@ -24,12 +25,12 @@ relative to a *fixed, trusted* representation (syntactic frameworks fix one impl
 through the programming language's value representation; a machine-grounded framework
 must fix it explicitly). This file provides that representation:
 
-* `ToCslib.Computability.StrEncFam` — a security-parameter-indexed family of injective raw
+* `ToCslib.Computability.StrEncFam` — a size-parameter-indexed family of injective raw
   `List Bool` encodings with a polynomial length bound. This is the *variable-width*
   notion, the representation freedom left to a machine's internal state.
 * `ToCslib.Computability.BitEncFam` — the *fixed-width* refinement: at each parameter every
   value encodes to exactly `wid n` bits, with `wid` polynomially bounded. This is the
-  pinned *boundary* representation for inputs, outputs, and oracle interfaces. The
+  pinned *boundary* representation for inputs, outputs, and interaction interfaces. The
   structure does not itself certify that an encoding is canonical: call sites must pin
   a trusted constructor or an explicitly reviewed encoding. Its polynomial width bound
   ensures every boundary value has `poly(n)` length; machine-family bounds charge `n`
@@ -44,7 +45,7 @@ must fix it explicitly). This file provides that representation:
   polynomial time and description-size bounds: the reusable unit "this function family
   is computed by polynomial machines relative to these encodings". Base machines
   produce these; the closure combinators (`comp`, `id`, `const`, `ofFintype`) compose
-  them; a polynomial-time adversary carries four of them.
+  them; clients supply one certificate for each implemented function family.
 
 Everything here is raw `α → List Bool`: no intermediate alphabet types and no one-hot
 symbol relabeling — encodings are binary from the start, so encoded lengths are the
@@ -85,7 +86,7 @@ theorem natToBits_inj {w m₁ m₂ : ℕ} (h₁ : m₁ < 2 ^ w) (h₂ : m₂ < 2
 
 /-! ## Variable-width bounded string encodings -/
 
-/-- A security-parameter-indexed family of injective raw bit-string encodings with a
+/-- A size-parameter-indexed family of injective raw bit-string encodings with a
 polynomial length bound: the representation freedom left to a machine's internal
 state. Injectivity is the only semantic demand; the length bound is what keeps
 resource accounting polynomial. -/
@@ -101,7 +102,7 @@ structure StrEncFam (α : ℕ → Type u) : Type u where
 
 /-! ## Pinned fixed-width boundary encodings -/
 
-/-- A security-parameter-indexed family of **fixed-width** raw bit-string encodings.
+/-- A size-parameter-indexed family of **fixed-width** raw bit-string encodings.
 At parameter `n` every value encodes to exactly
 `wid n` bits, and `wid` is polynomially bounded — the formal content of the
 security-parameter size convention used by this family model. Fixed widths make pairing
@@ -356,12 +357,12 @@ end BitEncFam
 /-! ## Uniform polynomial-time machine families -/
 
 /-- A family of encoded polynomial-time machine witnesses with **uniform** polynomial
-bounds: one machine per security parameter computing `f n` relative to the given
+bounds: one machine per size parameter computing `f n` relative to the given
 string encodings, a single polynomial bounding all running times (in `n` plus the
 input length), and a single polynomial bounding all description sizes (the advice
 bound — without it, per-parameter table machines smuggle unbounded advice). This is
-the reusable unit of the polynomial-time adversary model: base machines produce these,
-combinators compose them, and an adversary's four step functions each carry one.
+a reusable unit of encoded machine computability: base machines produce certificates,
+and combinators compose them without fixing a particular client interface.
 
 Like `EncPolyTime`, the structure imposes nothing on the encodings themselves; its
 certifying power comes from the call site pinning the injective families

--- a/ToCslib/Computability/PolyTime.lean
+++ b/ToCslib/Computability/PolyTime.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Devon Tuma
 -/
+
 module
 
 public import Cslib.Computability.Machines.Turing.SingleTape.Deterministic
@@ -17,7 +18,7 @@ of raw string functions `List Symbol → List Symbol`. This file adds the encodi
 arbitrary types is polynomial-time computable relative to `Bool`-string encodings
 `ea : α → List Bool` and `eb : β → List Bool`, by bundling a machine-computed total
 string function that intertwines the encodings. The encodings are supplied by call
-sites; the adversary model pins the injective fixed-width and length-bounded families
+sites, which can pin the injective fixed-width and length-bounded families
 of `ToCslib.Computability.BitEncoding` (`ToCslib.Computability.BitEncFam`,
 `ToCslib.Computability.StrEncFam`) at its boundaries.
 
@@ -28,13 +29,11 @@ which replaces a machine's time bound with its own polynomial.
 
 Besides the running time `EncPolyTime.time`, every witness has a **description size**
 `EncPolyTime.size`: the state count of its machine. Cslib's `PolyTimeComputable` bounds
-only the running time, which suffices for a *single* function but not for a *family* of
-witnesses indexed by a security parameter: a finite-table machine looks up any function
-in linear time using one state per valid input, so without a size bound a family of
-witnesses smuggles unbounded advice and the induced "polynomial-time" class contains
-every function on polynomially-encodable domains. Families must therefore bound
-`size` polynomially as well (see a uniform description bound), giving the standard
-non-uniform P/poly model.
+only the running time of a single function. A nonuniform family also needs a separate
+bound on machine descriptions: time bounds do not constrain the number of states
+in a machine. `EncPolyTimeFam` packages uniform polynomial bounds on both quantities.
+These are encoded machine certificates; equivalence to a circuit complexity class
+requires a separate characterization theorem.
 -/
 
 public section
@@ -71,8 +70,8 @@ number of states. Over the fixed `Bool` alphabet the transition table has exactl
 rows per state, and each target-state entry needs logarithmically many bits. Thus a
 polynomial state-count bound is polynomially equivalent to a conventional transition-
 table bit-size bound (rather than equal up to a constant factor). It is the advice
-measure counted by `B`. Time bounds alone do not control it: a table machine looks up
-any function on a finite domain in linear time using one state per valid input.
+measure counted by `B`. Time bounds alone do not control the number of states
+in a machine description.
 
 Deliberately restricted to `Symbol := Bool`: over a family of growing alphabets the
 transition table has `Fintype.card Symbol + 1` rows per state, so a bare state count
@@ -124,8 +123,8 @@ variable {ea : α → List Bool} {eb : β → List Bool} {ec : γ → List Bool}
 def time {f : α → β} (h : EncPolyTime ea eb f) : Polynomial ℕ := h.polyTime.poly
 
 /-- The description size (machine state count) of the underlying machine. Families of
-witnesses indexed by a security parameter must bound this polynomially — the advice
-bound of the non-uniform P/poly model; see the module docstring. -/
+witnesses indexed by a size parameter must bound this separately from running time;
+see `EncPolyTimeFam`. -/
 def size {f : α → β} (h : EncPolyTime ea eb f) : ℕ := h.polyTime.size
 
 /-- The time accessor returns the polynomial carried by the underlying cslib witness. -/

--- a/ToCslib/Computability/SingleTape/Counting.lean
+++ b/ToCslib/Computability/SingleTape/Counting.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 PolyFun Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Devon Tuma, Elias Judin
 -/
+
 module
 
 public import ToCslib.Computability.BitEncoding
@@ -12,10 +13,9 @@ public import Mathlib.Data.FinEnum
 /-!
 # Counting Polynomial-Size Turing Machines
 
-The combinatorial core of the non-triviality certificate for the machine-grounded
-polynomial-time model : only
-sub-doubly-exponentially many predicates `BitVec n → Bool` are realizable by
-`d`-state single-tape machines, while there are `2 ^ (2 ^ n)` such predicates.
+This module bounds the number of predicates `BitVec n → Bool` realizable by pairs
+of single-tape machines with at most `d` states each. It compares that bound with
+the `2 ^ (2 ^ n)` Boolean predicates to obtain a nonuniform separation theorem.
 
 The pieces, each isolated so the diagonalization argument reads as pure counting:
 
@@ -38,8 +38,11 @@ The pieces, each isolated so the diagonalization argument reads as pure counting
   (`ToCslib.Computability.eventually_poly_le`), while the machine count stays below the function
   count (`ToCslib.Computability.eventually_count_lt`).
 * **The function space** has cardinality `2 ^ (2 ^ n)` (`ToCslib.Computability.card_bitVec_fun`),
-  and a `Finset` family of subexponential cardinality misses a diagonal predicate
+  and a `Finset` family smaller than that predicate space misses a diagonal predicate
   eventually (`ToCslib.Computability.exists_diagonal`).
+* **Nonuniform separation** (`ToCslib.Computability.exists_not_realizableLE_poly`): some
+  Boolean predicate family admits no polynomial bound on the sizes of its realizing
+  machine pairs, even without a uniform running-time bound across input lengths.
 -/
 
 public section
@@ -509,7 +512,7 @@ theorem eventually_count_lt :
 
 /-! ## The diagonal predicate -/
 
-/-- A `Finset` family of subexponential cardinality misses a predicate eventually: if
+/-- A `Finset` family smaller than the predicate space eventually misses a predicate: if
 `(S n).card < 2 ^ (2 ^ n)` cofinitely, some family `f` has `f n ∉ S n` cofinitely. -/
 theorem exists_diagonal (S : (n : ℕ) → Finset (BitVec n → Bool))
     (hS : ∀ᶠ n in atTop, (S n).card < 2 ^ (2 ^ n)) :
@@ -525,5 +528,27 @@ theorem exists_diagonal (S : (n : ℕ) → Finset (BitVec n → Bool))
   refine hS.mono fun n hn => ?_
   simp only [dif_pos hn]
   exact (key n hn).choose_spec
+
+/-- Some Boolean predicate family cannot be realized by machine pairs of polynomially
+bounded description size. `RealizableLE` counts separately polynomial-time initialization
+and observation machines; no uniform time bound across input lengths is assumed here. -/
+theorem exists_not_realizableLE_poly :
+    ∃ f : (n : ℕ) → BitVec n → Bool,
+      ¬ ∃ q : Polynomial ℕ, ∀ n, f n ∈ RealizableLE n (q.eval n) := by
+  classical
+  let cover : (n : ℕ) → Finset (BitVec n → Bool) :=
+    fun n ↦ (exists_realizableLE_covering n (2 ^ (n / 4))).choose
+  have covered : ∀ n, RealizableLE n (2 ^ (n / 4)) ⊆ ↑(cover n) := fun n ↦
+    (exists_realizableLE_covering n (2 ^ (n / 4))).choose_spec.1
+  have cardBound : ∀ n, (cover n).card ≤ B (2 ^ (n / 4)) ^ 2 := fun n ↦
+    (exists_realizableLE_covering n (2 ^ (n / 4))).choose_spec.2
+  obtain ⟨f, misses⟩ := exists_diagonal cover
+    (eventually_count_lt.mono fun n bound ↦ lt_of_le_of_lt (cardBound n) bound)
+  refine ⟨f, fun ⟨q, realizable⟩ ↦ ?_⟩
+  have belongs : ∀ᶠ n in atTop, f n ∈ cover n :=
+    (eventually_poly_le q).mono fun n bound ↦
+      Finset.mem_coe.mp (covered n (realizableLE_mono bound (realizable n)))
+  obtain ⟨n, belongsAtN, missesAtN⟩ := (belongs.and misses).exists
+  exact missesAtN belongsAtN
 
 end ToCslib.Computability

--- a/docs/wiki/linting.md
+++ b/docs/wiki/linting.md
@@ -4,28 +4,28 @@
 
 ```bash
 lake exe cache get
-lake build PolyFun ToCslib PolyFunTest --wfail
+lake build PolyFun ToCslib PolyFunCslib PolyFunTest --wfail
 lake lint -- --trace
-lake exe lint-style PolyFun ToCslib
+lake exe lint-style PolyFun ToCslib PolyFunCslib
 ```
 
 The convenience command `./scripts/validate.sh --lint --test --axioms` runs
-both production builds with warnings fatal, environment and text-style
+all production builds with warnings fatal, environment and text-style
 linting, the test library, and the integrity/axiom checks.
 
-`PolyFun` and `ToCslib` are separate production roots. Both must be named in
+`PolyFun`, `ToCslib`, and `PolyFunCslib` are separate production roots. All must be named in
 environment linting and standalone text linting. The default target is only
-`PolyFun`, so `lake exe lint-style` alone misses `ToCslib`. The style CI job
+`PolyFun`, so `lake exe lint-style` alone misses the other two roots. The style CI job
 uses the upstream action for the default target and an explicit command for
-the auxiliary root. Update coverage when adding another production library.
+the auxiliary roots. Update coverage when adding another production library.
 
 The checks serve different purposes:
 
 - Build-time linters include Mathlib's standard set and core's `checkUnivs`.
   `--wfail` makes their warnings fail the build.
-- `lake lint` uses Batteries' environment runner, with both production roots
+- `lake lint` uses Batteries' environment runner, with all production roots
   supplied by `lintDriverArgs`. `--trace` shows which checks actually run.
-- `lake exe lint-style PolyFun ToCslib` uses Mathlib's source-text checks,
+- `lake exe lint-style PolyFun ToCslib PolyFunCslib` uses Mathlib's source-text checks,
   including Unicode. Build-time checks do not cover every text-style rule.
 
 `PolyFunTest` is built with warnings fatal and excluded from production

--- a/docs/wiki/quickstart.md
+++ b/docs/wiki/quickstart.md
@@ -21,7 +21,7 @@ lake exe cache get
 `./scripts/validate.sh` is the recommended convenience wrapper for routine
 local validation. By default it runs:
 
-1. `lake build PolyFun ToCslib --wfail` (warnings — including `mathlibStandardSet` style
+1. `lake build PolyFun ToCslib PolyFunCslib --wfail` (warnings — including `mathlibStandardSet` style
    warnings — are hard failures, matching CI)
 2. `./scripts/check-modules.sh` (all Lean sources use module mode and the
    Interaction public-scope policy is respected)
@@ -57,12 +57,12 @@ untracked `PolyFun/**/*.lean` files are present.
 ```
 
 `--lint` adds `lake lint` (Batteries' environment linters) and
-`lake exe lint-style PolyFun ToCslib` to the wrapper.
+`lake exe lint-style PolyFun ToCslib PolyFunCslib` to the wrapper.
 `checkUnivs` runs during elaboration, not in the environment runner.
 See [linting.md](linting.md) for coverage and exception maintenance.
 `--test` builds `PolyFunTest` with warnings fatal and runs `lake test`. `--axioms` adds
-the executable fixture matrix and `lake exe polyfun-axiomsweep --check`. The check scans
-every imported `PolyFun.*` declaration and fails on any `sorryAx` or non-standard
+the executable fixture matrix and `lake exe polyfun-axiomsweep --root PolyFun --root ToCslib --root PolyFunCslib --check`. The check scans
+every declaration under the three production roots and fails on any `sorryAx` or non-standard
 axiom dependency. The committed `scripts/axiom_baseline.json` is a zero-debt
 policy, not an allowlist: both arrays must remain empty. Update mode refuses to
 record taint and is only useful for resetting a stale baseline after all debt is
@@ -112,7 +112,7 @@ deliberately outside the `lake lint` scope.
 - [`../../.github/workflows/ci.yml`](../../.github/workflows/ci.yml): runs
   three independent jobs on every push to `main` and on pull requests — a
   `build` job (`./scripts/validate.sh`, which includes
-  `lake build PolyFun ToCslib --wfail`), a `lint` job (`lake lint`, the environment linters),
+  `lake build PolyFun ToCslib PolyFunCslib --wfail`), a `lint` job (`lake lint`, the environment linters),
   and a `test` job (`lake test`, the
   `PolyFunTest` library). All builds pass `--wfail`, so any compiler or
   `mathlibStandardSet` warning fails CI rather than slipping through. The
@@ -130,7 +130,7 @@ deliberately outside the `lake lint` scope.
   a production/test module docstring from its prologue, will fail this job.
 - [`../../.github/workflows/linting.yml`](../../.github/workflows/linting.yml):
   runs the community `leanprover-community/lint-style-action` on `PolyFun`,
-  then explicitly runs Mathlib text linting on `ToCslib`.
+  then explicitly runs Mathlib text linting on `ToCslib` and `PolyFunCslib`.
 - [`../../.github/workflows/docs.yml`](../../.github/workflows/docs.yml):
   builds and publishes searchable API documentation from `main`.
 - [`../../.github/workflows/release-tag.yml`](../../.github/workflows/release-tag.yml)

--- a/docs/wiki/realizability.md
+++ b/docs/wiki/realizability.md
@@ -447,17 +447,59 @@ scheme whose operations the word class admits, supplied as `WordPairing` and
 this writing complexitylib has the ingredients (`Complexity.pair`, `unpair?`,
 `delimit`) but has not exposed them as a class-level closure result, and cslib's
 `PolyTimeComputable` has `id` and `comp` but no pairing or projection machines at
-all. So a cslib instantiation is blocked upstream, not here.
+all. The local `ToCslib` extensions supply encoded machine families and finite-table
+constructors. `PolyFunCslib` uses those concrete certificates directly; it does not
+claim a complete `ofWordClass` structural instance.
 
 `StepClass.computable` — Mathlib's `Primcodable` representations and `Computable`
 functions — is the in-repo instance that works today and exercises every mixin.
 
+## Local cslib Complexity Theory And The Optional Adapter
+
+Concrete machine and complexity theory is maintained locally in `ToCslib` while
+upstream APIs stabilize. `ToCslib/Computability/PolyTime.lean` supplies encoded
+single-tape witnesses; `ToCslib/Computability/BitEncoding.lean` packages injective
+encoding families and uniform polynomial time and description bounds.
+`ToCslib/Computability/SingleTape/Counting.lean` proves
+`exists_not_realizableLE_poly`: some Boolean predicate family has no polynomial
+bound on its realizing machine-pair descriptions. This conclusion does not need
+a uniform running-time bound across input lengths. These modules import only
+cslib and Mathlib.
+
+The optional `PolyFunCslib/` library connects this theory to PolyFun:
+
+- `PolyFunCslib/Backend.lean` interprets `EncPolyTime` as quantitative executable
+  evidence. Its qualitative admissibility predicate is unconstrained; every
+  quantitative map still carries a concrete machine certificate.
+- `PolyFunCslib/PPoly.lean` pins the input, output, position, and dependent-answer
+  encodings. `IsPPolyBy` carries initialization, combined head observation, and
+  partial-update machine families, polynomial state-length and round bounds,
+  bounded semantic implementation, and progress at every reachable query.
+  `Witness.executionWork_le_totalTime` bounds every finite execution prefix by
+  `initTime + (rounds + 1) * headTime + rounds * updateTime`, using the generic
+  trace length and additive cost lemmas in `Quantitative.lean`.
+- `PolyFunCslib/Nontriviality.lean` extracts an initialization/observation pair
+  from a pure Boolean certificate and applies the local counting theorem.
+
+The work charge is each machine witness's certified time envelope. It excludes
+external answer computation and does not count the exact steps of a linked
+whole-program machine. No equivalence with the circuit characterization of
+P/poly is asserted. Encodings are fixed by the caller; arbitrary changes of
+encoding have no automatic complexity-preservation theorem. Precomposition and
+result mapping require supplied code families.
+
+The ordinary-import examples in `PolyFunTest/Realizability/CslibPPoly.lean`
+cover pure returns, real Boolean queries, distinct answers, mismatched update
+tags, nontrivial input/result maps, and rejection of an empty-answer query.
+`PolyFunTest/ToCslib/Basic.lean` consumes the machine separation independently
+of PolyFun. The generated `PolyFun` umbrella imports neither concrete library.
+
 ## Known Gaps
 
-- **No concrete machine-adequacy theorem.** `QuantitativeStepClass` retains
-  `Type`-valued executable witnesses, encoded sizes, and backend-relative costs,
-  but a concrete backend must still relate those costs to a standard operational
-  machine model before making a complexity-class claim.
+- **No whole-program machine-adequacy theorem.** `PolyFunCslib` certifies the
+  local step maps with cslib machines and bounds their additive time envelopes.
+  A compiler and linking theorem for the complete interactive machine, and a
+  circuit characterization, remain separate obligations.
 - **Open-process closure is a certificate obligation.**
   `OpenProcess.IsRealizabilityClosed` consists of four first-order lens
   admissibility certificates at the pinned boundary family

--- a/docs/wiki/repo-map.md
+++ b/docs/wiki/repo-map.md
@@ -337,7 +337,9 @@ Realizability/Quantitative/Closure -> Realizability/Quantitative/BoundedClosure
  Realizability/Quantitative/Polynomial}
   -> Realizability/Quantitative/Resource
 Realizability/{Instances, Quantitative} -> Realizability/Quantitative/WordClass
-{Realizability/Quantitative/Polynomial, ToCslib/Computability/BitEncoding}
+{Realizability/Quantitative, ToCslib/Computability/PolyTime}
+  -> PolyFunCslib/Backend
+{PolyFunCslib/Backend, ToCslib/Computability/BitEncoding}
   -> PolyFunCslib/PPoly
 Mathlib/Order/Monotone/Basic -> Complexity/SecondOrderPolynomial
   (Instances additionally draws on Mathlib's Computability and Fintype layers;

--- a/docs/wiki/repo-map.md
+++ b/docs/wiki/repo-map.md
@@ -341,6 +341,8 @@ Realizability/{Instances, Quantitative} -> Realizability/Quantitative/WordClass
   -> PolyFunCslib/Backend
 {PolyFunCslib/Backend, ToCslib/Computability/BitEncoding}
   -> PolyFunCslib/PPoly
+{PolyFunCslib/PPoly, ToCslib/Computability/SingleTape/Counting}
+  -> PolyFunCslib/Nontriviality
 Mathlib/Order/Monotone/Basic -> Complexity/SecondOrderPolynomial
   (Instances additionally draws on Mathlib's Computability and Fintype layers;
    Quantitative/Closure assembles executable structural code but asserts no

--- a/docs/wiki/repo-map.md
+++ b/docs/wiki/repo-map.md
@@ -33,7 +33,7 @@ PolyFun/
                      quarantine root (Do/Basic)
   Logic/             small logic helpers (HEq)
 
-ToCslib/             separate low-level extensions to the pinned cslib machine
+ToCslib/             local machine and complexity theory over the pinned cslib
                      API; imports cslib and Mathlib, never PolyFun
 PolyFunCslib/         optional cslib-backed PolyFun realizability adapter;
                      excluded from the PolyFun umbrella
@@ -60,10 +60,15 @@ recorded in [`AGENTS.md`](../../AGENTS.md):
 
 ```text
 Cslib + Mathlib -> ToCslib -> optional PolyFun backend adapters
+ToCslib/Computability/PolyTime -> ToCslib/Computability/BitEncoding
+  -> ToCslib/Computability/SingleTape/Counting (nonuniform separation)
 ```
 
-It contains concrete machine constructions and lemmas, but no realizability,
-oracle, probability, or cryptographic policy.
+It contains concrete machine constructions, encoded polynomial-time families,
+and counting/diagonalization results. Complexity theory stays here while upstream
+APIs stabilize. It does not depend on PolyFun realizability, oracle semantics,
+probability, or cryptographic policy. `PolyFunCslib` contains the PolyFun-specific
+certificate and its bridge to the machine-counting separation theorem.
 
 ```text
 PFunctor/{Basic, Bound, M, Equiv, Chart, Lens}

--- a/docs/wiki/repo-map.md
+++ b/docs/wiki/repo-map.md
@@ -24,7 +24,8 @@ PolyFun/
     UC/              open-process / open-theory layer (no security content)
   Realizability/     step classes and realizability of dynamical systems and
                      free programs by admissible first-order machines;
-                     executable quantitative realizers and syntactic run costs
+                     executable quantitative realizers and syntactic run costs;
+    Backend/         optional concrete adapters, isolated from the generic core
   Complexity/        generic resource-bound syntax (not a concrete complexity class)
   Control/           monad/comonad and LTS infrastructure (Coalgebra,
                      Comonad, Free, Iter, Bisimulation, LTS/Trace),
@@ -335,6 +336,8 @@ Realizability/Quantitative/Closure -> Realizability/Quantitative/BoundedClosure
  Realizability/Quantitative/Polynomial}
   -> Realizability/Quantitative/Resource
 Realizability/{Instances, Quantitative} -> Realizability/Quantitative/WordClass
+{Realizability/Quantitative/Polynomial, ToCslib/Computability/BitEncoding}
+  -> Realizability/Backend/Cslib/PPoly
 Mathlib/Order/Monotone/Basic -> Complexity/SecondOrderPolynomial
   (Instances additionally draws on Mathlib's Computability and Fintype layers;
    Quantitative/Closure assembles executable structural code but asserts no
@@ -381,8 +384,9 @@ plain imports, and reducibility is exposed declaration-by-declaration.
   closure operations: start in `PolyFun/Realizability/Quantitative.lean` and
   `PolyFun/Realizability/Quantitative/Closure.lean`; for ranked termination,
   trace transport, and restricted pathwise closure, continue with
-  `PolyFun/Realizability/Quantitative/BoundedClosure.lean`. Concrete complexity
-  classes and adequacy theorems belong downstream.
+  `PolyFun/Realizability/Quantitative/BoundedClosure.lean`. Optional concrete
+  adapters live under `PolyFun/Realizability/Backend/`; cryptographic policy and
+  protocol-specific adequacy theorems belong downstream.
 - Updating notation: start in `PolyFun/Interaction/UC/Notation.lean`. See
   [`notation.md`](notation.md).
 

--- a/docs/wiki/repo-map.md
+++ b/docs/wiki/repo-map.md
@@ -24,7 +24,7 @@ PolyFun/
     UC/              open-process / open-theory layer (no security content)
   Realizability/     step classes and realizability of dynamical systems and
                      free programs by admissible first-order machines;
-                     executable quantitative realizers and syntactic run costs;
+                     executable quantitative realizers and syntactic run costs
   Complexity/        generic resource-bound syntax (not a concrete complexity class)
   Control/           monad/comonad and LTS infrastructure (Coalgebra,
                      Comonad, Free, Iter, Bisimulation, LTS/Trace),
@@ -390,8 +390,9 @@ plain imports, and reducibility is exposed declaration-by-declaration.
   `PolyFun/Realizability/Quantitative/Closure.lean`; for ranked termination,
   trace transport, and restricted pathwise closure, continue with
   `PolyFun/Realizability/Quantitative/BoundedClosure.lean`. Optional concrete
-  adapters live in separate library roots such as `PolyFunCslib/`; cryptographic policy and
-  protocol-specific adequacy theorems belong downstream.
+  adapters live in separate library roots such as `PolyFunCslib/`;
+  cryptographic policy and protocol-specific adequacy theorems belong
+  downstream.
 - Updating notation: start in `PolyFun/Interaction/UC/Notation.lean`. See
   [`notation.md`](notation.md).
 

--- a/docs/wiki/repo-map.md
+++ b/docs/wiki/repo-map.md
@@ -25,7 +25,6 @@ PolyFun/
   Realizability/     step classes and realizability of dynamical systems and
                      free programs by admissible first-order machines;
                      executable quantitative realizers and syntactic run costs;
-    Backend/         optional concrete adapters, isolated from the generic core
   Complexity/        generic resource-bound syntax (not a concrete complexity class)
   Control/           monad/comonad and LTS infrastructure (Coalgebra,
                      Comonad, Free, Iter, Bisimulation, LTS/Trace),
@@ -36,6 +35,8 @@ PolyFun/
 
 ToCslib/             separate low-level extensions to the pinned cslib machine
                      API; imports cslib and Mathlib, never PolyFun
+PolyFunCslib/         optional cslib-backed PolyFun realizability adapter;
+                     excluded from the PolyFun umbrella
 
 PolyFunTest/         tests and worked examples; imports PolyFun one-way,
                      built by lake test
@@ -337,7 +338,7 @@ Realizability/Quantitative/Closure -> Realizability/Quantitative/BoundedClosure
   -> Realizability/Quantitative/Resource
 Realizability/{Instances, Quantitative} -> Realizability/Quantitative/WordClass
 {Realizability/Quantitative/Polynomial, ToCslib/Computability/BitEncoding}
-  -> Realizability/Backend/Cslib/PPoly
+  -> PolyFunCslib/PPoly
 Mathlib/Order/Monotone/Basic -> Complexity/SecondOrderPolynomial
   (Instances additionally draws on Mathlib's Computability and Fintype layers;
    Quantitative/Closure assembles executable structural code but asserts no
@@ -385,7 +386,7 @@ plain imports, and reducibility is exposed declaration-by-declaration.
   `PolyFun/Realizability/Quantitative/Closure.lean`; for ranked termination,
   trace transport, and restricted pathwise closure, continue with
   `PolyFun/Realizability/Quantitative/BoundedClosure.lean`. Optional concrete
-  adapters live under `PolyFun/Realizability/Backend/`; cryptographic policy and
+  adapters live in separate library roots such as `PolyFunCslib/`; cryptographic policy and
   protocol-specific adequacy theorems belong downstream.
 - Updating notation: start in `PolyFun/Interaction/UC/Notation.lean`. See
   [`notation.md`](notation.md).

--- a/docs/wiki/review-hardening.md
+++ b/docs/wiki/review-hardening.md
@@ -43,8 +43,10 @@ If a reusable result is genuinely absent, keep the local result narrow and
 record the upstream search and the condition under which the local declaration
 can be deleted. PolyFun remains the correct home for polynomial, interaction,
 qualitative machine structure, and backend-relative quantitative accounting.
-Probability, concrete complexity-class and machine-adequacy claims, and
-cryptographic policy remain downstream.
+Concrete machine and complexity theory stays local in `ToCslib` while the upstream
+API stabilizes, using only cslib and Mathlib. `PolyFunCslib` supplies the optional
+bridge to PolyFun realizability. Probability, cryptographic policy, and
+protocol-specific adequacy claims remain downstream.
 
 ## Hardening Checklist
 

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,12 +1,12 @@
 name = "PolyFun"
 defaultTargets = ["PolyFun"]
 
-# `lake lint` runs Batteries' environment linters over both production libraries.
+# `lake lint` runs Batteries' environment linters over all production libraries.
 # `lake test` builds the `PolyFunTest` library; any failing `example` /
 # `#guard` / `#eval` fails elaboration. This mirrors Mathlib and cslib, which
 # reuse `batteries/runLinter` rather than shipping a local runner.
 lintDriver = "batteries/runLinter"
-lintDriverArgs = ["PolyFun", "ToCslib"]
+lintDriverArgs = ["PolyFun", "ToCslib", "PolyFunCslib"]
 testDriver = "PolyFunTest"
 
 [leanOptions]
@@ -48,8 +48,13 @@ name = "PolyFun"
 [[lean_lib]]
 name = "ToCslib"
 
+# Optional adapter from the cslib machine substrate to PolyFun realizability.
+# Kept outside the `PolyFun/` root so `import PolyFun` remains backend-neutral.
+[[lean_lib]]
+name = "PolyFunCslib"
+
 # Test / worked-example library. Built by `lake test`, kept out of the
-# `lake lint` scope (which lints `PolyFun` and `ToCslib`). Glob-based, so no umbrella
+# `lake lint` scope. Glob-based, so no umbrella
 # file is generated; the file-header style linter is relaxed on test files.
 [[lean_lib]]
 name = "PolyFunTest"

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -42,7 +42,7 @@ rev = "v4.33.1"
 [[lean_lib]]
 name = "PolyFun"
 
-# Low-level extensions of the pinned cslib machine API. This target does not
+# Local machine and complexity theory over the pinned cslib API. This target does not
 # import PolyFun and is intentionally separate from the generated `PolyFun`
 # umbrella; PolyFun backend adapters may import it explicitly.
 [[lean_lib]]

--- a/scripts/check-docs-integrity.py
+++ b/scripts/check-docs-integrity.py
@@ -37,7 +37,7 @@ TRACKED_PATHS = [
 MARKDOWN_LINK_RE = re.compile(r"(?<!!)\[[^\]]+\]\(([^)]+)\)")
 LEAN_PATH_RE = re.compile(
     r"(?<![A-Za-z0-9_./])"
-    r"((?:PolyFun|PolyFunTest)/(?:"
+    r"((?:PolyFun|ToCslib|PolyFunCslib|PolyFunTest)/(?:"
     r"[A-Za-z0-9_./-]+\.lean|"
     r"[A-Za-z0-9_./-]*\{[A-Za-z0-9_./, -]+\}(?:[A-Za-z0-9_./-]*\.lean)?"
     r"))"
@@ -167,8 +167,14 @@ def has_module_docstring(text: str) -> bool:
 
 def check_module_docstrings() -> list[str]:
     errors: list[str] = []
-    for source_root in (REPO_ROOT / "PolyFun", REPO_ROOT / "PolyFunTest"):
-        for lean_file in source_root.rglob("*.lean"):
+    for root_name in ("PolyFun", "ToCslib", "PolyFunCslib", "PolyFunTest"):
+        source_root = REPO_ROOT / root_name
+        lean_files = list(source_root.rglob("*.lean"))
+        umbrella = REPO_ROOT / f"{root_name}.lean"
+        # PolyFun.lean is a generated import index without a module docstring.
+        if root_name != "PolyFun" and umbrella.is_file():
+            lean_files.append(umbrella)
+        for lean_file in lean_files:
             if not has_module_docstring(lean_file.read_text()):
                 rel_path = lean_file.relative_to(REPO_ROOT)
                 errors.append(f"Missing module docstring: {rel_path}")

--- a/scripts/check-modules.sh
+++ b/scripts/check-modules.sh
@@ -14,7 +14,8 @@ while IFS= read -r file; do
     echo "ERROR: $file does not enable module mode with a 'module' command." >&2
     status=1
   fi
-done < <(git ls-files -- 'PolyFun.lean' 'PolyFun/*.lean' 'PolyFunTest/*.lean')
+done < <(git ls-files -- 'PolyFun.lean' 'PolyFun/*.lean' 'ToCslib.lean' 'ToCslib/*.lean' \
+  'PolyFunCslib.lean' 'PolyFunCslib/*.lean' 'PolyFunTest/*.lean')
 
 while IFS= read -r file; do
   if ! grep -qx 'public section' "$file"; then
@@ -61,7 +62,8 @@ while IFS= read -r file; do
       status=1
     fi
   fi
-done < <(git ls-files -- 'PolyFun.lean' 'PolyFun/*.lean' 'PolyFunTest/*.lean')
+done < <(git ls-files -- 'PolyFun.lean' 'PolyFun/*.lean' 'ToCslib.lean' 'ToCslib/*.lean' \
+  'PolyFunCslib.lean' 'PolyFunCslib/*.lean' 'PolyFunTest/*.lean')
 
 if grep -rEn --include='*.lean' '@\[expose\][[:space:]]+public section' PolyFun/Interaction; then
   echo "ERROR: Broad exposed public sections are forbidden in PolyFun/Interaction." >&2

--- a/scripts/test-docs-integrity.py
+++ b/scripts/test-docs-integrity.py
@@ -7,6 +7,7 @@ import importlib.util
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 SCRIPT_PATH = Path(__file__).with_name("check-docs-integrity.py")
 SPEC = importlib.util.spec_from_file_location("check_docs_integrity", SCRIPT_PATH)
@@ -44,6 +45,24 @@ public section
 """
         self.assertFalse(CHECKER.has_module_docstring(text))
 
+    def test_auxiliary_modules_and_umbrellas_are_checked(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            for root_name in ("ToCslib", "PolyFunCslib"):
+                source = repo_root / root_name / "MissingDoc.lean"
+                source.parent.mkdir()
+                source.write_text("module\n\npublic section\n")
+            (repo_root / "PolyFunCslib.lean").write_text("module\n")
+            with patch.object(CHECKER, "REPO_ROOT", repo_root):
+                self.assertCountEqual(
+                    CHECKER.check_module_docstrings(),
+                    [
+                        "Missing module docstring: ToCslib/MissingDoc.lean",
+                        "Missing module docstring: PolyFunCslib/MissingDoc.lean",
+                        "Missing module docstring: PolyFunCslib.lean",
+                    ],
+                )
+
 
 class LeanPathTests(unittest.TestCase):
     def test_literal_and_grouped_paths_expand(self) -> None:
@@ -51,6 +70,8 @@ class LeanPathTests(unittest.TestCase):
 `PolyFun/PFunctor/Basic.lean`
 `PolyFun/PFunctor/Dynamical/{Responder, Game}.lean`
 `PolyFun/ITree/{Basic.lean,Bisim/Defs.lean}`
+`ToCslib/Computability/PolyTime.lean`
+`PolyFunCslib/{Backend, PPoly}.lean`
 """
         self.assertEqual(
             set(CHECKER.lean_paths(text)),
@@ -60,6 +81,9 @@ class LeanPathTests(unittest.TestCase):
                 "PolyFun/PFunctor/Dynamical/Game.lean",
                 "PolyFun/ITree/Basic.lean",
                 "PolyFun/ITree/Bisim/Defs.lean",
+                "ToCslib/Computability/PolyTime.lean",
+                "PolyFunCslib/Backend.lean",
+                "PolyFunCslib/PPoly.lean",
             },
         )
 

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -92,7 +92,7 @@ if (( run_axioms )); then
 
   echo ""
   echo "# Enforcing zero axiom/sorry debt"
-  lake exe polyfun-axiomsweep --root PolyFun --root ToCslib --check
+  lake exe polyfun-axiomsweep --root PolyFun --root ToCslib --root PolyFunCslib --check
 fi
 
 echo ""

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -52,7 +52,7 @@ for arg in "$@"; do
 done
 
 echo "# Building project"
-lake build PolyFun ToCslib --wfail
+lake build PolyFun ToCslib PolyFunCslib --wfail
 
 echo ""
 echo "# Checking module scopes"
@@ -71,7 +71,7 @@ if (( run_lint )); then
   echo ""
   echo "# Running environment linters (lake lint)"
   lake lint
-  lake exe lint-style PolyFun ToCslib
+  lake exe lint-style PolyFun ToCslib PolyFunCslib
 fi
 
 if (( run_test )); then
@@ -84,7 +84,7 @@ fi
 if (( run_axioms )); then
   echo ""
   echo "# Building axiom sweep roots"
-  lake build PolyFun ToCslib --wfail
+  lake build PolyFun ToCslib PolyFunCslib --wfail
 
   echo ""
   echo "# Testing the axiom sweep tool"

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -16,13 +16,13 @@ usage() {
 Usage: ./scripts/validate.sh [--lint] [--test] [--axioms]
 
 Default checks:
-  - lake build
+  - lake build PolyFun ToCslib PolyFunCslib --wfail
   - ./scripts/check-modules.sh
   - ./scripts/check-imports.sh
   - python3 ./scripts/check-docs-integrity.py
 
 Optional checks:
-  --lint    Run environment and text-style linters over PolyFun and ToCslib
+  --lint    Run environment and text-style linters over all production libraries
   --test    Run `lake test` (builds the PolyFunTest library)
   --axioms  Test axiomsweep, then enforce the zero axiom/sorry-debt gate
 EOF


### PR DESCRIPTION
Adds an optional bridge from PolyFun programs to cslib machine families with fixed encodings, polynomial resource bounds, and bounded semantic implementation. Concrete machine and complexity theory remains local in `ToCslib` while upstream APIs stabilize; `PolyFunCslib` contains the PolyFun-specific certificate and bridge.

- Certify initialization, combined return/query observation, and partial updates with `EncPolyTimeFam`. Bound time envelopes, descriptions, hidden-state encoding lengths, and query rounds independently.
- Require progress at every reachable query, including rejection of empty-answer stuck programs. Close certificates under pointwise equality and code-supplied input/result maps.
- Reuse generic quantitative traces. `Witness.executionWork_le_totalTime` bounds every prefix by `initTime + (rounds + 1) * headTime + rounds * updateTime`, deriving its round bound from implementation. The reusable trace length and additive work lemmas live in `PolyFun/Realizability/Quantitative.lean`.
- Prove `ToCslib.Computability.exists_not_realizableLE_poly` entirely in the local machine layer: some Boolean predicate family has no polynomial bound on its realizing machine-pair descriptions. The optional adapter derives `exists_not_isPPolyBy_pure` by extracting the initial-state initialization/observation pair from a pure-program certificate.
- Cover the optional production library in the existing build, lint, style, module, documentation-integrity, and axiom checks. Add no scripts. Keep `PolyFun` as the default target and exclude the concrete libraries from its generated umbrella.

The cost is a certified envelope for local cslib machines. It excludes external-answer computation and does not establish exact linked whole-program cost or equivalence with the textbook circuit definition of P/poly. Boundary representations are fixed by the caller; closure requires actual supplied code. Scope and source comments state these limits explicitly.

Validation: `./scripts/validate.sh --lint --test --axioms` and `git diff --check` pass on the unchanged Lean 4.33.1 dependency pins. The production sweep checks 10,997 declarations across 284 modules with zero sorry/nonstandard-axiom taint. Explicit axiom checks pass for both separation theorems, the witness cost bound, closure, and generic trace lemmas. Ordinary-import examples cover pure returns, real queries and distinct answers, mismatched indices, nontrivial maps, empty-answer rejection, and the lower-layer separation independently of PolyFun. Documentation-checker fixtures cover the auxiliary roots.

## Provenance

This adapter uses the machine-counting development in [PolyFun #178](https://github.com/Verified-zkEVM/PolyFun/pull/178), including the state-normalization and covering proofs contributed by Elias Judin in [VCVio #487](https://github.com/Verified-zkEVM/VCVio/pull/487) and ported through [VCVio #500](https://github.com/Verified-zkEVM/VCVio/pull/500). That original commit records `Co-authored-by: Aristotle (Harmonic) <aristotle-harmonic@harmonic.fun>`. The current pure-program bridge uses certified initialization and initial-head observation; `realizableLE_of_isPPolyBy_pure` and `exists_not_isPPolyBy_pure` provide the corresponding nontriviality endpoint for the new model.

