### PR TITLE
fix(lint): remove unused arguments and prove conversion injectivity

### DIFF
--- a/PolyFun/Control/Comonad/Instances.lean
+++ b/PolyFun/Control/Comonad/Instances.lean
@@ -8,7 +8,6 @@ module
 public import PolyFun.Control.Comonad.Basic
 public import Mathlib.Data.Stream.Init
 public import Batteries.Data.List.Basic
-import Batteries.Tactic.Lint
 
 /-!
 # Instances of Comonads
@@ -137,11 +136,6 @@ structure NonEmptyList (α : Type u) where
   tail : List α
 
 deriving Repr, DecidableEq
-
--- The `prec` precedence argument is mandated by the `Repr.reprPrec` interface but is
--- unused for this structure (there is no infix form to disambiguate), so the derived
--- `repr` legitimately ignores it.
-attribute [nolint unusedArguments] instReprNonEmptyList.repr
 
 namespace NonEmptyList
 variable {α β : Type u} -- Declare universes here
@@ -411,11 +405,6 @@ structure List.Zipper (α : Type u) where
   right  : List α
 
 deriving Repr, DecidableEq
-
--- The `prec` precedence argument is mandated by the `Repr.reprPrec` interface but is
--- unused for this structure (there is no infix form to disambiguate), so the derived
--- `repr` legitimately ignores it.
-attribute [nolint unusedArguments] List.instReprZipper.repr
 
 -- Define instances for List.Zipper
 namespace List.Zipper

--- a/PolyFun/IPFunctor/Basic.lean
+++ b/PolyFun/IPFunctor/Basic.lean
@@ -6,7 +6,6 @@ Authors: Devon Tuma
 module
 
 public import PolyFun.PFunctor.Basic
-import Batteries.Tactic.Lint
 
 /-!
 # Two-Index (Indexed) Polynomial Functors
@@ -55,10 +54,9 @@ implements the functor composition `Q ∘ P : (I → Type) → (K → Type)`. Se
   preservation law) live in [`PolyFun/IPFunctor/Lens/Basic.lean`](Lens/Basic.lean),
   [`PolyFun/IPFunctor/Chart/Basic.lean`](Chart/Basic.lean), and
   [`PolyFun/IPFunctor/Equiv/Basic.lean`](Equiv/Basic.lean).
-* When both `I` and `J` have at most one element, `IPFunctor I J` reduces to an ordinary
-  `PFunctor` via `IPFunctor.toPFunctor`. For the weaker `[Unique J]`-only case, the
-  selected-output-fiber view is `IPFunctor.fiberPFunctor` (an erasure, since the input
-  index `I` can still carry information that gets flattened). The unconditional
+* With `[Unique J]`, `IPFunctor.toPFunctor` and `IPFunctor.fiberPFunctor` select the
+  unique output fiber and erase its source-index map. With `[Unique I]` as well,
+  `IPFunctor.toPFunctor_injective` proves that no information is lost. The unconditional
   Σ-bundled erasure is `IPFunctor.sigmaPFunctor`.
 -/
 
@@ -153,9 +151,8 @@ different `I`-fibers and that distinction is lost on the target.
 The constraint is `[Unique J]` rather than `[Inhabited J]` because a richer `J` would have
 multiple fibers and silently picking the default one would discard observable information.
 For arbitrary `J`, use [`sigmaPFunctor`](#IPFunctor.sigmaPFunctor) instead, which Σ-bundles
-the index into positions and preserves every fiber. For the genuine `PFunctor`
-recovery — where nothing is lost — see [`toPFunctor`](#IPFunctor.toPFunctor), which
-strengthens to `[Unique I] [Unique J]`. -/
+the index into positions and preserves every fiber. With `[Unique I]` as well,
+`toPFunctor_injective` proves that the selected-output-fiber view loses no information. -/
 @[reducible, inline]
 def fiberPFunctor [Unique J] (P : IPFunctor I J) : PFunctor where
   A := P.A default
@@ -167,28 +164,42 @@ def fiberPFunctor [Unique J] (P : IPFunctor I J) : PFunctor where
 @[simp] lemma fiberPFunctor_one [Unique J] :
     (1 : IPFunctor.{uI, uJ, uA, uB} I J).fiberPFunctor = 1 := rfl
 
-/-- View an `IPFunctor I J` as a plain `PFunctor` when both input and output index types are
-unique. With `[Unique I] [Unique J]` there is exactly one fiber on each side and `P.src`'s
-single possible value carries no information, so this is a genuine no-information-lost
-recovery — not an erasure. For the fiber-only view that drops `P.src` even when `I` is
-non-trivial, see [`fiberPFunctor`](#IPFunctor.fiberPFunctor); for the unconditional
-Σ-bundled erasure, see [`sigmaPFunctor`](#IPFunctor.sigmaPFunctor). -/
--- `[Unique I]` is not needed to elaborate the body, but it is a deliberate part of the
--- interface: it witnesses that `P.src`'s single value carries no information, which is what
--- makes this a no-information-lost recovery rather than the fiber-only `fiberPFunctor`.
-@[reducible, inline, nolint unusedArguments]
-def toPFunctor [Unique I] [Unique J] (P : IPFunctor I J) : PFunctor where
-  A := P.A default
-  B := P.B default
+/-- The selected-output-fiber view of an indexed polynomial, with its source-index map
+forgotten. This is `fiberPFunctor`; when the input index is also unique,
+`toPFunctor_injective` gives its information-preservation guarantee. -/
+@[reducible, inline]
+def toPFunctor [Unique J] (P : IPFunctor I J) : PFunctor := P.fiberPFunctor
 
-@[simp] lemma toPFunctor_zero [Unique I] [Unique J] :
+/-- Selecting the unique output fiber loses no information when the input index is unique:
+the source-index map is then determined by its codomain. -/
+theorem toPFunctor_injective [Unique I] [Unique J] :
+    Function.Injective (fun P : IPFunctor.{uI, uJ, uA, uB} I J => P.toPFunctor) := by
+  intro P Q h
+  cases P with
+  | mk A B src =>
+    cases Q with
+    | mk A' B' src' =>
+      have hA : A = A' := funext fun j => by
+        simpa only [Subsingleton.elim j default] using congrArg PFunctor.A h
+      cases hA
+      have hB : B = B' := funext fun j => by
+        have hj : j = default := Subsingleton.elim _ _
+        subst j
+        exact eq_of_heq (PFunctor.mk.inj h).2
+      cases hB
+      have hs : src = src' := funext fun j => funext fun a => funext fun b =>
+        Subsingleton.elim _ _
+      cases hs
+      rfl
+
+@[simp] lemma toPFunctor_zero [Unique J] :
     (0 : IPFunctor.{uI, uJ, uA, uB} I J).toPFunctor = 0 := rfl
 
-@[simp] lemma toPFunctor_one [Unique I] [Unique J] :
+@[simp] lemma toPFunctor_one [Unique J] :
     (1 : IPFunctor.{uI, uJ, uA, uB} I J).toPFunctor = 1 := rfl
 
 /-- View an `IPFunctor` as a `PFunctor` by Σ-bundling the output index into each position.
-Unlike `toPFunctor`, no shape information is lost — but positions become `Σ j : J, P.A j` and
+All output fibers are retained: positions become `Σ j : J, P.A j`, and
 the source map `P.src` is still not represented on the target side. Works for any input
 and output index types (no `[Inhabited J]` required).
 

--- a/PolyFun/Interaction/Basic/Node.lean
+++ b/PolyFun/Interaction/Basic/Node.lean
@@ -7,8 +7,6 @@ Authors: Quang Dao
 module
 
 public import PolyFun.PFunctor.Free.Basic
-public import Batteries.Tactic.Lint
-
 /-!
 # Node-local contexts and schemas
 
@@ -292,7 +290,6 @@ family it determines.
 -/
 -- The schema argument is ignored in the body (the context `Γ` is recovered from its
 -- type), but it is intentional: it lets callers write `S.toContext` in schema-level terms.
-@[nolint unusedArguments]
 abbrev Schema.toContext {Γ : Context} (_ : Schema Γ) : Context := Γ
 
 namespace Schema

--- a/PolyFun/Interaction/Concurrent/Process.lean
+++ b/PolyFun/Interaction/Concurrent/Process.lean
@@ -13,8 +13,6 @@ public import PolyFun.PFunctor.Dynamical.Combinators
 public import PolyFun.PFunctor.Dynamical.Safety
 public import PolyFun.PFunctor.Dynamical.Trajectory
 public import Mathlib.Data.PFunctor.Univariate.M
-public import Batteries.Tactic.Lint
-
 /-!
 # Dynamic concurrent processes
 
@@ -318,7 +316,6 @@ namespace ProcessOver
 exposed under its dynamical name for dot notation at use sites. -/
 -- The process argument exists only to support dot notation; the state space is
 -- fully determined by the parameter `P`.
-@[nolint unusedArguments]
 abbrev Proc {P : Type v} {Γ : Interaction.TypeTree.Node.Context.{w, w₂}}
     (_process : ProcessOver.{v, w, w₂} P Γ) : Type v :=
   P

--- a/PolyFun/Interaction/TwoParty/Decoration.lean
+++ b/PolyFun/Interaction/TwoParty/Decoration.lean
@@ -11,8 +11,6 @@ public import PolyFun.Interaction.Basic.TypeTree
 public import PolyFun.Interaction.Basic.Decoration
 public import PolyFun.Interaction.Basic.MonadDecoration
 public import PolyFun.Interaction.TwoParty.Role
-public import Batteries.Tactic.Lint
-
 /-!
 # Role decorations and common role-based node contexts
 
@@ -54,19 +52,16 @@ variable {P : PFunctor.{uA, uB}} {α : Type t}
 /-- The generic role-labeled node context for a polynomial control tree. -/
 -- A constant context family: the same role data is attached at every position, so the
 -- `P.A` argument is intentionally ignored.
-@[nolint unusedArguments]
 abbrev RoleContextOver (P : PFunctor.{uA, uB}) : P.A → Type :=
   fun _ => Role
 
 /-- Generic role context extended by one bundled monad field. -/
 -- Constant context family; the `P.A` argument is intentionally ignored.
-@[nolint unusedArguments]
 abbrev RoleMonadContextOver (P : PFunctor.{uA, uB}) : P.A → Type (u + 1) :=
   fun _ => Σ _ : Role, BundledMonad.{u, u}
 
 /-- Generic role context extended by a pair of bundled monads. -/
 -- Constant context family; the `P.A` argument is intentionally ignored.
-@[nolint unusedArguments]
 abbrev RolePairedMonadContextOver (P : PFunctor.{uA, uB}) : P.A → Type (u + 1) :=
   fun _ => Σ _ : Role, BundledMonad.{u, u} × BundledMonad.{u, u}
 

--- a/PolyFunTest/IPFunctor/Examples.lean
+++ b/PolyFunTest/IPFunctor/Examples.lean
@@ -53,6 +53,30 @@ W-type.
 
 namespace IPFunctor.Examples
 
+universe u v a b
+
+/-! ## Selected-fiber information preservation -/
+
+/-- An indexed polynomial whose only response selects the given Boolean source. -/
+def sourceChoice (source : Bool) : IPFunctor Bool Unit where
+  A _ := Unit
+  B _ _ := Unit
+  src _ _ _ := source
+
+example : (sourceChoice false).toPFunctor = (sourceChoice true).toPFunctor := rfl
+
+example : sourceChoice false ≠ sourceChoice true := by
+  intro h
+  have hs := (IPFunctor.mk.inj h).2.2
+  have : (fun (_ : Unit) (_ : Unit) (_ : Unit) => false) =
+      (fun (_ : Unit) (_ : Unit) (_ : Unit) => true) := eq_of_heq hs
+  have hf := congrFun (congrFun (congrFun this ()) ()) ()
+  cases hf
+
+example {I : Type u} {J : Type v} [Unique I] [Unique J]
+    (P Q : IPFunctor.{u, v, a, b} I J) (h : P.toPFunctor = Q.toPFunctor) : P = Q :=
+  toPFunctor_injective h
+
 /-! ## Two-phase protocol fixture -/
 
 /-- The two phases of the running protocol. Once we leave `opn`, we never

--- a/docs/wiki/ipfunctor.md
+++ b/docs/wiki/ipfunctor.md
@@ -34,8 +34,12 @@ case where input and output indices coincide. Free monads, indexed monads, and
 `do`-notation only make sense in the endomorphic case (a free monad arises from
 an endofunctor, not an arbitrary functor between family categories).
 
-When `J` has only one element, `IPFunctor I J` further collapses to a `PFunctor`
-via `IPFunctor.toPFunctor` (after fixing `J` to its default element).
+With `[Unique J]`, `IPFunctor.toPFunctor` (definitionally `fiberPFunctor`)
+selects the unique output fiber and forgets its source-index map. The conversion
+does not require `[Unique I]`. That assumption belongs to
+`IPFunctor.toPFunctor_injective`, which proves that the conversion loses no
+information when both index types are unique. Free-tree erasure still requires
+`[Unique I]` to identify the source indices of continuations.
 
 References:
 [`REFERENCES.md`](../../REFERENCES.md). Hancock-Setzer 2000,


### PR DESCRIPTION
Remove all eight unused-argument suppressions. Seven are obsolete on the pinned toolchain. For `IPFunctor.toPFunctor`, remove the unused `[Unique I]` parameter and implement the conversion through `fiberPFunctor`, retaining `[Unique J]` and the existing reduction behavior.

Add `toPFunctor_injective` under `[Unique I] [Unique J]`, putting the information-preservation assumption on the theorem that needs it. Ordinary-import regressions cover injectivity and two Boolean source maps with identical erased polynomials. Existing free-tree erasure still requires input uniqueness. Remove unused linter imports and update the indexed-functor documentation.

Validation: focused production and indexed-example builds passed with `--wfail`. The complete stack passed the full build, Batteries and style linters, tests, and zero-axiom/sorry checks. API review checked conversion reduction, the non-injective counterexample, and unchanged free-tree erasure laws.

Second of six stacked draft PRs; base is the configuration PR.
