### PR TITLE
fix(lint): remove obsolete universe suppressions

### DIFF
--- a/PolyFun/Interaction/Concurrent/Machine.lean
+++ b/PolyFun/Interaction/Concurrent/Machine.lean
@@ -46,7 +46,6 @@ universe u v
 namespace Interaction
 namespace Concurrent
 
-set_option linter.checkUnivs false in
 /--
 `Machine S` is the minimal state-indexed presentation of a concurrent system
 with residual states `S`: a dynamical system over the universe polynomial. At

--- a/PolyFun/Interaction/Concurrent/Process.lean
+++ b/PolyFun/Interaction/Concurrent/Process.lean
@@ -824,7 +824,6 @@ abbrev currentController? {Party : Type u} {P : Type v}
 
 end StepOver
 
-set_option linter.checkUnivs false in
 /--
 The closed-world specialization of `ProcessOver`, with residual state space
 `P`.

--- a/PolyFun/Interaction/UC/Realizability.lean
+++ b/PolyFun/Interaction/UC/Realizability.lean
@@ -55,7 +55,9 @@ namespace OpenProcess
 
 set_option linter.checkUnivs false in
 /-- The universe-normalized polynomial interface exposed by open processes at
-boundary `Δ`. -/
+boundary `Δ`. The state universe `v` and move universe `w` are independent before
+the lift combines them; keeping both preserves the boundary's definitional
+agreement with `DynSystem.ulift`. -/
 abbrev StructuralPFunctor (Party : Type u) (Δ : PortBoundary) :=
   PFunctor.ulift.{max u (w + 1), w, max v w, max v (max u (w + 1))}
     (StepOver.toPFunctor (OpenNodeContext.{u, w} Party Δ))
@@ -120,7 +122,6 @@ theorem IsStructurallyRealizableBy.mapBoundary
 
 /-! ## Direct closure contract -/
 
-set_option linter.checkUnivs false in
 /-- The lifted regrouped polynomial lens implementing scheduler interleaving
 of open-process boundaries: the shared structural content of `openTheory.par`,
 `openTheory.wire`, and `openTheory.plug`, which differ only in the injection

--- a/PolyFun/PFunctor/Dynamical/Refinement.lean
+++ b/PolyFun/PFunctor/Dynamical/Refinement.lean
@@ -46,7 +46,6 @@ variable {SImpl : Type u₁} {SSpec : Type u₂}
 
 /-! ## Operational forward simulation -/
 
-set_option linter.checkUnivs false in
 /-- A trace-theoretic forward simulation between bare dynamical systems.
 
 Related implementation states can match every concrete implementation step by
@@ -91,7 +90,6 @@ def ReflectsStatePred (sim : ForwardSimulation impl spec matchStep)
 
 end ForwardSimulation
 
-set_option linter.checkUnivs false in
 /-- `SafetyRefinement impl spec matchStep` is a forward simulation from the
 implementation system `impl` to the specification system `spec`:
 
@@ -520,7 +518,6 @@ abbrev ReverseSafetyRefinement (impl : SafetySpec.{u₁} p) (spec : SafetySpec.{
     (matchStep : StepRel impl.toDynSystem spec.toDynSystem := StepRel.top) :=
   SafetyRefinement spec impl (StepRel.reverse matchStep)
 
-set_option linter.checkUnivs false in
 /-- `MutualSafetyRefinement left right matchForth matchBack` packages one forward
 simulation in each direction between `left` and `right`. By default, the
 backward step-matching relation is the reversal of the forward one.

--- a/PolyFun/PFunctor/Dynamical/Safety.lean
+++ b/PolyFun/PFunctor/Dynamical/Safety.lean
@@ -74,7 +74,6 @@ structure Ticketed (p : PFunctor.{uA, uB}) extends Machine.{u} p where
   /-- The assignment of a ticket to each transition. -/
   ticket : toMachine.toDynSystem.Tickets Ticket
 
-set_option linter.checkUnivs false in
 /-- A safety-verification problem: dynamics together with initial states,
 ambient assumptions, and the state predicate to be established.
 

--- a/PolyFun/Realizability/Instances.lean
+++ b/PolyFun/Realizability/Instances.lean
@@ -104,7 +104,6 @@ instance : (unconstrained.{u, v}).IsDistributive where
   distrib_mem _ _ _ := True.intro
 
 -- Independent universes, as in `StepClass.HasULiftProd` itself.
-set_option linter.checkUnivs false in
 instance : (unconstrained.{max s t, v}).HasULiftProd.{s, t} where
   uliftProd _ _ := PUnit.unit
   up_mem _ _ := True.intro
@@ -145,7 +144,6 @@ instance : (finite.{u}).IsDistributive where
   distrib_mem _ _ _ := True.intro
 
 -- Independent universes, as in `StepClass.HasULiftProd` itself.
-set_option linter.checkUnivs false in
 instance : (finite.{max s t}).HasULiftProd.{s, t} where
   uliftProd {A B} a b := by
     let : Fintype (ULift.{t} A) := a
@@ -246,7 +244,6 @@ instance : (computable.{u}).HasOption where
     exact Computable.option_some
 
 -- Independent universes, as in `StepClass.HasULiftProd` itself.
-set_option linter.checkUnivs false in
 instance : (computable.{max s t}).HasULiftProd.{s, t} where
   uliftProd {A B} a b := by
     let : Primcodable (ULift.{t} A) := a

--- a/PolyFun/Realizability/StepClass.lean
+++ b/PolyFun/Realizability/StepClass.lean
@@ -366,7 +366,6 @@ attribute [instance] Distributive.toIsDistributive
 -- parameters of the regrouping, which is used precisely where a lifted
 -- composite state must live in a universe above both components, as in
 -- `DynSystem.ulift`.  The explicit binder list pins the order `s, t, v`.
-set_option linter.checkUnivs false in
 /-- The class represents the `ULift` regrouping of binary products: from
 representations of the lifted factors, a representation of the lifted product
 with both canonical regrouping maps admissible.
@@ -394,7 +393,6 @@ class HasULiftProd.{s, t, v'} (C : StepClass.{max s t, v'}) [P : C.HasProd] wher
 
 /-! ## Refinement between classes -/
 
-set_option linter.checkUnivs false in
 /-- A refinement of step classes: a translation of representations carrying
 `C`-admissibility to `D`-admissibility, compatibly with the product and sum
 representations. Realizability transports forward along a refinement, so a
@@ -434,7 +432,6 @@ def Refines.refl (C : StepClass.{u, v}) [C.HasProd] [C.HasSum] [C.HasOption] :
   str_sum _ _ := rfl
   str_option _ := rfl
 
-set_option linter.checkUnivs false in
 /-- Refinements compose. -/
 -- Three independent representation universes, for the same reason as `Refines`.
 def Refines.trans {C : StepClass.{u, v}} {D : StepClass.{u, v₂}}

--- a/docs/wiki/quickstart.md
+++ b/docs/wiki/quickstart.md
@@ -74,6 +74,11 @@ checks enforce headers, line length, and module
 docstrings. The standalone text checks additionally enforce Unicode and other
 source-text rules; they are not interchangeable.
 
+Lean's `checkUnivs` examines each declaration's type. A bundled structure can
+have type `Type (max u v)` even though its fields require independent universes.
+Such declarations keep a documented, declaration-scoped exception. Do not
+identify the universes or add dummy arguments just to satisfy this heuristic.
+
 ## Optional Direct Commands
 
 You can still run the underlying pieces directly when debugging a specific


### PR DESCRIPTION
Remove 13 declaration-scoped `checkUnivs` overrides that no longer produce diagnostics on the pinned Lean version. Preserve the original signatures and independent universe parameters.

Keep the remaining 27 reproduced warnings narrowly scoped and document why a structure's `Type (max u v)` can hide independent universes in its fields. Clarify the lifted structural-boundary exception. No universe equalities or dummy parameters are introduced.

Validation: affected concurrent, dynamical-refinement, and realizability modules built with `--wfail`; the complete stack passed the full build, linters, tests, and zero-axiom/sorry checks.

Third of six stacked draft PRs; base is the unused-argument PR.
