### PR TITLE
test(lint): assert deprecated API warnings

### DIFF
--- a/PolyFunTest/PFunctor/Equiv/DeprecatedCompatibility.lean
+++ b/PolyFunTest/PFunctor/Equiv/DeprecatedCompatibility.lean
@@ -21,22 +21,46 @@ open scoped PFunctor
 
 namespace PFunctor.Equiv
 
-set_option linter.deprecated false in
+/--
+warning: `PFunctor.Equiv.tensorX` has been deprecated: Use `PFunctor.Equiv.tensorY` instead
+---
+warning: `PFunctor.Equiv.tensorX_equivA` has been deprecated: Use `PFunctor.Equiv.tensorY_equivA` instead
+-/
+#guard_msgs in
 example (P : PFunctor.{0, 0}) :
     (tensorX.{0, 0, 0, 0} P).equivA = _root_.Equiv.prodPUnit P.A :=
   tensorX_equivA.{0, 0, 0, 0} P
 
-set_option linter.deprecated false in
+/--
+warning: `PFunctor.X` has been deprecated: Use `PFunctor.y` instead
+---
+warning: `PFunctor.Equiv.tensorX` has been deprecated: Use `PFunctor.Equiv.tensorY` instead
+---
+warning: `PFunctor.Equiv.tensorX_equivB` has been deprecated: Use `PFunctor.Equiv.tensorY_equivB` instead
+-/
+#guard_msgs in
 example (P : PFunctor.{0, 0}) (a : (P ⊗ X).A) :
     (tensorX.{0, 0, 0, 0} P).equivB a = _root_.Equiv.prodPUnit (P.B a.1) :=
   tensorX_equivB.{0, 0, 0, 0} P a
 
-set_option linter.deprecated false in
+/--
+warning: `PFunctor.Equiv.xTensor` has been deprecated: Use `PFunctor.Equiv.yTensor` instead
+---
+warning: `PFunctor.Equiv.xTensor_equivA` has been deprecated: Use `PFunctor.Equiv.yTensor_equivA` instead
+-/
+#guard_msgs in
 example (P : PFunctor.{0, 0}) :
     (xTensor.{0, 0, 0, 0} P).equivA = _root_.Equiv.punitProd P.A :=
   xTensor_equivA.{0, 0, 0, 0} P
 
-set_option linter.deprecated false in
+/--
+warning: `PFunctor.X` has been deprecated: Use `PFunctor.y` instead
+---
+warning: `PFunctor.Equiv.xTensor` has been deprecated: Use `PFunctor.Equiv.yTensor` instead
+---
+warning: `PFunctor.Equiv.xTensor_equivB` has been deprecated: Use `PFunctor.Equiv.yTensor_equivB` instead
+-/
+#guard_msgs in
 example (P : PFunctor.{0, 0}) (a : (X ⊗ P).A) :
     (xTensor.{0, 0, 0, 0} P).equivB a = _root_.Equiv.punitProd (P.B a.2) :=
   xTensor_equivB.{0, 0, 0, 0} P a

--- a/PolyFunTest/PFunctor/Lens/DeprecatedCompatibility.lean
+++ b/PolyFunTest/PFunctor/Lens/DeprecatedCompatibility.lean
@@ -21,10 +21,20 @@ open scoped PFunctor
 
 namespace PFunctor.Lens
 
-set_option linter.deprecated false in
+/--
+warning: `PFunctor.X` has been deprecated: Use `PFunctor.y` instead
+---
+warning: `PFunctor.Lens.fromX` has been deprecated: Use `PFunctor.Lens.fromY` instead
+-/
+#guard_msgs in
 example {P : PFunctor.{0, 0}} (a : P.A) : Lens X P := fromX a
 
-set_option linter.deprecated false in
+/--
+warning: `PFunctor.X` has been deprecated: Use `PFunctor.y` instead
+---
+warning: `PFunctor.Lens.Equiv.compX` has been deprecated: Use `PFunctor.Lens.Equiv.compY` instead
+-/
+#guard_msgs in
 example {P : PFunctor.{0, 0}} : Lens.Equiv (P ◃ X) P := Lens.Equiv.compX
 
 end PFunctor.Lens

--- a/PolyFunTest/PFunctor/Notation.lean
+++ b/PolyFunTest/PFunctor/Notation.lean
@@ -89,13 +89,14 @@ section DirectImportCompatibility
 /- These canaries intentionally use deprecated spellings. They import only
 `PFunctor.Basic`, proving the compatibility surface is not accidentally tied
 to the aggregate `PFunctor.Deprecated` or `PolyFun` umbrella imports. -/
-set_option linter.deprecated false in
+/--
+warning: `PFunctor.X` has been deprecated: Use `PFunctor.y` instead
+-/
+#guard_msgs in
 example : (X : PFunctor.{0, 0}) = y := rfl
 
-set_option linter.deprecated false in
 example : (Bool X^ Nat) = monomial Bool Nat := rfl
 
-set_option linter.deprecated false in
 example (p : PFunctor.{0, 0}) : p ^ 2 = p ◃ (p ◃ y) := rfl
 
 end DirectImportCompatibility

--- a/docs/wiki/quickstart.md
+++ b/docs/wiki/quickstart.md
@@ -79,6 +79,10 @@ have type `Type (max u v)` even though its fields require independent universes.
 Such declarations keep a documented, declaration-scoped exception. Do not
 identify the universes or add dummy arguments just to satisfy this heuristic.
 
+Compatibility tests that intentionally use deprecated declarations assert the
+expected diagnostics with strict `#guard_msgs`. Keep the warning enabled so
+unexpected diagnostics or a missing deprecation warning fail the test.
+
 ## Optional Direct Commands
 
 You can still run the underlying pieces directly when debugging a specific


### PR DESCRIPTION
Remove all nine `linter.deprecated false` calls. Existing compatibility examples now assert the 15 expected warnings with strict `#guard_msgs`; the two examples that emit no warning remain ordinary examples.

Preserve the deprecated aliases and narrow direct imports, so the tests continue checking compatibility availability while unexpected or missing diagnostics fail validation. Document this testing policy.

Validation: the three affected test modules built with `--wfail`; the complete stack passed all existing validation gates.

Fourth of six stacked draft PRs; base is the universe-suppression PR.
