### PR TITLE
feat(realizability): execute and account for finite machine prefixes

### DIFF
--- a/PolyFun.lean
+++ b/PolyFun.lean
@@ -277,7 +277,9 @@ public import PolyFun.Realizability.Quantitative
 public import PolyFun.Realizability.Quantitative.BoundedClosure
 public import PolyFun.Realizability.Quantitative.Closure
 public import PolyFun.Realizability.Quantitative.Polynomial
+public import PolyFun.Realizability.Quantitative.Prefix
 public import PolyFun.Realizability.Quantitative.Resource
+public import PolyFun.Realizability.Quantitative.TraceCost
 public import PolyFun.Realizability.Quantitative.WordClass
 public import PolyFun.Realizability.Representation
 public import PolyFun.Realizability.StepClass

--- a/PolyFun/Control/Monad/Support.lean
+++ b/PolyFun/Control/Monad/Support.lean
@@ -414,6 +414,12 @@ theorem allOutputs_bind (p : β → Prop) (x : m α) (f : α → m β) :
     obtain ⟨a, ha, hb⟩ := mem_support_bind.mp hb
     exact h a ha b hb
 
+/-- Mapping the returned value pulls an output assertion back along that map. -/
+@[simp]
+theorem allOutputs_map (p : β → Prop) (f : α → β) (x : m α) :
+    AllOutputs p (f <$> x) ↔ AllOutputs (p ∘ f) x := by
+  simp only [AllOutputs, support_map, Set.forall_mem_image, Function.comp_apply]
+
 @[simp]
 theorem someOutput_pure (p : α → Prop) (a : α) :
     SomeOutput p (pure a : m α) ↔ p a := by

--- a/PolyFun/Control/Monad/Support.lean
+++ b/PolyFun/Control/Monad/Support.lean
@@ -418,7 +418,8 @@ theorem allOutputs_bind (p : β → Prop) (x : m α) (f : α → m β) :
 @[simp]
 theorem allOutputs_map (p : β → Prop) (f : α → β) (x : m α) :
     AllOutputs p (f <$> x) ↔ AllOutputs (p ∘ f) x := by
-  simp only [AllOutputs, support_map, Set.forall_mem_image, Function.comp_apply]
+  change (∀ a ∈ support (f <$> x), p a) ↔ ∀ a ∈ support x, p (f a)
+  simp only [support_map, Set.forall_mem_image]
 
 @[simp]
 theorem someOutput_pure (p : α → Prop) (a : α) :

--- a/PolyFun/Realizability/Quantitative/Prefix.lean
+++ b/PolyFun/Realizability/Quantitative/Prefix.lean
@@ -1,0 +1,162 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+
+module
+
+public import PolyFun.Realizability.Quantitative.TraceCost
+public import PolyFun.PFunctor.Free.Support
+
+/-!
+# Executing and charging finite machine prefixes
+
+`runPrefix` executes at most the given number of visible queries, retaining the actual reached
+state and accumulated transition resources. The final observation is charged separately by
+`observedCost`. Every result is witnessed by a fully syntactic `ExecutionTrace`, including a
+fuel-exhausted run that has not returned. Erasing state and cost recovers ordinary bounded
+unrolling of the same machine.
+-/
+
+public section
+
+universe u v w
+
+open MonadAttach
+
+namespace PFunctor.DynSystem.DynComputation.QuantitativeRealization
+
+variable {p : PFunctor.{u, u}} {α β : Type u}
+  {C : StepClass.{u, v}} [C.HasProd] [C.HasSum] [C.HasOption] [DecidableEq p.A]
+  {Q : QuantitativeStepClass.{u, v, w} C} {bd : Boundary C p α β}
+
+/-- Execute a finite prefix and charge each transition as it happens. -/
+@[expose]
+def runPrefix (R : QuantitativeRealization Q bd) :
+    ℕ → R.machine.State → FreeM p (R.machine.State × ExecutionCost)
+  | 0, state => pure (state, 0)
+  | n + 1, state => match R.machine.view state with
+    | .inl _ => pure (state, 0)
+    | .inr ⟨position, next⟩ =>
+        FreeM.liftBind position fun direction =>
+          (fun out => (out.1, RankedResource.queryStepCost R state position direction + out.2)) <$>
+            R.runPrefix n (next direction)
+
+/-- A returned state stays fixed at every larger prefix budget and executes no transitions. -/
+@[simp]
+theorem runPrefix_return (R : QuantitativeRealization Q bd) (n : ℕ)
+    (state : R.machine.State) (value : β) (hview : R.machine.view state = .inl value) :
+    R.runPrefix n state = pure (state, 0) := by
+  cases n <;> simp [runPrefix, hview]
+
+/-- Adjacent executed prefixes compose by continuing at the reached state and adding the
+actual transition resources, including the peak-size maxima in `ExecutionCost` addition. -/
+theorem runPrefix_add (R : QuantitativeRealization Q bd) (n m : ℕ)
+    (state : R.machine.State) :
+    R.runPrefix (n + m) state = (do
+      let first ← R.runPrefix n state
+      let second ← R.runPrefix m first.1
+      return (second.1, first.2 + second.2)) := by
+  induction n generalizing state with
+  | zero => simp [runPrefix]
+  | succ n ih =>
+      cases hview : R.machine.view state with
+      | inl value => simp [runPrefix, hview]
+      | inr query =>
+          rcases query with ⟨position, next⟩
+          simp only [Nat.succ_add, runPrefix, hview]
+          apply congrArg (FreeM.liftBind position)
+          funext direction
+          simp [ih, map_bind, bind_map_left, add_assoc]
+
+/-- Observe whether the reached state has returned, without consuming another query. -/
+@[expose]
+def returned (R : QuantitativeRealization Q bd) (state : R.machine.State) : Option β :=
+  match R.machine.view state with
+  | .inl value => some value
+  | .inr _ => none
+
+/-- Charge initialization and the final observation around an accumulated transition cost. -/
+@[expose]
+def observedCost (R : QuantitativeRealization Q bd) (input : α)
+    (out : R.machine.State × ExecutionCost) : ExecutionCost :=
+  ExecutionCost.ofWork (Q.cost R.initCode input) + out.2 +
+    ExecutionCost.ofWork (Q.cost R.headCode out.1) +
+    ExecutionCost.observe (Q.size R.state out.1) (Q.size bd.head (R.machine.head out.1))
+
+/-- Cost erasure recovers the ordinary bounded machine semantics, including unresolved `none`. -/
+theorem map_returned_runPrefix (R : QuantitativeRealization Q bd)
+    (n : ℕ) (state : R.machine.State) :
+    (fun out => R.returned out.1) <$> R.runPrefix n state = R.machine.unroll n state := by
+  induction n generalizing state with
+  | zero => cases hview : R.machine.view state <;> simp [runPrefix, unroll, returned, hview]
+  | succ n ih =>
+      cases hview : R.machine.view state with
+      | inl value => simp [runPrefix, unroll, returned, hview]
+      | inr query =>
+          rcases query with ⟨position, next⟩
+          simp only [runPrefix, unroll, hview]
+          apply congrArg (FreeM.liftBind position)
+          funext direction
+          simpa only [FreeM.map_eq_map, Functor.map_map, Function.comp_def] using
+            ih (next direction)
+
+/-- Every returned state and transition charge is realized by an actual syntactic prefix. -/
+theorem runPrefix_trace (R : QuantitativeRealization Q bd) (n : ℕ)
+    (state : R.machine.State) :
+    AllOutputs (fun out => ∃ trace : ExecutionTrace R state out.1, trace.cost = out.2)
+      (R.runPrefix n state) := by
+  induction n generalizing state with
+  | zero =>
+      rw [runPrefix, allOutputs_pure]
+      exact ⟨.nil state, rfl⟩
+  | succ n ih =>
+      cases hview : R.machine.view state with
+      | inl value =>
+          rw [runPrefix, hview, allOutputs_pure]
+          exact ⟨.nil state, rfl⟩
+      | inr query =>
+          rcases query with ⟨position, next⟩
+          rw [runPrefix, hview, FreeM.allOutputs_liftBind]
+          intro direction
+          rw [allOutputs_map]
+          intro tail htail
+          obtain ⟨trace, hcost⟩ := ih (next direction) tail htail
+          exact ⟨.query hview direction trace, by
+            simp [ExecutionTrace.cost, RankedResource.queryStepCost, hcost]⟩
+
+/-- A prefix uses at most its query budget. If it is unresolved, it consumed that entire budget. -/
+theorem runPrefix_queries (R : QuantitativeRealization Q bd) (n : ℕ)
+    (state : R.machine.State) :
+    AllOutputs (fun out => out.2.queries ≤ n ∧ (R.returned out.1 = none → out.2.queries = n))
+      (R.runPrefix n state) := by
+  induction n generalizing state with
+  | zero => simp [runPrefix, allOutputs_pure]
+  | succ n ih =>
+      cases hview : R.machine.view state with
+      | inl value => simp [runPrefix, hview, allOutputs_pure, returned]
+      | inr query =>
+          rcases query with ⟨position, next⟩
+          rw [runPrefix, hview, FreeM.allOutputs_liftBind]
+          intro direction
+          rw [allOutputs_map]
+          intro tail htail
+          obtain ⟨hle, heq⟩ := ih (next direction) tail htail
+          change
+            (RankedResource.queryStepCost R state position direction + tail.2).queries ≤ n + 1 ∧
+            (R.returned tail.1 = none →
+              (RankedResource.queryStepCost R state position direction + tail.2).queries = n + 1)
+          simp only [RankedResource.queryStepCost, ExecutionCost.queries_add,
+            ExecutionCost.queries_ofWork, ExecutionCost.queries_observe,
+            ExecutionCost.queries_query, Nat.zero_add]
+          exact ⟨by omega, fun h => by rw [heq h]; omega⟩
+
+/-- The recorded complete resource vector is the cost of the witnessing machine trace. -/
+theorem observedCost_eq_executionCost (R : QuantitativeRealization Q bd) (input : α)
+    (out : R.machine.State × ExecutionCost)
+    (trace : ExecutionTrace R (R.machine.init input) out.1) (hcost : trace.cost = out.2) :
+    R.observedCost input out = R.executionCost input trace := by
+  simp only [observedCost, executionCost, hcost]
+
+end PFunctor.DynSystem.DynComputation.QuantitativeRealization

--- a/PolyFun/Realizability/Quantitative/Resource.lean
+++ b/PolyFun/Realizability/Quantitative/Resource.lean
@@ -8,6 +8,7 @@ module
 
 public import PolyFun.Realizability.Quantitative.BoundedClosure
 public import PolyFun.Realizability.Quantitative.Polynomial
+public import PolyFun.Realizability.Quantitative.TraceCost
 
 /-!
 # Resource contracts for quantitative realizations
@@ -578,41 +579,6 @@ end PureResourceCertificate
 /-! ## Ranked resource potentials -/
 
 namespace RankedResource
-
-/-- Cost of observing a state as the final state of an execution prefix. -/
-@[expose]
-def terminalCost (R : QuantitativeRealization Q bd) (state : R.machine.State) :
-    ExecutionCost :=
-  ExecutionCost.ofWork (Q.cost R.headCode state) +
-    ExecutionCost.observe (Q.size R.state state) (Q.size bd.head (R.machine.head state))
-
-/-- Cost contributed by one enabled position-response transition. -/
-@[expose]
-def queryStepCost (R : QuantitativeRealization Q bd) (state : R.machine.State)
-    (position : p.A) (direction : p.B position) : ExecutionCost :=
-  ExecutionCost.ofWork (Q.cost R.headCode state) +
-    ExecutionCost.ofWork (Q.cost R.updateCode (state, ⟨position, direction⟩)) +
-    ExecutionCost.observe (Q.size R.state state) (Q.size bd.head (R.machine.head state)) +
-    ExecutionCost.query (Q.size bd.pos position) (Q.size bd.idx ⟨position, direction⟩)
-
-@[simp]
-theorem executionTrace_cost_query {R : QuantitativeRealization Q bd}
-    {state : R.machine.State} {position : p.A} {next : p.B position → R.machine.State}
-    {finish : R.machine.State}
-    (view_eq : R.machine.view state = Sum.inr ⟨position, next⟩)
-    (direction : p.B position) (tail : R.ExecutionTrace (next direction) finish) :
-    (QuantitativeRealization.ExecutionTrace.query (R := R) view_eq direction tail).cost =
-      queryStepCost R state position direction + tail.cost :=
-  by
-    simp [QuantitativeRealization.ExecutionTrace.cost, queryStepCost]
-
-/-- Split prefix cost into initialization, transition cost, and the final observation. -/
-theorem executionCost_eq_init_add_trace_add_terminal
-    (R : QuantitativeRealization Q bd) (value : input) {finish : R.machine.State}
-    (trace : R.ExecutionTrace (R.machine.init value) finish) :
-    R.executionCost value trace =
-      ExecutionCost.ofWork (Q.cost R.initCode value) + (trace.cost + terminalCost R finish) := by
-  simp [QuantitativeRealization.executionCost, terminalCost, add_assoc]
 
 /-- Local resource potentials combined with a decreasing, progress-bearing query rank. -/
 structure PotentialCertificate (R : QuantitativeRealization Q bd)

--- a/PolyFun/Realizability/Quantitative/TraceCost.lean
+++ b/PolyFun/Realizability/Quantitative/TraceCost.lean
@@ -1,0 +1,77 @@
+/-
+Copyright (c) 2026 PolyFun Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+
+module
+
+public import PolyFun.Realizability.Quantitative
+
+/-!
+# Local resource costs of machine traces
+
+The initial observation, enabled transition, and terminal observation use the realizers and
+representations stored in the quantitative machine. These equations are shared by pathwise
+resource potentials and executed finite-prefix accounting.
+-/
+
+public section
+
+universe u v w
+
+namespace PFunctor.DynSystem.DynComputation.RankedResource
+
+variable {p : PFunctor.{u, u}} {input output : Type u}
+  {C : StepClass.{u, v}} [C.HasProd] [C.HasSum] [C.HasOption] [DecidableEq p.A]
+  {Q : QuantitativeStepClass.{u, v, w} C} {bd : Boundary C p input output}
+
+/-- Cost of observing a state as the final state of an execution prefix. -/
+@[expose]
+def terminalCost (R : QuantitativeRealization Q bd) (state : R.machine.State) :
+    ExecutionCost :=
+  ExecutionCost.ofWork (Q.cost R.headCode state) +
+    ExecutionCost.observe (Q.size R.state state) (Q.size bd.head (R.machine.head state))
+
+/-- Cost contributed by one enabled position-response transition. -/
+@[expose]
+def queryStepCost (R : QuantitativeRealization Q bd) (state : R.machine.State)
+    (position : p.A) (direction : p.B position) : ExecutionCost :=
+  ExecutionCost.ofWork (Q.cost R.headCode state) +
+    ExecutionCost.ofWork (Q.cost R.updateCode (state, ⟨position, direction⟩)) +
+    ExecutionCost.observe (Q.size R.state state) (Q.size bd.head (R.machine.head state)) +
+    ExecutionCost.query (Q.size bd.pos position) (Q.size bd.idx ⟨position, direction⟩)
+
+/-- Observing a state makes no oracle query. -/
+@[simp]
+theorem queries_terminalCost (R : QuantitativeRealization Q bd) (state : R.machine.State) :
+    (terminalCost R state).queries = 0 := by
+  simp [terminalCost]
+
+/-- Each enabled transition records exactly one visible query. -/
+@[simp]
+theorem queries_queryStepCost (R : QuantitativeRealization Q bd) (state : R.machine.State)
+    (position : p.A) (direction : p.B position) :
+    (queryStepCost R state position direction).queries = 1 := by
+  simp [queryStepCost]
+
+@[simp]
+theorem executionTrace_cost_query {R : QuantitativeRealization Q bd}
+    {state : R.machine.State} {position : p.A} {next : p.B position → R.machine.State}
+    {finish : R.machine.State}
+    (view_eq : R.machine.view state = Sum.inr ⟨position, next⟩)
+    (direction : p.B position) (tail : R.ExecutionTrace (next direction) finish) :
+    (QuantitativeRealization.ExecutionTrace.query (R := R) view_eq direction tail).cost =
+      queryStepCost R state position direction + tail.cost :=
+  by
+    simp [QuantitativeRealization.ExecutionTrace.cost, queryStepCost]
+
+/-- Split prefix cost into initialization, transition cost, and the final observation. -/
+theorem executionCost_eq_init_add_trace_add_terminal
+    (R : QuantitativeRealization Q bd) (value : input) {finish : R.machine.State}
+    (trace : R.ExecutionTrace (R.machine.init value) finish) :
+    R.executionCost value trace =
+      ExecutionCost.ofWork (Q.cost R.initCode value) + (trace.cost + terminalCost R finish) := by
+  simp [QuantitativeRealization.executionCost, terminalCost, add_assoc]
+
+end PFunctor.DynSystem.DynComputation.RankedResource

--- a/docs/wiki/realizability.md
+++ b/docs/wiki/realizability.md
@@ -38,6 +38,11 @@ PolyFun/Realizability/
                     admissible word encode/decode retractions
   Quantitative.lean Type-valued executable realizers, local cost, optional
                     categorical wiring, syntactic traces, and pathwise bounds
+  Quantitative/TraceCost.lean
+                    shared terminal and enabled-transition resource equations
+  Quantitative/Prefix.lean
+                    executed finite prefixes with exact trace costs, chunk
+                    composition, and erasure to ordinary bounded execution
   Quantitative/Closure.lean
                     executable product/sum/option/distributivity mixins;
                     ofFn, precomp, mapResult, unbounded seqComp, and lens transport
@@ -58,6 +63,12 @@ PolyFun/Realizability/
 `Machine.lean` and `StepClass.lean` are independent; `Basic.lean` joins them.
 `DynSystem.lean` is the non-returning substrate used by the UC bridge; it is
 also re-exported by `Basic.lean`.
+
+`QuantitativeRealization.runPrefix` returns the actual reached state and transition resource
+log. `runPrefix_trace` supplies its syntactic trace witness; `observedCost` adds initialization
+and the final observation exactly once. A prefix that has not returned consumes its full query
+budget (`runPrefix_queries`). Probability laws and expected-potential reasoning for these
+prefixes live downstream in VCVio, outside PolyFun's generic layer.
 
 ## `StepClass`: A Class Of Admissible Functions
 

--- a/docs/wiki/repo-map.md
+++ b/docs/wiki/repo-map.md
@@ -396,12 +396,15 @@ Realizability/{DynSystem, DynSystemClosure, StepClass, Machine}
   -> Realizability/Basic
 Realizability/Basic -> Realizability/{Closure, Instances, Representation}
 Realizability/Basic -> Realizability/Quantitative
+Realizability/Quantitative -> Realizability/Quantitative/TraceCost
+{Realizability/Quantitative/TraceCost, PFunctor/Free/Support}
+  -> Realizability/Quantitative/Prefix
 Realizability/Quantitative -> Realizability/Quantitative/Closure
 Realizability/Quantitative/Closure -> Realizability/Quantitative/BoundedClosure
 {Complexity/SecondOrderPolynomial, Realizability/Quantitative/Closure}
   -> Realizability/Quantitative/Polynomial
 {Realizability/Quantitative/BoundedClosure,
- Realizability/Quantitative/Polynomial}
+ Realizability/Quantitative/Polynomial, Realizability/Quantitative/TraceCost}
   -> Realizability/Quantitative/Resource
 Realizability/{Instances, Quantitative} -> Realizability/Quantitative/WordClass
 {Realizability/Quantitative, ToCslib/Computability/PolyTime}


### PR DESCRIPTION
Execute a finite prefix of a quantitative realization and retain its exact resource totals and syntactic trace. Prefixes compose by chunking, erase to bounded execution, and record returned versus unresolved executions without assuming termination.

Shared per-step accounting lives in `Quantitative.TraceCost`; ranked resource bounds and finite-prefix execution consume the same definitions. The output-map support law supports observable projections without requiring a measurable structure on hidden machine state. Probability and expected runtime remain downstream in VCVio.

Depends on the constructor/path API prerequisite (base branch `codex/free-constructor-api`).

Validation: `./scripts/validate.sh --lint --test --axioms` passed for the complete stack on current main: 295 production modules, zero axiom/sorry taint. VCVio's native `MachinePrefix` regression and its ordinary-import consumers passed. Those consumers distinguish zero-budget, returned and unresolved prefixes, chunk composition, output-recovery costs, and an infinite null-probability branch.

Review passes: current-main migration and full validation; generic monad/backend layering with no probability imports; finite-prefix and nontermination boundary cases; environment/style/docs/import/axiom checks. This provides exact backend-relative prefix accounting, not a conventional-machine adequacy theorem or an extractor runtime certificate.
