### PR TITLE
Expose routed packet observations after sender transport

### DIFF
--- a/PolyFun/Interaction/UC/Interface.lean
+++ b/PolyFun/Interaction/UC/Interface.lean
@@ -340,6 +340,22 @@ def mapSender {I : Interface.{uA, uB}} {M N : Type wA}
   sender := g rp.sender
   packet := rp.packet
 
+/-- Sender transport changes the observed sender by the supplied function. -/
+@[simp]
+theorem sender_mapSender {I : Interface.{uA, uB}} {M N : Type wA}
+    (g : M → N) (rp : RoutedPacket I M) : (mapSender g rp).sender = g rp.sender := by rfl
+
+/-- Sender transport leaves the dependent packet payload intact. -/
+@[simp]
+theorem packet_mapSender {I : Interface.{uA, uB}} {M N : Type wA}
+    (g : M → N) (rp : RoutedPacket I M) : (mapSender g rp).packet = rp.packet := by rfl
+
+/-- Sender transport on a constructed packet retains its port and dependent message. -/
+@[simp]
+theorem mapSender_mk {I : Interface.{uA, uB}} {M N : Type wA}
+    (g : M → N) (sender : M) (packet : Packet I) :
+    mapSender g ⟨sender, packet⟩ = ⟨g sender, packet⟩ := by rfl
+
 @[simp]
 theorem mapPacket_id {I : Interface.{uA, uB}} {M : Type wA} (rp : RoutedPacket I M) :
     mapPacket (Hom.id I) rp = rp := by

--- a/docs/wiki/interaction.md
+++ b/docs/wiki/interaction.md
@@ -67,6 +67,10 @@ Definitions are `@[expose]` only when downstream computation or definitional
 equality is an intentional part of the API. Proof modules use `import all`
 when they need opaque bodies without widening the exported reducer surface.
 
+Downstream packet runtimes can observe `Interface.RoutedPacket.mapSender` through
+`sender_mapSender`, `packet_mapSender`, and `mapSender_mk`. These public equations retain
+the dependent payload and expose the renamed sender without unfolding the implementation.
+
 ## Core concepts: TypeTree, Node, Party, Profile
 
 Before reading any one file, it helps to fix four words. They are the


### PR DESCRIPTION
Downstream FIFO runtimes need to inspect the sender and dependent payload of a renamed routed packet. Add public observation and constructor equations for `RoutedPacket.mapSender`, keeping its implementation opaque.

Validation: full `validate.sh --lint --test --axioms` and `lake exe lint-style PolyFun ToCslib PolyFunCslib` pass; 11,395 declarations across 295 modules, zero axiom or sorry debt. The VCVio consumer transports pending requests, typed responses, and explicit schedules along static client identities.
